### PR TITLE
Typing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,14 @@
+# MacOS
 .DS_Store
-.idea/
+
+# Quixstreams
 certificates/
+
+# Pycharm
+.idea/
+
+# VS Code
+.vscode/
 
 #direnv
 .direnv/

--- a/src/StreamingDataFrames/examples/.gitignore
+++ b/src/StreamingDataFrames/examples/.gitignore
@@ -1,0 +1,2 @@
+# Quixstreams
+state/

--- a/src/StreamingDataFrames/quixstreams/dataframe/column.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/column.py
@@ -5,7 +5,7 @@ from typing_extensions import Self, TypeAlias, Union
 
 from ..models import Row, MessageContext
 
-ColumnApplier: TypeAlias = Callable[[Any, MessageContext], Any]
+ColumnApplier: TypeAlias = Callable[[Any, MessageContext], object]
 
 __all__ = ("Column", "ColumnApplier")
 
@@ -21,7 +21,7 @@ class Column:
     def __init__(
         self,
         col_name: Optional[str] = None,
-        _eval_func: Optional[ColumnApplier] = None,
+        _eval_func: Optional[Callable[[Row], object]] = None,
     ):
         self.col_name = col_name
         self._eval_func = _eval_func if _eval_func else lambda row: row[self.col_name]
@@ -29,7 +29,7 @@ class Column:
     def __getitem__(self, item: Union[str, int]) -> Self:
         return self.__class__(_eval_func=lambda x: self.eval(x)[item])
 
