### PR TITLE
Fix some 0.6.0 issues and update librdkafka to 2.2.0

### DIFF
--- a/src/CsharpClient/QuixStreams.IntegrationTestBase/QuixStreams.IntegrationTestBase.csproj
+++ b/src/CsharpClient/QuixStreams.IntegrationTestBase/QuixStreams.IntegrationTestBase.csproj
@@ -7,7 +7,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
+        <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
         <PackageReference Include="Ductus.FluentDocker" Version="2.10.57" />
     </ItemGroup>
 

--- a/src/CsharpClient/QuixStreams.Kafka/KafkaProducer.cs
+++ b/src/CsharpClient/QuixStreams.Kafka/KafkaProducer.cs
@@ -118,7 +118,12 @@ namespace QuixStreams.Kafka
             
             try
             {
-                using (var adminClient = new AdminClientBuilder(this.config).Build())
+                void NullLoggerForAdminLogs(IAdminClient adminClient, LogMessage logMessage)
+                {
+                    // Log nothing
+                }
+                
+                using (var adminClient = new AdminClientBuilder(this.config).SetLogHandler(NullLoggerForAdminLogs).Build())
                 {
                     var maxBrokerMessageBytesNumeric = int.MaxValue;
                     try

--- a/src/CsharpClient/QuixStreams.Kafka/QuixStreams.Kafka.csproj
+++ b/src/CsharpClient/QuixStreams.Kafka/QuixStreams.Kafka.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />


### PR DESCRIPTION
- Consumer should complete Open on partition assign on top of wake-up event, which is not always a guarantee without message to consume or when topic and partition is auto-created.
- Fix unnecessary logs for producer when using admin client
- Kafka producer now includes changes from 5b2472, 53a3b6
- Update librdkafka to 2.2.0