### PR TITLE
Add Leading edge delay config for Timeseries buffer

### DIFF
--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesBufferShould.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesBufferShould.cs
@@ -22,16 +22,8 @@ namespace QuixStreams.Streaming.UnitTests.Models
             // when the buffer is disabled it is expected that each frame passed to the buffer is raised as-is.
             
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             var receivedData = new List<QuixStreams.Streaming.Models.TimeseriesData>();
 
@@ -88,19 +80,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithPacketSizeConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithPacketSizeConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.PacketSize = 2;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.PacketSize = 2;
@@ -124,18 +108,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithTimeSpanMsConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithTimeSpanMsConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.TimeSpanInMilliseconds = 200;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.TimeSpanInMilliseconds = 200;
@@ -159,19 +136,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithTimeSpanNsConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithTimeSpanNsConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.TimeSpanInNanoseconds = 200 * (long) 1e6;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.TimeSpanInNanoseconds = 200 * (long) 1e6;
@@ -193,7 +162,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
         }
 
         [Fact]
-        public void WriteData_WithTimeSpanAndBufferTimeoutConfiguration_ShouldRaiseProperOnReceiveEvents()
+        public void WriteData_WithTimeSpanAndBufferTimeoutConfiguration_ShouldRaiseOnDataReleasedCorrectly()
         {
             // Arrange
             var bufferConfiguration = new TimeseriesBufferConfiguration() 
@@ -228,21 +197,13 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithFilterConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithFilterConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // when the buffer is disabled it is expected that each frame passed to the buffer is raised as-is.
             
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.Filter = (timestamp) => timestamp.Parameters["param2"].NumericValue == 2;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.Filter = (timestamp) => timestamp.Parameters["param2"].NumericValue == 2;
@@ -266,19 +227,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithBufferTimeout_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithBufferTimeout_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.BufferTimeout = 100;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.BufferTimeout = 100;
@@ -302,19 +255,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithCustomTriggerConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithCustomTriggerConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.CustomTrigger = (data) => data.Timestamps.Count == 2;
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.CustomTrigger = (data) => data.Timestamps.Count == 2;
@@ -339,19 +284,11 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithCustomTriggerBeforeEnqueueConfiguration_ShouldRaiseProperOnReceiveEvents(bool initialConfig)
+        public void WriteData_WithCustomTriggerBeforeEnqueueConfiguration_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
         {
             // Arrange
-            var bufferConfiguration = new TimeseriesBufferConfiguration() // Set the buffer explicitly to null
-            {
-                PacketSize = null,
-                TimeSpanInMilliseconds = null,
-                TimeSpanInNanoseconds = null,
-                BufferTimeout = null,
-                Filter = null,
-                CustomTrigger = null,
-                CustomTriggerBeforeEnqueue = null
-            };
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
             if (initialConfig) bufferConfiguration.CustomTriggerBeforeEnqueue = timestamp => timestamp.Tags["tag2"] == "value2";
             var buffer = new TimeseriesBuffer(bufferConfiguration);
             if (!initialConfig) buffer.CustomTriggerBeforeEnqueue = timestamp => timestamp.Tags["tag2"] == "value2";
@@ -372,7 +309,248 @@ namespace QuixStreams.Streaming.UnitTests.Models
             receivedData[0].Should().BeEquivalentTo(new TimeseriesData(data.Timestamps.Skip(0).Take(2).ToList()));
             receivedData[1].Should().BeEquivalentTo(new TimeseriesData(data.Timestamps.Skip(2).Take(2).ToList()));
         }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteData_WithEdgeDelayConfig_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
+        {
+            // Arrange
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
 
+            if (initialConfig) bufferConfiguration.LeadingEdgeDelay = 500;
+            var buffer = new TimeseriesBuffer(bufferConfiguration);
+            if (!initialConfig) buffer.LeadingEdgeDelay = 500;
+            
+            var receivedData = new List<TimeseriesData>();
+            var onDataReleasedRaiseCount = 0;
+            buffer.OnDataReleased += (sender, args) =>
+            {
+                receivedData.Add(args.Data);
+                onDataReleasedRaiseCount++;
+            };
+            
+            //Act
+            foreach (var timeseriesDataWithSingleTimestamp in new []{300, 200, 400, 500, 800, 900, 1000}.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            {
+                buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
+            }
+
+            // Assert
+            onDataReleasedRaiseCount.Should().Be(3);
+            receivedData.Count.Should().Be(3); // (200, 300), 400, 500
+            receivedData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(200, 300));
+            receivedData[1].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(400));
+            receivedData[2].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(500));
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteData_WithEdgeDelayAndTimespanConfig_ShouldRaiseOnDataReleasedCorrectly(bool initialConfig)
+        {
+            // Arrange
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
+            if (initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 5000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+
+            var buffer = new TimeseriesBuffer(bufferConfiguration);
+            if (!initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 5000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+        
+
+            var receivedData = new List<TimeseriesData>();
+            var onDataReleasedRaiseCount = 0;
+            buffer.OnDataReleased += (sender, args) =>
+            {
+                receivedData.Add(args.Data);
+                onDataReleasedRaiseCount++;
+            };
+
+
+            //Act
+            foreach (var timeseriesDataWithSingleTimestamp in new []{1000, 1250, 1500, 1750, 2000, 2500, 9000}.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            {
+                buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
+            }
+
+            
+            // Assert
+            onDataReleasedRaiseCount.Should().Be(1);
+            receivedData.Count.Should().Be(1); // (1000, 1250, 1500, 1750, 2000, 2500)
+            receivedData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(1000, 1250, 1500, 1750, 2000, 2500));
+            
+            // or
+            // onDataReleasedRaiseCount.Should().Be(4);
+            // receivedData.Count.Should().Be(4); // (1000, 1250), (1500, 1750), 2000, 2500
+            // receivedData[0].Should().BeEquivalentTo(GetTimeseriesDataWithFixedTimestamp(1000, 1250));
+            // receivedData[1].Should().BeEquivalentTo(GetTimeseriesDataWithFixedTimestamp(1500, 1750));
+            // receivedData[2].Should().BeEquivalentTo(GetTimeseriesDataWithFixedTimestamp(2000));
+            // receivedData[3].Should().BeEquivalentTo(GetTimeseriesDataWithFixedTimestamp(2500));
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteData_WithEdgeDelayAndTimespanConfig_ShouldRaiseOnDataReleasedWithOrderedTimestamps(bool initialConfig)
+        {
+            // Arrange
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
+            if (initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+
+            var buffer = new TimeseriesBuffer(bufferConfiguration);
+            if (!initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+        
+
+            var receivedData = new List<TimeseriesData>();
+            var onDataReleasedRaiseCount = 0;
+            buffer.OnDataReleased += (sender, args) =>
+            {
+                receivedData.Add(args.Data);
+                onDataReleasedRaiseCount++;
+            };
+
+
+            //Act
+            foreach (var timeseriesDataWithSingleTimestamp in new []{1250, 1000, 1300, 2000, 1400, 1500}.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            {
+                buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
+            }
+            
+            // Sending timestamps in a single timestamp data
+            buffer.WriteChunk(CreateTimeseriesDataWithFixedTimestamp(2250, 2000, 2300, 3000, 2400, 2500).ConvertToTimeseriesDataRaw(false, false));
+            
+            // Assert
+            onDataReleasedRaiseCount.Should().Be(2);
+            receivedData.Count.Should().Be(2); // (1000, 1250, 1300, 1400, 1500) + (2000, 2250, 2300, 2400, 2500)
+            receivedData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(1000, 1250, 1300, 1400, 1500));
+            receivedData[1].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(2000, 2250, 2300, 2400, 2500));
+            
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteData_WithEdgeDelayAndTimespanConfig_WithoutDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
+        {
+            // Arrange
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
+            if (initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+
+            var buffer = new TimeseriesBuffer(bufferConfiguration);
+            if (!initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+            
+            buffer.OnDataReleased += (sender, args) => { };
+            
+            var backfilledData = new List<TimeseriesData>();
+            var onBackfillRaiseCount = 0;
+            buffer.OnBackfill += (sender, args) =>
+            {
+                backfilledData.Add(args.Data);
+                onBackfillRaiseCount++;
+            };
+
+            //Act
+            foreach (var timeseriesDataWithSingleTimestamp in new []{1000, 1250, 1500, 2500, 10, 20}.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            {
+                buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
+            }
+
+            buffer.WriteChunk(CreateTimeseriesDataWithFixedTimestamp(30, 40).ConvertToTimeseriesDataRaw(false, false));
+            
+            // Assert
+            onBackfillRaiseCount.Should().Be(3);
+            backfilledData.Count.Should().Be(3); // 10, 20, (30, 40)
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(10));
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(20));
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(30, 40));
+        }
+        
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void WriteData_WithEdgeDelayAndTimespanConfig_WithDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
+        {
+            // Arrange
+            var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
+
+            if (initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+
+            var buffer = new TimeseriesBuffer(bufferConfiguration);
+            if (!initialConfig)
+            {
+                bufferConfiguration.LeadingEdgeDelay = 1000;
+                bufferConfiguration.TimeSpanInMilliseconds = 500;
+            }
+            
+            var backfilledData = new List<TimeseriesData>();
+            var onBackfillRaiseCount = 0;
+            buffer.OnBackfill += (sender, args) =>
+            {
+                backfilledData.Add(args.Data);
+                onBackfillRaiseCount++;
+            };
+
+            //Act
+            foreach (var timeseriesDataWithSingleTimestamp in new []{1000, 1250, 1500, 2500, 10, 20 }.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            {
+                buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
+            }
+
+            buffer.WriteChunk(CreateTimeseriesDataWithFixedTimestamp(30, 40).ConvertToTimeseriesDataRaw(false, false));
+            
+            // Assert
+            onBackfillRaiseCount.Should().Be(3);
+            backfilledData.Count.Should().Be(3); // 10, 20, (30, 40)
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(10));
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(20));
+            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(30, 40));
+        }
+
+        private TimeseriesBufferConfiguration GetEmptyTimeseriesBufferConfiguration()
+        {
+            return new TimeseriesBufferConfiguration
+            {
+                PacketSize = null,
+                TimeSpanInMilliseconds = null,
+                TimeSpanInNanoseconds = null,
+                LeadingEdgeDelay = null,
+                BufferTimeout = null,
+                Filter = null,
+                CustomTrigger = null,
+                CustomTriggerBeforeEnqueue = null
+            };
+        }
+        
         private TimeseriesData GenerateTimeseriesData()
         {
             var data = new TimeseriesData();
@@ -403,5 +581,16 @@ namespace QuixStreams.Streaming.UnitTests.Models
             return data;
         }
 
+        private TimeseriesData CreateTimeseriesDataWithFixedTimestamp(params int[] msWithEpochArray)
+        {
+            var data = new TimeseriesData();
+            foreach (var msWithEpoch in msWithEpochArray)
+            {
+                data.AddTimestampNanoseconds(msWithEpoch, epochIncluded: true)
+                    .AddValue("ms_value", msWithEpoch);
+            }
+
+            return data;
+        }
     }
 }

--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesBufferShould.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesBufferShould.cs
@@ -442,7 +442,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithLEDelayAndTimeSpanConfig_WithoutDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
+        public void WriteData_WithLEDelayAndTimeSpanConfig_WithDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
         {
             // Arrange
             var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
@@ -482,14 +482,14 @@ namespace QuixStreams.Streaming.UnitTests.Models
             onBackfillRaiseCount.Should().Be(3);
             backfilledData.Count.Should().Be(3); // 10, 20, (30, 40)
             backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(10));
-            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(20));
-            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(30, 40));
+            backfilledData[1].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(20));
+            backfilledData[2].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(30, 40));
         }
         
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void WriteData_WithLEDelayAndTimeSpanConfig_WithDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
+        public void WriteData_WithLEDelayAndTimeSpanConfig_WithoutDataReleasedEvent_ShouldRaiseOnBackfillCorrectly(bool initialConfig)
         {
             // Arrange
             var bufferConfiguration = GetEmptyTimeseriesBufferConfiguration();
@@ -516,7 +516,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             };
 
             //Act
