### PR TITLE
Feature/sdf skeleton cleanup

### DIFF
--- a/src/PythonClient/src/quixstreams/dataframes/dataframe/dataframe.py
+++ b/src/PythonClient/src/quixstreams/dataframes/dataframe/dataframe.py
@@ -1,5 +1,4 @@
 import uuid
-from copy import deepcopy
 from functools import partial
 from typing import Self, Optional, Callable, TypeAlias, Union, List, Mapping
 
@@ -15,18 +14,13 @@ __all__ = ("StreamingDataFrame",)
 
 
 def subset(keys: list[str], row: Row) -> Row:
-    new_row = deepcopy(row)
-    new_row.value = new_row[keys]
-    return new_row
+    row.value = row[keys]
+    return row
 
 
 def setitem(k: str, v: Union[Column, OpValue], row: Row) -> Row:
     row[k] = v.eval(row) if isinstance(v, Column) else v
     return row
-
-
-def column_filter(column: Column, row: Row) -> Optional[Row]:
-    return row if column.eval(row) else None
 
 
 class StreamingDataFrame:
@@ -53,7 +47,8 @@ class StreamingDataFrame:
         :param func: callable that accepts and (usually) returns a QuixStreams Row
         :return: self (StreamingDataFrame)
         """
-        return self._clone()._apply(func=func)
+        self._pipeline.apply(func)
+        return self
 
     def process(self, row: Row) -> Optional[Union[Row, list[Row]]]:
         """
@@ -96,15 +91,15 @@ class StreamingDataFrame:
         self._real_producer = producer
 
     def __setitem__(self, key: str, value: Union[Column, OpValue, str]):
-        self._apply(partial(setitem, key, value))
+        self.apply(partial(setitem, key, value))
 
     def __getitem__(
         self, item: Union[str, list[str], Column, Self]
     ) -> Union[Column, Self]:
         if isinstance(item, Column):
-            return self._apply(partial(column_filter, item))
+            return self.apply(lambda row: row if item.eval(row) else None)
         elif isinstance(item, list):
-            return self._apply(partial(subset, item))
+            return self.apply(partial(subset, item))
         elif isinstance(item, StreamingDataFrame):
             # TODO: Implement filtering based on another SDF
             raise ValueError(
@@ -112,12 +107,3 @@ class StreamingDataFrame:
             )
         else:
             return Column(col_name=item)
-
-    def _clone(self) -> Self:
-        return self.__class__(
-            topics=list(self._topics.values()), _pipeline=self._pipeline.clone()
-        )
-
-    def _apply(self, func: RowApplier):
-        self._pipeline.apply(func)
-        return self

--- a/src/PythonClient/src/quixstreams/dataframes/dataframe/pipeline.py
+++ b/src/PythonClient/src/quixstreams/dataframes/dataframe/pipeline.py
@@ -1,43 +1,22 @@
 import logging
 import uuid
-from copy import deepcopy
 from typing import Self, Optional, Callable, Any, Union
 
 from ..models import Row
 
 logger = logging.getLogger(__name__)
 
-__all__ = ("InvalidPipelineBranching", "PipelineFunction", "Pipeline", "get_func_name")
+__all__ = ("PipelineFunction", "Pipeline")
 
 
-def get_attrs(obj, attrs):
-    attrs = attrs.split(".")
-    for a in attrs:
-        obj = obj.__getattribute__(a)
-    return obj
-
-
-def get_func_name(func):
-    for item in ["__name__", "func.__name__", "__class__.__name__"]:
-        try:
-            return get_attrs(func, item)
-        except AttributeError:
-            pass
-    return "callable"
-
-
-class InvalidPipelineBranching(Exception):
-    pass
-
-
-# TODO: Docstrings
 class PipelineFunction:
-    def __init__(self, func: Union[Callable], pipeline_name: str, name: str = None):
+    def __init__(self, func: Union[Callable]):
         self._id = str(uuid.uuid4())
-        self._pipeline_name = pipeline_name
         self._func = func
-        self._name = name or get_func_name(self._func)
-        logger.debug(f"Generated PipelineFunction {self.full_id}")
+
+    @property
+    def id(self) -> str:
+        return self._id
 
     def __repr__(self):
         return f'<{self.__class__.__name__} "{repr(self._func)}">'
@@ -45,86 +24,49 @@ class PipelineFunction:
     def __call__(self, row: Row):
         return self._func(row)
 
-    @property
-    def id(self) -> str:
-        return self._id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def pipeline_name(self) -> str:
-        return self._pipeline_name
-
-    @property
-    def full_id(self):
-        return f"[P:{self.pipeline_name}];[F:{self.name}];[ID:{self.id}]"
-
 
 class Pipeline:
     def __init__(
         self,
-        name: str = None,
         functions: list[PipelineFunction] = None,
-        graph: dict = None,
-        parent: str = None,
+        _id: str = None
     ):
+        self._id = _id or str(uuid.uuid4())
         self._functions = functions or []
-        self._name = name or str(uuid.uuid4())
-        self._graph = graph or {}
-        self._parent = parent
-        self._add_graph_node()
 
     @property
     def functions(self) -> list[PipelineFunction]:
         return self._functions
 
     @property
-    def name(self) -> str:
-        return self._name
+    def id(self) -> str:
+        return self._id
 