-    def _operation(self, other: Any, op: Callable[[Any, Any], Any]) -> Self:
+    def _operation(self, other: object, op: Callable[[Any, Any], object]) -> Self:
         return self.__class__(
             _eval_func=lambda x: op(
                 self.eval(x), other.eval(x) if isinstance(other, Column) else other
@@ -60,10 +60,10 @@ class Column:
     def isin(self, other: Container) -> Self:
         return self._operation(other, lambda a, b: operator.contains(b, a))
 
-    def contains(self, other: Any) -> Self:
+    def contains(self, other: object) -> Self:
         return self._operation(other, operator.contains)
 
-    def is_(self, other: Any) -> Self:
+    def is_(self, other: object) -> Self:
         """
         Check if column value refers to the same object as `other`
         :param other: object to check for "is"
@@ -71,7 +71,7 @@ class Column:
         """
         return self._operation(other, operator.is_)
 
-    def isnot(self, other: Any) -> Self:
+    def isnot(self, other: object) -> Self:
         """
         Check if column value refers to the same object as `other`
         :param other: object to check for "is"
@@ -97,43 +97,43 @@ class Column:
         """
         return self.apply(lambda v, ctx: abs(v))
 
-    def __and__(self, other: Any) -> Self:
+    def __and__(self, other: object) -> Self:
         return self._operation(other, operator.and_)
 
-    def __or__(self, other: Any) -> Self:
+    def __or__(self, other: object) -> Self:
         return self._operation(other, operator.or_)
 
-    def __mod__(self, other: Any) -> Self:
+    def __mod__(self, other: object) -> Self:
         return self._operation(other, operator.mod)
 
-    def __add__(self, other: Any) -> Self:
+    def __add__(self, other: object) -> Self:
         return self._operation(other, operator.add)
 
-    def __sub__(self, other: Any) -> Self:
+    def __sub__(self, other: object) -> Self:
         return self._operation(other, operator.sub)
 
-    def __mul__(self, other: Any) -> Self:
+    def __mul__(self, other: object) -> Self:
         return self._operation(other, operator.mul)
 
-    def __truediv__(self, other: Any) -> Self:
+    def __truediv__(self, other: object) -> Self:
         return self._operation(other, operator.truediv)
 
-    def __eq__(self, other: Any) -> Self:
+    def __eq__(self, other: object) -> Self:
         return self._operation(other, operator.eq)
 
-    def __ne__(self, other: Any) -> Self:
+    def __ne__(self, other: object) -> Self:
         return self._operation(other, operator.ne)
 
-    def __lt__(self, other: Any) -> Self:
+    def __lt__(self, other: object) -> Self:
         return self._operation(other, operator.lt)
 
-    def __le__(self, other: Any) -> Self:
+    def __le__(self, other: object) -> Self:
         return self._operation(other, operator.le)
 
-    def __gt__(self, other: Any) -> Self:
+    def __gt__(self, other: object) -> Self:
         return self._operation(other, operator.gt)
 
-    def __ge__(self, other: Any) -> Self:
+    def __ge__(self, other: object) -> Self:
         return self._operation(other, operator.ge)
 
     def __invert__(self) -> Self:

--- a/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/dataframe.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Optional, Callable, Union, List, Mapping, Any, overload, cast
+from typing import Optional, Callable, Union, List, Mapping, overload
 
 from typing_extensions import Self, TypeAlias
 
@@ -13,7 +13,7 @@ from ..state import State, StateStoreManager
 
 ApplyFunc: TypeAlias = Callable[[dict, MessageContext], Optional[dict]]
 StatefulApplyFunc: TypeAlias = Callable[[dict, MessageContext, State], Optional[dict]]
-KeyFunc: TypeAlias = Callable[[dict, MessageContext], Any]
+KeyFunc: TypeAlias = Callable[[dict, MessageContext], object]
 
 __all__ = ("StreamingDataFrame",)
 
@@ -23,7 +23,7 @@ def subset(keys: List[str], row: Row) -> Row:
     return row
 
 
-def setitem(k: str, v: Any, row: Row) -> Row:
+def setitem(k: str, v: object, row: Row) -> Row:
     row[k] = v.eval(row) if isinstance(v, Column) else v
     return row
 
@@ -231,7 +231,7 @@ class StreamingDataFrame:
     def producer(self, producer: RowProducerProto):
         self._real_producer = producer
 
-    def __setitem__(self, key: str, value: Any):
+    def __setitem__(self, key: str, value: object):
         self._apply(lambda row: setitem(key, value, row))
 
     @overload
@@ -250,7 +250,7 @@ class StreamingDataFrame:
         else:
             return Column(col_name=item)
 
-    def _produce(self, topic: Topic, row: Row, key: Optional[Any] = None) -> Row:
+    def _produce(self, topic: Topic, row: Row, key: Optional[object] = None) -> Row:
         self.producer.produce_row(row, topic, key=key)
         return row
 

--- a/src/StreamingDataFrames/quixstreams/dataframe/pipeline.py
+++ b/src/StreamingDataFrames/quixstreams/dataframe/pipeline.py
@@ -26,7 +26,11 @@ class PipelineFunction:
 
 
 class Pipeline:
-    def __init__(self, functions: List[PipelineFunction] = None, _id: str = None):
+    def __init__(
+        self,
+        functions: Optional[List[PipelineFunction]] = None,
+        _id: Optional[str] = None,
+    ):
         self._id = _id or str(uuid.uuid4())
         self._functions = functions or []
 

--- a/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
+++ b/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
@@ -6,7 +6,8 @@ import time
 from typing import Any, Union, Optional
 
 import rocksdict
-from typing_extensions import Self, Generator
+from typing import Iterator
+from typing_extensions import Self
 
 from quixstreams.state.types import (
     DumpsFunc,
@@ -286,7 +287,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
         return self._state
 
     @contextlib.contextmanager
-    def with_prefix(self, prefix: Any = b"") -> Generator[Self, None, None]:
+    def with_prefix(self, prefix: Any = b"") -> Iterator[Self]:
         """
         A context manager set the prefix for all keys in the scope.
 

--- a/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
+++ b/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import struct
 import time
-from typing import Any, Union, Optional
+from typing import Union, Optional
 
 import rocksdict
 from typing import Iterator
@@ -99,7 +99,7 @@ class RocksDBStorePartition(StorePartition):
         """
         self._db.write(batch)
 
-    def get(self, key: bytes, default: Any = None) -> Union[None, bytes, Any]:
+    def get(self, key: bytes, default: object = None) -> Union[None, bytes, object]:
         """
         Get a key from RocksDB.
 
@@ -287,7 +287,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
         return self._state
 
     @contextlib.contextmanager
-    def with_prefix(self, prefix: Any = b"") -> Iterator[Self]:
+    def with_prefix(self, prefix: object = b"") -> Iterator[Self]:
         """
         A context manager set the prefix for all keys in the scope.
 
@@ -318,7 +318,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
             self._prefix = _DEFAULT_PREFIX
 
     @_validate_transaction_state
-    def get(self, key: Any, default: Any = None) -> Optional[Any]:
+    def get(self, key: object, default: object = None) -> Optional[object]:
         """
         Get a key from the store.
 
@@ -347,7 +347,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
         return default
 
     @_validate_transaction_state
-    def set(self, key: Any, value: Any):
+    def set(self, key: object, value: object):
         """
         Set a key to the store.
 
@@ -368,7 +368,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
             raise
 
     @_validate_transaction_state
-    def delete(self, key: Any):
+    def delete(self, key: object):
         """
         Delete a key from the store.
 
@@ -385,7 +385,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
             raise
 
     @_validate_transaction_state
-    def exists(self, key: Any) -> bool:
+    def exists(self, key: object) -> bool:
         """
         Check if a key exists in the store.
 
@@ -454,13 +454,13 @@ class RocksDBPartitionTransaction(PartitionTransaction):
         finally:
             self._completed = True
 
-    def _serialize_value(self, value: Any) -> bytes:
+    def _serialize_value(self, value: object) -> bytes:
         return serialize(value, dumps=self._dumps)
 
-    def _deserialize_value(self, value: bytes) -> Any:
+    def _deserialize_value(self, value: bytes) -> object:
         return deserialize(value, loads=self._loads)
 
-    def _serialize_key(self, key: Any) -> bytes:
+    def _serialize_key(self, key: object) -> bytes:
         return serialize_key(key, prefix=self._prefix, dumps=self._dumps)
 
     def __enter__(self):

--- a/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
+++ b/src/StreamingDataFrames/quixstreams/state/rocksdb/partition.py
@@ -6,7 +6,7 @@ import time
 from typing import Any, Union, Optional
 
 import rocksdict
-from typing_extensions import Self
+from typing_extensions import Self, Generator
 
 from quixstreams.state.types import (
     DumpsFunc,
@@ -286,7 +286,7 @@ class RocksDBPartitionTransaction(PartitionTransaction):
         return self._state
 
     @contextlib.contextmanager
-    def with_prefix(self, prefix: Any = b"") -> Self:
+    def with_prefix(self, prefix: Any = b"") -> Generator[Self, None, None]:
         """
         A context manager set the prefix for all keys in the scope.
 

--- a/src/StreamingDataFrames/quixstreams/state/types.py
+++ b/src/StreamingDataFrames/quixstreams/state/types.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import (
     Protocol,
     Any,
@@ -5,17 +6,11 @@ from typing import (
     Callable,
     Iterator,
     Dict,
-    overload,
-    TypeVar,
-    Union,
 )
-from contextlib import contextmanager
-
-from typing_extensions import Self, Generator
+from typing_extensions import Self
 
 DumpsFunc = Callable[[Any], bytes]
 LoadsFunc = Callable[[bytes], Any]
-T = TypeVar("T")
 
 
 class Store(Protocol):
@@ -111,10 +106,7 @@ class State(Protocol):
     Primary interface for working with key-value state data from `StreamingDataFrame`
     """
 
-    # @overload()
-    # def get(self, key: Any, default: T) -> T
-
-    def get(self, key: Any, default: Optional[T] = None) -> Optional[Union[Any, T]]:
+    def get(self, key: Any, default=None) -> Optional[Any]:
         """
         Get the value for key if key is present in the state, else default
 

--- a/src/StreamingDataFrames/quixstreams/state/types.py
+++ b/src/StreamingDataFrames/quixstreams/state/types.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 from typing import (
     Protocol,
-    Any,
     Optional,
     Callable,
     Iterator,
@@ -9,8 +8,8 @@ from typing import (
 )
 from typing_extensions import Self
 
-DumpsFunc = Callable[[Any], bytes]
-LoadsFunc = Callable[[bytes], Any]
+DumpsFunc = Callable[[object], bytes]
+LoadsFunc = Callable[[bytes], object]
 
 
 class Store(Protocol):
@@ -106,7 +105,7 @@ class State(Protocol):
     Primary interface for working with key-value state data from `StreamingDataFrame`
     """
 
-    def get(self, key: Any, default=None) -> Optional[Any]:
+    def get(self, key: object, default=None) -> Optional[object]:
         """
         Get the value for key if key is present in the state, else default
 
@@ -116,7 +115,7 @@ class State(Protocol):
         """
         ...
 
-    def set(self, key: Any, value: Any):
+    def set(self, key: object, value: object):
         """
         Set value for the key.
         :param key: key
@@ -124,7 +123,7 @@ class State(Protocol):
         """
         ...
 
-    def delete(self, key: Any):
+    def delete(self, key: object):
         """
         Delete value for the key.
 
@@ -133,7 +132,7 @@ class State(Protocol):
         """
         ...
 
-    def exists(self, key: Any) -> bool:
+    def exists(self, key: object) -> bool:
         """
         Check if the key exists in state.
         :param key: key
@@ -177,7 +176,7 @@ class PartitionTransaction(State, Protocol):
         ...
 
     @contextmanager
-    def with_prefix(self, prefix: Any = b"") -> Iterator[Self]:
+    def with_prefix(self, prefix: object = b"") -> Iterator[Self]:
         """
         A context manager set the prefix for all keys in the scope.
 


### PR DESCRIPTION
Fixed several issues around typing.

There are still a few minor ones that are largely just in the library itself around the typing of returns from the "get" operations of the state store. These will surface when the users do operations with `.get` operations to retrieve their state, but I'm not sure there's really a way around that since they can store arbitrary values.

Another "larger" change: converted most of the `Any` types to the more preferred `object` type (as recommended by MyPy and others), which is more robust in terms of type checking, since `Any` basically removes type checking altogether. It was mostly a find-replace and did not add any new typing errors.

Also, this pull request includes an update to gitignore to ignore `.vscode` files