-            foreach (var timeseriesDataWithSingleTimestamp in new []{1000, 1250, 1500, 2500, 10, 20 }.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
+            foreach (var timeseriesDataWithSingleTimestamp in new []{1000, 1250, 1500, 2500, 3000, 10, 20 }.Select(x => CreateTimeseriesDataWithFixedTimestamp(x)))
             {
                 buffer.WriteChunk(timeseriesDataWithSingleTimestamp.ConvertToTimeseriesDataRaw(false, false)); 
             }
@@ -524,11 +524,8 @@ namespace QuixStreams.Streaming.UnitTests.Models
             buffer.WriteChunk(CreateTimeseriesDataWithFixedTimestamp(30, 40).ConvertToTimeseriesDataRaw(false, false));
             
             // Assert
-            onBackfillRaiseCount.Should().Be(3);
-            backfilledData.Count.Should().Be(3); // 10, 20, (30, 40)
-            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(10));
-            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(20));
-            backfilledData[0].Should().BeEquivalentTo(CreateTimeseriesDataWithFixedTimestamp(30, 40));
+            onBackfillRaiseCount.Should().Be(0);
+            backfilledData.Count.Should().Be(0);
         }
         
         [Theory]

--- a/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesDataRawShould.cs
+++ b/src/CsharpClient/QuixStreams.Streaming.UnitTests/Models/TimeseriesDataRawShould.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using FluentAssertions.Equivalency;
+using QuixStreams.Streaming.Models;
+using QuixStreams.Telemetry.Models;
+using Xunit;
+
+namespace QuixStreams.Streaming.UnitTests.Models
+{
+    public class TimeseriesDataRawShould
+    {
+        [Fact]
+        public void SortByTimestamp_WithUnorderedTimestamps_ShouldOrderThemByAsc()
+        {
+            // Arrange
+            var data = new TimeseriesData();
+            foreach (var timestamp in new int[]{1250, 1000, 1300, 2000, 1400, 1500})
+            {
+                data.AddTimestampNanoseconds(timestamp, epochIncluded: true)
+                    .AddValue("number", timestamp)
+                    .AddValue("str", $"ts_{timestamp}")
+                    .AddValue("bytes", Encoding.UTF8.GetBytes($"ts_{timestamp}"))
+                    .AddTag("tag", $"ts_{timestamp}");
+            }
+            
+            var raw = data.ConvertToTimeseriesDataRaw();
+
+            // Act
+            raw.SortByTimestamp();
+
+            // Assert
+            raw.Timestamps.Should().BeInAscendingOrder();
+            raw.NumericValues["number"].Should().BeInAscendingOrder();
+            raw.StringValues["str"].Should().BeInAscendingOrder();
+            raw.BinaryValues["bytes"].Select(Encoding.UTF8.GetString).Should().BeInAscendingOrder();
+            raw.TagValues["tag"].Should().BeInAscendingOrder();
+        }
+    }
+}