-    @property
-    def graph(self) -> dict:
-        return self._graph
+    def apply(self, func: Callable) -> Self:
+        """
+        Add a callable to the Pipeline execution list.
+        The provided callable should accept a single argument, which will be its input.
+        The provided callable should similarly return one output, or None
 
-    @property
-    def parent(self) -> str:
-        return self._parent
+        Note that if the expected input is a list, this function will be called with
+        each element in that list rather than the list itself.
 
-    def clone(self) -> Self:
-        return self.__class__(
-            functions=self._functions[:], graph=deepcopy(self.graph), parent=self.name
-        )
-
-    def _add_graph_node(self):
-        if self.parent:
-            self._graph[self.parent] = self.name
-        else:
-            self._graph[self.name] = None
-
-    def _check_child_contains_parent(self, parent: Self):
-        for key in parent.graph:
-            if parent_child := parent.graph[key]:
-                try:
-                    assert self.graph[key] == parent_child
-                except AssertionError:
-                    raise InvalidPipelineBranching
-
-    def remove_redundant_functions(self, parent: Self) -> Self:
-        self._check_child_contains_parent(parent)
-        self._functions = self.functions[
-            -(len(self.functions) - len(parent.functions)) :
-        ]
-        return self
-
-    def apply(self, func: Callable, func_name: str = None) -> Self:
-        self.functions.append(
-            PipelineFunction(func=func, pipeline_name=self.name, name=func_name)
-        )
+        :param func: callable that accepts and (usually) returns an object
+        :return: self (Pipeline)
+        """
+        self.functions.append(PipelineFunction(func=func))
         return self
 
     def process(self, data: Any) -> Optional[Any]:
+        """
+        Execute the previously defined Pipeline functions on a provided input, `data`.
+
+        Note that if `data` is a list, each function will be called with each element
+        in that list rather than the list itself.
+
+        :param data: any object, noting rows
+        :return: Row, list of Rows, or None (if filtered)
+        """
         result = data
         for func in self.functions:
             if isinstance(result, list):
@@ -135,8 +77,17 @@ class Pipeline:
                 result = func(result)
             if result is None:
                 logger.debug(
-                    f"Pipeline {self.name} processing step returned a None; "
-                    f"terminating processing"
+                    "Pipeline {pid} processing step returned a None; "
+                    "terminating processing".format(pid=self.id)
                 )
                 break
         return result
+
+    def clone(self) -> Self:
+        """
+        Creates a clone of this Pipeline, including its function set. A new id will be
+        generated for the clone.
+
+        :return: cloned Pipeline instance
+        """
+        return self.__class__(functions=self._functions[:])

--- a/src/PythonClient/src/quixstreams/dataframes/dataframe/pipeline.py
+++ b/src/PythonClient/src/quixstreams/dataframes/dataframe/pipeline.py
@@ -64,9 +64,11 @@ class Pipeline:
         Note that if `data` is a list, each function will be called with each element
         in that list rather than the list itself.
 