--- a/src/CsharpClient/QuixStreams.Streaming/Models/StreamProducer/TimeseriesBufferProducer.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/StreamProducer/TimeseriesBufferProducer.cs
@@ -203,7 +203,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
         /// </summary>
         public void Flush()
         {
-            this.FlushData(false);
+            this.FlushData(false, includeDataInLeadingEdgeDelay: true);
         }
         
         protected override void InvokeOnReceive(object sender, TimeseriesDataReadEventArgs args)

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesBufferConfiguration.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesBufferConfiguration.cs
@@ -36,12 +36,13 @@ namespace QuixStreams.Streaming.Models
         }
         
         /// <summary>
-        /// Gets or sets the leading edge delay for the buffer in milliseconds. Used when data is arriving to the buffer with no order.
-        /// When the difference between the a package's timestamp in buffer is surpasses the leading edge delay, the <see cref="TimeseriesBuffer.OnDataReleased"/> event
-        /// is invoked and the data is cleared from the buffer.
-        /// Defaults to null (disabled)..
-        /// Note: It should be used in combination with <see cref="TimeSpanInMilliseconds"/> to avoid sending packages one by one.
+        /// Gets or sets the buffer's leading edge delay in milliseconds.
+        /// The <see cref="TimeseriesBuffer.OnDataReleased"/> event is triggered, and the data is removed from the buffer once a package's timestamp exceeds the leading edge delay.
+        /// The default value is null, which means this feature is disabled.
         /// </summary>
+        /// <remarks>
+        /// A leading edge delay is particularly useful in time-sensitive applications where data is expected to arrive out of order. By delaying the release of data from the buffer based on a package's timestamp, we can help ensure that data is processed in the correct order.
+        /// </remarks>
         public long? LeadingEdgeDelay { get; set; } = null;
 
 

--- a/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesBufferConfiguration.cs
+++ b/src/CsharpClient/QuixStreams.Streaming/Models/TimeseriesBufferConfiguration.cs
@@ -34,6 +34,15 @@ namespace QuixStreams.Streaming.Models
             get => TimeSpanInNanoseconds /(long)1e6;
             set => this.TimeSpanInNanoseconds = value * (long)1e6;
         }
+        
+        /// <summary>
+        /// Gets or sets the leading edge delay for the buffer in milliseconds. Used when data is arriving to the buffer with no order.
+        /// When the difference between the a package's timestamp in buffer is surpasses the leading edge delay, the <see cref="TimeseriesBuffer.OnDataReleased"/> event
+        /// is invoked and the data is cleared from the buffer.
+        /// Defaults to null (disabled)..
+        /// Note: It should be used in combination with <see cref="TimeSpanInMilliseconds"/> to avoid sending packages one by one.
+        /// </summary>
+        public long? LeadingEdgeDelay { get; set; } = null;
 
 
         /// <summary>

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/TimeseriesDataRaw.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/TimeseriesDataRaw.cs
@@ -94,8 +94,7 @@ namespace QuixStreams.Telemetry.Models
         }
         
         /// <summary>