-        :param data: any object, noting rows
-        :return: Row, list of Rows, or None (if filtered)
+        :param data: any object, but usually a QuixStreams Row
+        :return: an object OR list of objects OR None (if filtered)
         """
+        # TODO: maybe have an arg that allows passing "blacklisted" result types
+        # or SDF inspects each result somehow?
         result = data
         for func in self.functions:
             if isinstance(result, list):
@@ -82,12 +84,3 @@ class Pipeline:
                 )
                 break
         return result
-
-    def clone(self) -> Self:
-        """
-        Creates a clone of this Pipeline, including its function set. A new id will be
-        generated for the clone.
-
-        :return: cloned Pipeline instance
-        """
-        return self.__class__(functions=self._functions[:])

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/fixtures.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/fixtures.py
@@ -1,17 +1,12 @@
-from copy import deepcopy
-from functools import partial
-
 import pytest
 
-from src.quixstreams.dataframes.dataframe.column import Column
-from src.quixstreams.dataframes.dataframe.dataframe import StreamingDataFrame
+from src.quixstreams.dataframes.models.rows import Row
+from src.quixstreams.dataframes.models.topics import Topic
+from src.quixstreams.dataframes.models.timestamps import MessageTimestamp, TimestampType
 from src.quixstreams.dataframes.dataframe.pipeline import Pipeline, PipelineFunction
-from src.quixstreams.dataframes.models import (
-    Topic,
-    Row,
-    MessageTimestamp,
-    TimestampType,
-)
+from src.quixstreams.dataframes.dataframe.dataframe import StreamingDataFrame
+from copy import deepcopy
+from functools import partial
 
 
 @pytest.fixture()
@@ -19,87 +14,41 @@ def row_msg_value_factory():
     def _row_msg_value_factory(message_value):
         return Row(
             value=message_value,
-            topic="test_topic",
+            topic='test_topic',
             partition=0,
             offset=0,
             size=0,
-            timestamp=MessageTimestamp(1234567890, TimestampType(1)),
+            timestamp=MessageTimestamp(1234567890, TimestampType(1))
         )
-
     return _row_msg_value_factory
-
-
-@pytest.fixture()
-def msg_value_with_ints():
-    return {"k": 0, "x": 5, "x2": 5, "y": 20, "z": 110}
-
-
-@pytest.fixture()
-def msg_value_with_list():
-    return {
-        "x": 5,
-        "x_list": [0, 1, 2],
-    }
-
-
-@pytest.fixture()
-def msg_value_with_bools():
-    return {"x": True, "y": True, "z": False}
-
-
-@pytest.fixture()
-def row_with_ints(row_msg_value_factory, msg_value_with_ints):
-    return row_msg_value_factory(msg_value_with_ints)
-
-
-@pytest.fixture()
-def row_with_list(row_msg_value_factory, msg_value_with_list):
-    return row_msg_value_factory(msg_value_with_list)
-
-
-@pytest.fixture()
-def row_with_bools(row_msg_value_factory, msg_value_with_bools):
-    return row_msg_value_factory(msg_value_with_bools)
 
 
 @pytest.fixture()
 def pipeline_function():
     def test_func(data):
         return {k: v + 1 for k, v in data.items()}
-
-    return PipelineFunction(func=test_func, pipeline_name="test_pipeline")
+    return PipelineFunction(func=test_func)
 
 
 @pytest.fixture()
 def pipeline(pipeline_function):
-    return Pipeline(
-        name="test_pipeline",
-        functions=[pipeline_function],
-        graph={"test_pipeline_parent": "test_pipeline"},
-        parent="test_pipeline_parent",
-    )
-
-
-@pytest.fixture()
-def column():
-    return Column("x")
+    return Pipeline(functions=[pipeline_function])
 
 
 @pytest.fixture()
 def dataframe():
-    return StreamingDataFrame(topics=[Topic("test")], name="test_dataframe")
+    return StreamingDataFrame(topics=[Topic("test")])
 
 
 @pytest.fixture()
 def more_rows_func():
     def more_rows(row):
         rows_out = []
-        for item in row["x_list"]:
+        for item in row['x_list']:
             row_out = deepcopy(row)
-            row_out["x_list"] = item
+            row_out['x_list'] = item
             rows_out.append(row_out)
         return rows_out
-
     return more_rows
 
 
@@ -114,20 +63,6 @@ def row_plus_n_func():
     """
     This generally will be used alongside "row_plus_n"
     """
-
-    def _row_values_plus_n(n):
+    def _row_values_plus_n(n=None):
         return partial(row_values_plus_n, n)
-
     return _row_values_plus_n
-
-
-@pytest.fixture()
-def row_plus_n():
-    """
-    This generally will be used alongside "row_plus_n_func"
-    """
-
-    def _row_plus_n(n, row):
-        return row_values_plus_n(n, deepcopy(row))
-
-    return _row_plus_n

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_column.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_column.py
@@ -2,162 +2,194 @@ from src.quixstreams.dataframes.dataframe.column import Column
 
 
 class TestColumn:
-    def test_apply(self, msg_value_with_ints):
-        result = Column("x").apply(lambda v: v + 22)
+    def test_apply(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x').apply(lambda v: v + 22)
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 27
+        assert result.eval(msg_value) == 27
 
-    def test_addition(self, msg_value_with_ints):
-        result = Column("x") + Column("y")
+    def test_addition(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') + Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 25
+        assert result.eval(msg_value) == 25
 
-    def test_multi_op(self, msg_value_with_ints):
-        result = Column("x") + Column("y") + Column("z")
+    def test_multi_op(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') + Column('y') + Column('z')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 135
+        assert result.eval(msg_value) == 135
 
-    def test_scaler_op(self, msg_value_with_ints):
-        result = Column("x") + 2
+    def test_scaler_op(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') + 2
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 7
+        assert result.eval(msg_value) == 7
 
-    def test_subtraction(self, msg_value_with_ints):
-        result = Column("y") - Column("x")
+    def test_subtraction(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') - Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 15
+        assert result.eval(msg_value) == 15
 
-    def test_multiplication(self, msg_value_with_ints):
-        result = Column("x") * Column("y")
+    def test_multiplication(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') * Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 100
+        assert result.eval(msg_value) == 100
 
-    def test_div(self, msg_value_with_ints):
-        result = Column("z") / Column("y")
+    def test_div(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('z') / Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 5.5
+        assert result.eval(msg_value) == 5.5
 
-    def test_mod(self, msg_value_with_ints):
-        result = Column("y") % Column("x")
+    def test_mod(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') % Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) == 0
+        assert result.eval(msg_value) == 0
 
-    def test_equality_true(self, msg_value_with_ints):
-        result = Column("x") == Column("x2")
+    def test_equality_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'x2': 5})
+        result = Column('x') == Column('x2')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_equality_false(self, msg_value_with_ints):
-        result = Column("x") == Column("y")
+    def test_equality_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') == Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_inequality_true(self, msg_value_with_ints):
-        result = Column("x") != Column("y")
+    def test_inequality_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') != Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_inequality_false(self, msg_value_with_ints):
-        result = Column("x") != Column("x2")
+    def test_inequality_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'x2': 5})
+        result = Column('x') != Column('x2')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_less_than_true(self, msg_value_with_ints):
-        result = Column("x") < Column("y")
+    def test_less_than_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') < Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_less_than_false(self, msg_value_with_ints):
-        result = Column("y") < Column("x")
+    def test_less_than_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') < Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_less_than_or_equal_equal_true(self, msg_value_with_ints):
-        result = Column("x") <= Column("x2")
+    def test_less_than_or_equal_equal_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'x2': 5})
+        result = Column('x') <= Column('x2')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_less_than_or_equal_less_true(self, msg_value_with_ints):
-        result = Column("x") <= Column("y")
+    def test_less_than_or_equal_less_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') <= Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_less_than_or_equal_false(self, msg_value_with_ints):
-        result = Column("y") <= Column("x")
+    def test_less_than_or_equal_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') <= Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_greater_than_true(self, msg_value_with_ints):
-        result = Column("y") > Column("x")
+    def test_greater_than_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') > Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_greater_than_false(self, msg_value_with_ints):
-        result = Column("x") > Column("y")
+    def test_greater_than_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') > Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_greater_than_or_equal_equal_true(self, msg_value_with_ints):
-        result = Column("x") >= Column("x2")
+    def test_greater_than_or_equal_equal_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'x2': 5})
+        result = Column('x') >= Column('x2')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_greater_than_or_equal_greater_true(self, msg_value_with_ints):
-        result = Column("y") >= Column("x")
+    def test_greater_than_or_equal_greater_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('y') >= Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_greater_than_or_equal_greater_false(self, msg_value_with_ints):
-        result = Column("x") >= Column("y")
+    def test_greater_than_or_equal_greater_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = Column('x') >= Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False
 
-    def test_and_true(self, msg_value_with_bools):
-        result = Column("x") & Column("y")
+    def test_and_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & Column('y')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is True
+        assert result.eval(msg_value) is True
 
-    def test_and_true_multiple(self, msg_value_with_bools):
-        result = Column("x") & Column("y") & Column("x")
+    def test_and_true_multiple(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & Column('y') & Column('x')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is True
+        assert result.eval(msg_value) is True
 
-    def test_and_false_multiple(self, msg_value_with_bools):
-        result = Column("x") & Column("y") & Column("z")
+    def test_and_false_multiple(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & Column('y') & Column('z')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is False
+        assert result.eval(msg_value) is False
 
-    def test_and_false(self, msg_value_with_bools):
-        result = Column("x") & Column("z")
+    def test_and_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & Column('z')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is False
+        assert result.eval(msg_value) is False
 
-    def test_and_true_bool(self, msg_value_with_bools):
-        result = Column("x") & True
+    def test_and_true_bool(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & True
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is True
+        assert result.eval(msg_value) is True
 
-    def test_and_false_bool(self, msg_value_with_bools):
-        result = Column("x") & False
+    def test_and_false_bool(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') & False
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is False
+        assert result.eval(msg_value) is False
 
-    def test_or_true(self, msg_value_with_bools):
-        result = Column("x") | Column("z")
+    def test_or_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('x') | Column('z')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is True
+        assert result.eval(msg_value) is True
 
-    def test_or_false(self, msg_value_with_bools):
-        result = Column("z") | Column("z")
+    def test_or_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': True, 'y': True, 'z': False})
+        result = Column('z') | Column('z')
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_bools) is False
+        assert result.eval(msg_value) is False
 
-    def test_and_inequalities_true(self, msg_value_with_ints):
-        result = (Column("x") <= Column("y")) & (Column("x") <= Column("z"))
+    def test_and_inequalities_true(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = (Column('x') <= Column('y')) & (Column('x') <= Column('z'))
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is True
+        assert result.eval(msg_value) is True
 
-    def test_and_inequalities_false(self, msg_value_with_ints):
-        result = (Column("x") <= Column("y")) & (Column("x") > Column("z"))
+    def test_and_inequalities_false(self, row_msg_value_factory):
+        msg_value = row_msg_value_factory({'x': 5, 'y': 20, 'z': 110})
+        result = (Column('x') <= Column('y')) & (Column('x') > Column('z'))
         assert isinstance(result, Column)
-        assert result.eval(msg_value_with_ints) is False
+        assert result.eval(msg_value) is False

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_dataframe.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_dataframe.py
@@ -1,21 +1,19 @@
 import pytest
 
 from src.quixstreams.dataframes.dataframe.pipeline import (
-    InvalidPipelineBranching,
     Pipeline,
 )
 
 
 class TestDataframe:
     def test_dataframe(self, dataframe):
-        assert dataframe.name == "test_dataframe"
         assert isinstance(dataframe._pipeline, Pipeline)
-        assert dataframe._pipeline.name == dataframe.name
+        assert dataframe._pipeline.id == dataframe.id
 
     def test__clone(self, dataframe):
         cloned_df = dataframe._clone()
         assert id(cloned_df) != id(dataframe)
-        assert cloned_df._pipeline.name != dataframe._pipeline.name
+        assert cloned_df._pipeline.id != dataframe._pipeline.id
 
     def test_apply(self, dataframe):
         def test_func(row):
@@ -23,267 +21,137 @@ class TestDataframe:
 
         dataframe2 = dataframe.apply(test_func)
         assert id(dataframe) != id(dataframe2)
-        assert dataframe2._pipeline.functions[-1].name == "apply:test_func"
 
 
 class TestDataframeProcess:
-    def test_row_apply(self, dataframe, row_with_ints, row_plus_n_func, row_plus_n):
-        n = 1
-        dataframe = dataframe.apply(row_plus_n_func(n))
-        expected = row_plus_n(n, row_with_ints)
-        assert dataframe.process(row_with_ints) == expected
-
-    def test_row_apply_fluent(
-        self,
-        dataframe,
-        row_with_ints,
-        row_plus_n_func,
-        row_plus_n,
-        row_msg_value_factory,
-    ):
-        dataframe = dataframe.apply(row_plus_n_func(1)).apply(row_plus_n_func(2))
-        expected = row_plus_n(3, row_with_ints)
-        assert dataframe.process(row_with_ints) == expected
-
-    def test_row_apply_sequential(
-        self, dataframe, row_with_ints, row_plus_n_func, row_plus_n
-    ):
+    def test_apply(self, dataframe, row_msg_value_factory, row_plus_n_func):
         dataframe = dataframe.apply(row_plus_n_func(1))
-        dataframe = dataframe.apply(row_plus_n_func(2))
-        expected = row_plus_n(3, row_with_ints)
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 2, 'y': 3})
 
-    def test_set_item_primitive(
-        self, dataframe, row_with_ints, msg_value_with_ints, row_msg_value_factory
-    ):
-        dataframe["new_val"] = 1
-        expected = row_msg_value_factory({**msg_value_with_ints, "new_val": 1})
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+    def test_apply_fluent(self, dataframe, row_msg_value_factory, row_plus_n_func):
+        dataframe = dataframe.apply(row_plus_n_func(n=1)).apply(row_plus_n_func(n=2))
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 4, 'y': 5})
 
-    def test_set_item_column_only(
-        self, dataframe, row_with_ints, msg_value_with_ints, row_msg_value_factory
-    ):
-        dataframe["new_val"] = dataframe["x"]
-        expected = row_msg_value_factory(
-            {**msg_value_with_ints, "new_val": msg_value_with_ints["x"]}
-        )
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+    def test_apply_sequential(self, dataframe, row_msg_value_factory, row_plus_n_func):
+        dataframe = dataframe.apply(row_plus_n_func(n=1))
+        dataframe = dataframe.apply(row_plus_n_func(n=2))
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 4, 'y': 5})
 
-    def test_set_item_column_with_function(
-        self, dataframe, row_with_ints, msg_value_with_ints, row_msg_value_factory
-    ):
-        dataframe["new_val"] = dataframe["x"].apply(lambda v: v + 10)
-        expected = row_msg_value_factory(
-            {**msg_value_with_ints, "new_val": msg_value_with_ints["x"] + 10}
-        )
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+    def test_setitem_primitive(self, dataframe, row_msg_value_factory):
+        dataframe['new'] = 1
+        row = row_msg_value_factory({'x': 1})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 1, 'new': 1})
 
-    def test_set_item_column_with_operations(
-        self, dataframe, row_with_ints, msg_value_with_ints, row_msg_value_factory
-    ):
-        dataframe["new_val"] = (
-            dataframe["x"] + dataframe["y"].apply(lambda v: v + 10) + 1
-        )
-        expected = row_msg_value_factory(
-            {
-                **msg_value_with_ints,
-                "new_val": msg_value_with_ints["x"]
-                + (msg_value_with_ints["y"] + 10)
-                + 1,
-            }
-        )
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+    def test_setitem_column_only(self, dataframe, row_msg_value_factory):
+        dataframe['new'] = dataframe['x']
+        row = row_msg_value_factory({'x': 1})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 1, 'new': 1})
 
-    def test_column_subset(
-        self, dataframe, row_with_ints, msg_value_with_ints, row_msg_value_factory
-    ):
-        key_list = ["x", "y"]
-        dataframe = dataframe[key_list]
-        expected = row_msg_value_factory({k: msg_value_with_ints[k] for k in key_list})
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+    def test_setitem_column_with_function(self, dataframe, row_msg_value_factory):
+        dataframe['new'] = dataframe['x'].apply(lambda v: v + 5)
+        row = row_msg_value_factory({'x': 1})
+        assert dataframe.process(row) == row_msg_value_factory({'x': 1, 'new': 6})
+
+    def test_setitem_column_with_operations(self, dataframe, row_msg_value_factory):
+        dataframe['new'] = dataframe['x'] + dataframe['y'].apply(lambda v: v + 5) + 1
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        expected = row_msg_value_factory({'x': 1, 'y': 2, 'new': 9})
+        assert dataframe.process(row) == expected
+
+    def test_column_subset(self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[['x', 'y']]
+        row = row_msg_value_factory({'x': 1, 'y': 2, 'z': 3})
+        expected = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == expected
 
     def test_column_subset_with_funcs(
-        self,
-        dataframe,
-        row_with_ints,
-        msg_value_with_ints,
-        row_plus_n_func,
-        row_msg_value_factory,
+            self, dataframe, row_msg_value_factory, row_plus_n_func
     ):
-        n = 1
-        key_list = ["x", "y"]
-        dataframe = dataframe[key_list].apply(row_plus_n_func(n))
-        expected = row_msg_value_factory(
-            {k: msg_value_with_ints[k] + n for k in key_list}
-        )
-        actual = dataframe.process(row_with_ints)
-        assert actual == expected
+        dataframe = dataframe[['x', 'y']].apply(row_plus_n_func(n=5))
+        row = row_msg_value_factory({'x': 1, 'y': 2, 'z': 3})
+        expected = row_msg_value_factory({'x': 6, 'y': 7})
+        assert dataframe.process(row) == expected
 
-    def test_inequality_filtering(self, dataframe, row_with_ints):
-        dataframe = dataframe[dataframe["x"] > 0]
-        assert dataframe.process(row_with_ints) == row_with_ints
+    def test_inequality_filter(self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[dataframe['x'] > 0]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row
 
-    def test_inequality_filtering_with_operation(self, dataframe, row_with_ints):
-        dataframe = dataframe[(dataframe["x"] - 0 + dataframe["y"]) > 0]
-        assert dataframe.process(row_with_ints) == row_with_ints
+    def test_inequality_filter_is_filtered(self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[dataframe['x'] >= 1000]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) is None
 
-    def test_inequality_filtering_with_operation_filtered(
-        self, dataframe, row_with_ints
+    def test_inequality_filter_with_operation(self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[(dataframe['x'] - 0 + dataframe['y']) > 0]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row
+
+    def test_inequality_filter_with_operation_is_filtered(
+            self, dataframe, row_msg_value_factory
     ):
-        dataframe = dataframe[(dataframe["x"] - dataframe["y"]) > 0]
-        assert dataframe.process(row_with_ints) is None
+        dataframe = dataframe[(dataframe['x'] - dataframe['y']) > 0]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) is None
 
-    def test_inequality_filtering_with_apply_filtered(self, dataframe, row_with_ints):
-        dataframe = dataframe[dataframe["x"].apply(lambda v: v - 1000) >= 0]
-        assert dataframe.process(row_with_ints) is None
-
-    def test_inequality_filtering_filtered(self, dataframe, row_with_ints):
-        dataframe = dataframe[dataframe["x"] >= 1000]
-        assert dataframe.process(row_with_ints) is None
-
-    def test_compound_inequality_filtering_continue(self, dataframe, row_with_ints):
-        dataframe = dataframe[(dataframe["x"] >= 0) & (dataframe["y"] < 100)]
-        assert dataframe.process(row_with_ints) == row_with_ints
-
-    def test_compound_inequality_filtering_filtered(self, dataframe, row_with_ints):
-        dataframe = dataframe[(dataframe["x"] >= 0) & (dataframe["y"] < 0)]
-        assert dataframe.process(row_with_ints) is None
-
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_fails(self, dataframe, row_with_ints):
-        dataframe = dataframe[
-            dataframe.apply(lambda row: row if row["x"] > 0 else None)
-        ]
-        with pytest.raises(
-            ValueError,
-            match="Filtering based on StreamingDataFrame is not supported yet",
-        ):
-            assert dataframe.process(row_with_ints) == row_with_ints
-
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_continue(self, dataframe, row_with_ints):
-        dataframe = dataframe[
-            dataframe.apply(lambda row: row if row["x"] > 0 else None)
-        ]
-        assert dataframe.process(row_with_ints) == row_with_ints
-
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_filter_none(self, dataframe, row_with_ints):
-        dataframe = dataframe[
-            dataframe.apply(lambda row: row if row["x"] < 0 else None)
-        ]
-        assert dataframe.process(row_with_ints) is None
-
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_filter_false(self, dataframe, row_with_ints):
-        dataframe = dataframe[dataframe.apply(lambda row: False)]
-        assert dataframe.process(row_with_ints) is None
-
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_sequential_continue(self, dataframe, row_with_ints):
-        p_filter = dataframe.apply(lambda row: row if row["x"] > 0 else None)
-        dataframe = dataframe[p_filter]
-        assert dataframe.process(row_with_ints) == row_with_ints
-
-    @pytest.mark.skip("Requires copying, not implemented yet")
-    def test_row_apply_filtering_dataframe_uses_apply_in_filter(
-        self, dataframe, row_with_ints, row_plus_n_func, row_plus_n
+    def test_inequality_filtering_with_apply(
+            self, dataframe, row_msg_value_factory
     ):
-        n = 1
-        dataframe = dataframe.apply(row_plus_n_func(n))
-        dataframe = dataframe[dataframe.apply(lambda row: row)]
-        assert dataframe.process(row_with_ints) == row_plus_n(n, row_with_ints)
+        dataframe = dataframe[dataframe['x'].apply(lambda v: v - 1) >= 0]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row
 
-    @pytest.mark.skip("Requires copying, not implemented yet")
-    def test_row_apply_filtering_separate_filtering_dataframe(
-        self, dataframe, row_with_ints, row_plus_n_func, row_plus_n
+    def test_inequality_filtering_with_apply_is_filtered(
+            self, dataframe, row_msg_value_factory
     ):
-        dataframe = dataframe.apply(row_plus_n_func(1))
-        # note, filter should NOT apply to final dataframe result!
-        filter_dataframe = dataframe.apply(row_plus_n_func(2))
-        dataframe = dataframe[filter_dataframe.apply(lambda row: row)]
-        assert dataframe.process(row_with_ints) == row_plus_n(1, row_with_ints)
+        dataframe = dataframe[dataframe['x'].apply(lambda v: v - 10) >= 0]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) is None
 
-    @pytest.mark.skip("SDF-based filtering is not supported yet")
-    def test_row_apply_filtering_parent_child_divergence_raises_invalid(
-        self, dataframe, row_with_ints, row_plus_n_func
-    ):
-        """
-        This is invalid due to the "parent" dataframe adding new functions after
-        previously generating a child that is later used as the parent's filter.
+    def test_compound_inequality_filter(self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[(dataframe['x'] >= 0) & (dataframe['y'] < 10)]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) == row
 
-        This is, admittedly, likely to be very edge-casey.
-        """
-        with pytest.raises(InvalidPipelineBranching):
-            dataframe = dataframe.apply(row_plus_n_func(1))
-            filter_dataframe = dataframe.apply(row_plus_n_func(2))
-            dataframe = dataframe.apply(row_plus_n_func(3))
-            dataframe = dataframe[filter_dataframe.apply(lambda row: row)]
-            dataframe.process(row_with_ints)
+    def test_compound_inequality_filter_is_filtered(
+            self, dataframe, row_msg_value_factory):
+        dataframe = dataframe[(dataframe['x'] >= 0) & (dataframe['y'] < 0)]
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        assert dataframe.process(row) is None
 
-    @pytest.mark.skip("This should fail based on our outline but currently does not")
+    @pytest.mark.skip('This should fail based on our outline but currently does not')
     # TODO: make this fail correctly
-    def test_non_row_apply_breaks_things(self, dataframe, row_with_ints):
+    def test_non_row_apply_breaks_things(self, dataframe, row_msg_value_factory):
         dataframe = dataframe.apply(lambda row: False)
         dataframe = dataframe.apply(lambda row: row)
-        dataframe.process(row_with_ints)
+        row = row_msg_value_factory({'x': 1, 'y': 2})
+        dataframe.process(row)
 
     def test_multiple_row_generation(
-        self,
-        dataframe,
-        more_rows_func,
-        row_msg_value_factory,
-        row_with_list,
-        msg_value_with_list,
+            self, dataframe, more_rows_func, row_msg_value_factory
     ):
         dataframe = dataframe.apply(more_rows_func)
-        expected = [
-            row_msg_value_factory({**msg_value_with_list, "x_list": v})
-            for v in msg_value_with_list["x_list"]
-        ]
-        actual = dataframe.process(row_with_list)
-        assert actual == expected
+        expected = [row_msg_value_factory({'x': 1, 'x_list': i}) for i in range(3)]
+        row = row_msg_value_factory({'x': 1, 'x_list': [0, 1, 2]})
+        assert dataframe.process(row) == expected
 
     def test_multiple_row_generation_with_additional_apply(
-        self,
-        dataframe,
-        more_rows_func,
-        row_msg_value_factory,
-        row_with_list,
-        msg_value_with_list,
+            self, dataframe, more_rows_func, row_msg_value_factory, row_plus_n_func
     ):
-        def add_to_xlist(row):
-            row["x_list"] += 1
-            return row
-
         dataframe = dataframe.apply(more_rows_func)
-        dataframe = dataframe.apply(add_to_xlist)
-        expected = [
-            row_msg_value_factory({**msg_value_with_list, "x_list": v + 1})
-            for v in msg_value_with_list["x_list"]
-        ]
-        actual = dataframe.process(row_with_list)
-        assert actual == expected
+        dataframe = dataframe.apply(row_plus_n_func(n=1))
+        expected = [row_msg_value_factory({'x': 2, 'x_list': i + 1}) for i in range(3)]
+        row = row_msg_value_factory({'x': 1, 'x_list': [0, 1, 2]})
+        assert dataframe.process(row) == expected
 
     def test_multiple_row_generation_with_additional_filtering(
-        self,
-        dataframe,
-        more_rows_func,
-        row_msg_value_factory,
-        row_with_list,
-        msg_value_with_list,
+            self, dataframe, more_rows_func, row_msg_value_factory
     ):
         dataframe = dataframe.apply(more_rows_func)
-        dataframe = dataframe.apply(lambda row: row if row["x_list"] > 0 else None)
-        expected = [
-            row_msg_value_factory({**msg_value_with_list, "x_list": v})
-            for v in msg_value_with_list["x_list"][1:]
-        ]
-        actual = dataframe.process(row_with_list)
-        assert actual == expected
+        dataframe = dataframe.apply(lambda row: row if row['x_list'] > 0 else None)
+        expected = [row_msg_value_factory({'x': 1, 'x_list': i}) for i in range(1, 3)]
+        row = row_msg_value_factory({'x': 1, 'x_list': [0, 1, 2]})
+        assert dataframe.process(row) == expected

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_dataframe.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_dataframe.py
@@ -10,18 +10,6 @@ class TestDataframe:
         assert isinstance(dataframe._pipeline, Pipeline)
         assert dataframe._pipeline.id == dataframe.id
 
-    def test__clone(self, dataframe):
-        cloned_df = dataframe._clone()
-        assert id(cloned_df) != id(dataframe)
-        assert cloned_df._pipeline.id != dataframe._pipeline.id
-
-    def test_apply(self, dataframe):
-        def test_func(row):
-            return row
-
-        dataframe2 = dataframe.apply(test_func)
-        assert id(dataframe) != id(dataframe2)
-
 
 class TestDataframeProcess:
     def test_apply(self, dataframe, row_msg_value_factory, row_plus_n_func):

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_pipeline.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_pipeline.py
@@ -7,12 +7,6 @@ class TestPipeline:
     def test_pipeline(self, pipeline_function, pipeline):
         assert pipeline._functions == [pipeline_function]
 
-    def test_clone(self, pipeline):
-        clone = pipeline.clone()
-        assert clone.functions == pipeline.functions
-        assert id(pipeline) != id(clone)
-        assert pipeline.id != clone.id
-
     def test_apply(self, pipeline):
         def throwaway_func(data):
             return data

--- a/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_pipeline.py
+++ b/src/PythonClient/tests/quixstreams/test_dataframes/test_dataframe/test_pipeline.py
@@ -1,82 +1,39 @@
-import pytest
-
 from src.quixstreams.dataframes.dataframe.pipeline import (
-    InvalidPipelineBranching,
     PipelineFunction,
 )
 
 
-# TODO: change/remove graph/child-based tests based on upcoming SDF merge function
-
-
 class TestPipeline:
     def test_pipeline(self, pipeline_function, pipeline):
-        assert pipeline.name == "test_pipeline"
-        assert pipeline._parent == "test_pipeline_parent"
-        assert pipeline._graph == {"test_pipeline_parent": "test_pipeline"}
         assert pipeline._functions == [pipeline_function]
 
-    def test__clone(self, pipeline):
+    def test_clone(self, pipeline):
         clone = pipeline.clone()
-        assert clone.parent == pipeline.name
         assert clone.functions == pipeline.functions
-        assert id(clone.graph) != pipeline.graph
-
-    def test_add_graph_node_with_parent(self, pipeline):
-        pipeline._parent = "throwaway"
-        pipeline._add_graph_node()
-        assert pipeline.graph["throwaway"] == pipeline.name
-
-    def test__add_graph_node_no_parent(self, pipeline):
-        pipeline._parent = None
-        pipeline._add_graph_node()
-        assert pipeline._graph[pipeline.name] is None
-
-    def test__check_child_contains_parent(self, pipeline):
-        pipeline.apply(lambda data: True)
-        child_pipeline = pipeline.clone()
-        child_pipeline = child_pipeline.apply(lambda data: "banana")
-        child_pipeline._check_child_contains_parent(pipeline)
-
-    def test__check_child_contains_parent_raise_error(self, pipeline):
-        with pytest.raises(InvalidPipelineBranching):
-            child_pipeline = pipeline.clone()
-            pipeline._graph["a_node"] = "node_x"
-            child_pipeline._graph["a_node"] = "node_y"
-            child_pipeline._check_child_contains_parent(pipeline)
-
-    def test_remove_redundant_functions(self, pipeline):
-        child_pipeline = pipeline.clone()
-        pipeline._functions = ["f_0", "f_1"]
-        child_pipeline._functions = ["f_0", "f_1", "f_2", "f_3"]
-        expected = ["f_2", "f_3"]
-        actual = child_pipeline.remove_redundant_functions(pipeline).functions
-        assert actual == expected
+        assert id(pipeline) != id(clone)
+        assert pipeline.id != clone.id
 
     def test_apply(self, pipeline):
         def throwaway_func(data):
             return data
-
         pipeline = pipeline.apply(throwaway_func)
         assert isinstance(pipeline.functions[-1], PipelineFunction)
         assert pipeline.functions[-1]._func == throwaway_func
 
-    def test_process(self, pipeline, msg_value_with_ints):
-        actual = pipeline.process(msg_value_with_ints)
-        expected = {k: v + 1 for k, v in msg_value_with_ints.items()}
+    def test_process(self, pipeline):
+        assert pipeline.process({'a': 1, 'b': 2}) == {'a': 2, 'b': 3}
+
+    def test_process_list(self, pipeline):
+        actual = pipeline.process([{'a': 1, 'b': 2}, {'a': 10, 'b': 11}])
+        expected = [{'a': 2, 'b': 3}, {'a': 11, 'b': 12}]
         assert actual == expected
 
-    def test_process_list(self, pipeline, msg_value_with_ints):
-        actual = pipeline.process([msg_value_with_ints, {"a": 10}])
-        expected = [{k: v + 1 for k, v in msg_value_with_ints.items()}, {"a": 11}]
-        assert actual == expected
-
-    def test_process_break_and_return_none(self, pipeline, msg_value_with_ints):
+    def test_process_break_and_return_none(self, pipeline):
         """
         Add a new function that returns None, then reverse the _functions order
         so that an exception would get thrown if the pipeline doesn't (as expected)
         stop processing when attempting to execute a function with a NoneType input.
         """
-        pipeline = pipeline.apply(lambda data: None)
+        pipeline = pipeline.apply(lambda d: None)
         pipeline._functions.reverse()
-        assert pipeline.process(msg_value_with_ints) is None
+        assert pipeline.process({'a': 1, 'b': 2}) is None


### PR DESCRIPTION
Tons of cleanup:
- made tests related to `dataframe.py`, `pipeline.py`, and `column.py` more explicit/easy to follow 
- removing extra functions where possible
- removed row and dataframe/pipeline cloning since it's not needed for current feature set
  - removed respective tests
- removed functionality around logging function names during `debug`, where applicable
- added missing docstrings