-        /// Sorts the Timestamps array and all associated data arrays within NumericValues, StringValues, 
-        /// BinaryValues, and TagValues dictionaries in increasing order based on the Timestamps values. 
+        /// Sorts all data in increasing order based on the Timestamps values. 
         /// </summary>
         public void SortByTimestamp()
         {

--- a/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/TimeseriesDataRaw.cs
+++ b/src/CsharpClient/QuixStreams.Telemetry/Models/Telemetry/Parameters/TimeseriesDataRaw.cs
@@ -92,6 +92,42 @@ namespace QuixStreams.Telemetry.Models
 
             return JsonConvert.SerializeObject(this, settings);
         }
+        
+        /// <summary>
+        /// Sorts the Timestamps array and all associated data arrays within NumericValues, StringValues, 
+        /// BinaryValues, and TagValues dictionaries in increasing order based on the Timestamps values. 
+        /// </summary>
+        public void SortByTimestamp()
+        {
+            if (Timestamps == null || Timestamps.Length == 0) return;
+            
+            // Create a list of indexes from 0 to the size of the Timestamps array
+            List<int> indexes = Enumerable.Range(0, Timestamps.Length).ToList();
+
+            // Sort this list based on corresponding value from Timestamps array
+            indexes.Sort((a, b) => Timestamps[a].CompareTo(Timestamps[b]));
+
+            // Reorder Timestamp values based on sorted indexes
+            Timestamps = ReorderByIndexes(Timestamps, indexes);
+
+            // Reorder values dictionaries
+            NumericValues = ReorderByIndexes(NumericValues, indexes);
+            StringValues = ReorderByIndexes(StringValues, indexes);
+            BinaryValues = ReorderByIndexes(BinaryValues, indexes);
+            TagValues = ReorderByIndexes(TagValues, indexes);
+        }
+
+        private static long[] ReorderByIndexes(long[] array, List<int> indexes)
+        {
+            return indexes.Select(index => array[index]).ToArray();
+        }
+
+        private static Dictionary<string, T[]> ReorderByIndexes<T>(Dictionary<string, T[]> dict, List<int> indexes)
+        {
+            return dict.ToDictionary(
+                pair => pair.Key, 
+                pair => indexes.Select(index => pair.Value[index]).ToArray());
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
### Configuration
``` csharp
streamProducer.Timeseries.Buffer.LeadingEdgeDelay = 5000;
streamProducer.Timeseries.Buffer.TimeSpanInMilliseconds = 500;

streamProducer.Timeseries.Buffer.OnBackfill += (s, e) => 
```

### Principle
Data arriving into buffer not ordered. The principle of delay is wait for data to arrive and send them ordered.

### Backfill event
Items arriving after LeadingEdgeDelay are discarded from the output topic but released in this event for further processing or forwarding.

#### Example
Image data with columns Timestamp and Speed and buffer configured to send data in 500ms batches in 5 seconds delay.

10:00:00.750: 250 arrived

10:00:00.500: 240 arrived

10:00:01.250: 260 arrived
10:00:00.500: 240 sent

10:00:01.000: 255 arrived

10:00:01.500: 270 arrived
10:00:00.750: 250 sent