### PR TITLE
Produce state changes to changelog topics

### DIFF
--- a/examples/bank_example/json_version/producer.py
+++ b/examples/bank_example/json_version/producer.py
@@ -11,9 +11,7 @@ from quixstreams import TopicManager
 
 load_dotenv("./env_vars.env")
 
-topic_manager = TopicManager(
-    admin_client=Admin(broker_address=environ["BROKER_ADDRESS"])
-)
+topic_manager = TopicManager(admin=Admin(broker_address=environ["BROKER_ADDRESS"]))
 topic_name = topic_manager.topic(
     name="json__purchase_events",
     # "config" only needed if you wish to not use the defaults!

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -30,7 +30,7 @@ from .platforms.quix import (
 )
 from .rowconsumer import RowConsumer
 from .rowproducer import RowProducer
-from .state import StateStoreManager
+from .state import StateStoreManager, ChangelogManager
 from .state.rocksdb import RocksDBOptionsType
 from .topic_manager import TopicManager, TopicManagerType
 
@@ -196,7 +196,11 @@ class Application:
             group_id=consumer_group,
             state_dir=state_dir,
             rocksdb_options=rocksdb_options,
-            topic_manager=self._topic_manager if use_changelog_topics else None,
+            changelog_manager=ChangelogManager(
+                topic_admin=self._topic_manager, producer=self._producer
+            )
+            if use_changelog_topics
+            else None,
         )
 
     def _set_quix_config_builder(self, config_builder: QuixKafkaConfigsBuilder):

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import signal
+from functools import partial
 from typing import Optional, List, Callable, Literal, Mapping
 
 from confluent_kafka import TopicPartition
@@ -30,9 +31,11 @@ from .platforms.quix import (
 )
 from .rowconsumer import RowConsumer
 from .rowproducer import RowProducer
-from .state import StateStoreManager, ChangelogManager
+from .state import StateStoreManager
+from .state.changelog import ChangelogManager, RecoveryManager
 from .state.rocksdb import RocksDBOptionsType
 from .topic_manager import TopicManager, TopicManagerType
+
 
 __all__ = ("Application",)
 
@@ -85,7 +88,7 @@ class Application:
         consumer_group: str,
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
-        assignment_strategy: AssignmentStrategy = "range",
+        assignment_strategy: AssignmentStrategy = "cooperative-sticky",
         partitioner: Partitioner = "murmur2",
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
@@ -182,6 +185,8 @@ class Application:
         self._quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None
         self._auto_create_topics = auto_create_topics
         self._topic_validation = topic_validation
+        self._processing = lambda: None
+        self._run_mode = None
 
         if not topic_manager:
             topic_manager = TopicManager()
@@ -203,6 +208,7 @@ class Application:
                     extra_config=producer_extra_config,
                     on_error=on_producer_error,
                 ),
+                consumer=self._consumer,
             )
             if use_changelog_topics
             else None
@@ -223,7 +229,7 @@ class Application:
         consumer_group: str,
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
-        assignment_strategy: AssignmentStrategy = "range",
+        assignment_strategy: AssignmentStrategy = "cooperative-sticky",
         partitioner: Partitioner = "murmur2",
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
@@ -539,6 +545,70 @@ class Application:
                 validation_level=self._topic_validation
             )
 
+    def _process_messages(self, dataframe_composed, start_state_transaction):
+        # Serve producer callbacks
+        self._producer.poll(self._producer_poll_timeout)
+        rows = self._consumer.poll_row(timeout=self._consumer_poll_timeout)
+
+        if rows is None:
+            return
+
+        # Deserializer may return multiple rows for a single message
+        rows = rows if isinstance(rows, list) else [rows]
+        if not rows:
+            return
+
+        first_row = rows[0]
+        topic_name, partition, offset = (
+            first_row.topic,
+            first_row.partition,
+            first_row.offset,
+        )
+        # Create a new contextvars.Context and set the current MessageContext
+        # (it's the same across multiple rows)
+        context = copy_context()
+        context.run(set_message_context, first_row.context)
+
+        with start_state_transaction(
+            topic=topic_name, partition=partition, offset=offset
+        ):
+            for row in rows:
+                try:
+                    # Execute StreamingDataFrame in a context
+                    context.run(dataframe_composed, row.value)
+                except Filtered:
+                    # The message was filtered by StreamingDataFrame
+                    continue
+                except Exception as exc:
+                    # TODO: This callback might be triggered because of Producer
+                    #  errors too because they happen within ".process()"
+                    to_suppress = self._on_processing_error(exc, row, logger)
+                    if not to_suppress:
+                        raise
+
+        # Store the message offset after it's successfully processed
+        self._consumer.store_offsets(
+            offsets=[
+                TopicPartition(
+                    topic=topic_name,
+                    partition=partition,
+                    offset=offset + 1,
+                )
+            ]
+        )
+
+        if self._on_message_processed is not None:
+            self._on_message_processed(topic_name, partition, offset)
+
+    def _recovery(self):
+        try:
+            self._state_manager.do_recovery()
+        except RecoveryManager.RecoveryComplete:
+            self._run_mode = self._processing
+
+    def _do_run_mode(self):
+        return self._run_mode()
+
     def run(
         self,
         dataframe: StreamingDataFrame,
@@ -607,60 +677,13 @@ class Application:
             self._running = True
 
             dataframe_composed = dataframe.compose()
+            self._processing = partial(
+                self._process_messages, dataframe_composed, start_state_transaction
+            )
+            self._run_mode = self._processing
+
             while self._running:
-                # Serve producer callbacks
-                self._producer.poll(self._producer_poll_timeout)
-                rows = self._consumer.poll_row(timeout=self._consumer_poll_timeout)
-
-                if rows is None:
-                    continue
-
-                # Deserializer may return multiple rows for a single message
-                rows = rows if isinstance(rows, list) else [rows]
-                if not rows:
-                    continue
-
-                first_row = rows[0]
-                topic_name, partition, offset = (
-                    first_row.topic,
-                    first_row.partition,
-                    first_row.offset,
-                )
-                # Create a new contextvars.Context and set the current MessageContext
-                # (it's the same across multiple rows)
-                context = copy_context()
-                context.run(set_message_context, first_row.context)
-
-                with start_state_transaction(
-                    topic=topic_name, partition=partition, offset=offset
-                ):
-                    for row in rows:
-                        try:
-                            # Execute StreamingDataFrame in a context
-                            context.run(dataframe_composed, row.value)
-                        except Filtered:
-                            # The message was filtered by StreamingDataFrame
-                            continue
-                        except Exception as exc:
-                            # TODO: This callback might be triggered because of Producer
-                            #  errors too because they happen within ".process()"
-                            to_suppress = self._on_processing_error(exc, row, logger)
-                            if not to_suppress:
-                                raise
-
-                # Store the message offset after it's successfully processed
-                self._consumer.store_offsets(
-                    offsets=[
-                        TopicPartition(
-                            topic=topic_name,
-                            partition=partition,
-                            offset=offset + 1,
-                        )
-                    ]
-                )
-
-                if self._on_message_processed is not None:
-                    self._on_message_processed(topic_name, partition, offset)
+                self._do_run_mode()
 
             logger.info("Stop processing of StreamingDataFrame")
 
@@ -671,6 +694,8 @@ class Application:
         :param topic_partitions: list of `TopicPartition` from Kafka
         """
         if self._state_manager.stores:
+            if self._state_manager.using_changelogs:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: assigning state store partitions")
             for tp in topic_partitions:
                 # Assign store partitions
@@ -703,6 +728,8 @@ class Application:
         Revoke partitions from consumer and state
         """
         if self._state_manager.stores:
+            if self._state_manager.using_changelogs:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: revoking state store partitions")
             for tp in topic_partitions:
                 self._state_manager.on_partition_revoke(tp)
@@ -712,6 +739,8 @@ class Application:
         Dropping lost partitions from consumer and state
         """
         if self._state_manager.stores:
+            if self._state_manager.using_changelogs:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: dropping lost state store partitions")
             for tp in topic_partitions:
                 self._state_manager.on_partition_lost(tp)

--- a/quixstreams/kafka/consumer.py
+++ b/quixstreams/kafka/consumer.py
@@ -502,6 +502,12 @@ class Consumer:
         """
         return self._consumer.set_sasl_credentials(username, password)
 
+    def incremental_assign(self, partitions: List[TopicPartition]):
+        return self._consumer.incremental_assign(partitions)
+
+    def incremental_unassign(self, partitions: List[TopicPartition]):
+        return self._consumer.incremental_unassign(partitions)
+
     def close(self):
         """
         Close down and terminate the Kafka Consumer.

--- a/quixstreams/kafka/producer.py
+++ b/quixstreams/kafka/producer.py
@@ -1,12 +1,14 @@
 import logging
-from typing import List, Dict, Tuple, Union, Optional
-from typing_extensions import Literal
+from typing import Union, Optional
 
 from confluent_kafka import (
     Producer as ConfluentProducer,
     KafkaError,
     Message,
 )
+from typing_extensions import Literal
+
+from quixstreams.types import Headers
 
 __all__ = (
     "Producer",
@@ -15,11 +17,6 @@ __all__ = (
 
 Partitioner = Literal[
     "random", "consistent_random", "murmur2", "murmur2_random", "fnv1a", "fnv1a_random"
-]
-HeaderValue = Optional[Union[str, bytes]]
-Headers = Union[
-    List[Tuple[str, HeaderValue]],
-    Dict[str, HeaderValue],
 ]
 
 logger = logging.getLogger(__name__)

--- a/quixstreams/models/serializers/simple_types.py
+++ b/quixstreams/models/serializers/simple_types.py
@@ -35,7 +35,7 @@ def _wrap_serialization_error(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (_SerializationError, AttributeError, TypeError) as exc:
+        except (_SerializationError, AttributeError) as exc:
             raise SerializationError(str(exc)) from exc
 
     return wrapper
@@ -46,13 +46,8 @@ class BytesDeserializer(Deserializer):
     A deserializer to bypass bytes without any changes
     """
 
-    @_wrap_serialization_error
-    def __call__(
-        self, value: bytes, ctx: SerializationContext
-    ) -> Union[bytes, Mapping[str, bytes]]:
-        if isinstance(value, bytes):
-            return self._to_dict(value)
-        raise TypeError(f"serializer expected type 'bytes', received '{type(value)}'")
+    def __call__(self, value: bytes, ctx: SerializationContext):
+        return self._to_dict(value)
 
 
 class BytesSerializer(Serializer):
@@ -60,11 +55,8 @@ class BytesSerializer(Serializer):
     A serializer to bypass bytes without any changes
     """
 
-    @_wrap_serialization_error
     def __call__(self, value: bytes, ctx: SerializationContext) -> bytes:
-        if isinstance(value, bytes):
-            return value
-        raise TypeError(f"serializer expected type 'bytes', received '{type(value)}'")
+        return value
 
 
 class StringDeserializer(Deserializer):

--- a/quixstreams/models/topics.py
+++ b/quixstreams/models/topics.py
@@ -271,8 +271,18 @@ class Topic:
         )
 
     def deserialize(self, message: ConfluentKafkaMessageProto):
-        # TODO: Implement SerDes for raw messages
-        raise NotImplementedError
+        # TODO: confirm this is a valid context
+        ctx = SerializationContext(topic="", headers=message.headers())
+        return KafkaMessage(
+            key=self._key_deserializer(key, ctx=ctx)
+            if (key := message.key())
+            else None,
+            value=self._value_serializer(value, ctx=ctx)
+            if (value := message.value())
+            else None,
+            headers=message.headers(),
+            timestamp=message.timestamp(),
+        )
 
     def __repr__(self):
         return f'<{self.__class__} name="{self._name}"> '

--- a/quixstreams/models/topics.py
+++ b/quixstreams/models/topics.py
@@ -99,6 +99,13 @@ class Topic:
     instance.
     """
 
+    _serialize_map = {
+        "key": "_key_serializer",
+        "value": "_value_serializer",
+    }
+
+    _deserialize_map = {"key": "_key_deserializer", "value": "_value_deserializer"}
+
     def __init__(
         self,
         name: str,
@@ -251,8 +258,14 @@ class Topic:
         headers: Optional[Union[Mapping, MessageHeadersTuples]] = None,
         timestamp_ms: int = None,
     ) -> KafkaMessage:
-        # TODO: Implement SerDes for raw messages (also to produce primitive values)
-        raise NotImplementedError
+        # TODO: confirm this is a valid context
+        ctx = SerializationContext(topic="", headers=headers)
+        return KafkaMessage(
+            key=self._key_serializer(key, ctx=ctx) if key else None,
+            value=self._value_serializer(value, ctx=ctx) if value else None,
+            headers=headers,
+            timestamp=timestamp_ms,
+        )
 
     def deserialize(self, message: ConfluentKafkaMessageProto):
         # TODO: Implement SerDes for raw messages

--- a/quixstreams/state/__init__.py
+++ b/quixstreams/state/__init__.py
@@ -1,2 +1,3 @@
 from .manager import *
 from .types import *
+from .changelog import ChangelogManager

--- a/quixstreams/state/changelog.py
+++ b/quixstreams/state/changelog.py
@@ -1,8 +1,104 @@
-from typing import Optional
+from typing import Optional, Dict, List
 
+from confluent_kafka import TopicPartition as ConfluentPartition
+
+from quixstreams.models import ConfluentKafkaMessageProto
+from quixstreams.kafka import Consumer
 from quixstreams.rowproducer import RowProducer
+from quixstreams.state.types import StorePartition
 from quixstreams.topic_manager import TopicManagerType, BytesTopic
 from quixstreams.types import Headers
+from quixstreams.utils.dicts import dict_values
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RecoveryPartition:
+    """
+    A changelog partition mapped to a respective StorePartition with helper methods
+    to determine its current recovery status.
+
+    Since `StorePartition`s do recovery directly, it also handles recovery transactions.
+    """
+
+    def __init__(
+        self,
+        topic: str,
+        changelog: str,
+        partition: int,
+        store_partition: StorePartition,
+    ):
+        self.topic = topic
+        self.changelog = changelog
+        self.partition = partition
+        self.store_partition = store_partition
+        self._changelog_lowwater: Optional[int] = None
+        self._changelog_highwater: Optional[int] = None
+
+    class OffsetUpdate(ConfluentKafkaMessageProto):
+        def __init__(self, offset):
+            self._offset = offset
+
+        def offset(self):
+            return self._offset
+
+    @property
+    def offset(self) -> int:
+        return self.store_partition.get_changelog_offset() or 0
+
+    @property
+    def topic_partition(self) -> ConfluentPartition:
+        return ConfluentPartition(self.topic, self.partition)
+
+    @property
+    def changelog_partition(self) -> ConfluentPartition:
+        return ConfluentPartition(self.changelog, self.partition)
+
+    @property
+    def changelog_assignable_partition(self):
+        return ConfluentPartition(self.changelog, self.partition, self.offset)
+
+    @property
+    def needs_recovery(self):
+        has_consumable_offsets = self._changelog_lowwater != self._changelog_highwater
+        state_is_behind = (self._changelog_highwater - self.offset) > 0
+        return has_consumable_offsets and state_is_behind
+
+    @property
+    def needs_offset_update(self):
+        return self._changelog_highwater and (self.offset != self._changelog_highwater)
+
+    def _warn_bad_offset(self):
+        logger.warning(
+            f"The recorded changelog offset in state for "
+            f"{self.changelog}: p{self.partition} was larger than the actual offset "
+            f"available on that topic-partition, likely as a result of some "
+            f"sort of error (mostly likely Kafka or network related). "
+            f"It is possible that the state of any affected message keys may end "
+            f"up inaccurate due to potential double processing. This is an "
+            f"unfortunate possibility with 'at least once' processing guarantees. "
+            f"The offset will now be corrected."
+        )
+
+    def update_offset(self):
+        logger.info(
+            f"topic:partition {self.changelog}:{self.partition} "
+            f"requires an offset update"
+        )
+        if self.offset > self._changelog_highwater:
+            self._warn_bad_offset()
+        self.store_partition.set_changelog_offset(
+            changelog_message=self.OffsetUpdate(self.offset)
+        )
+
+    def recover(self, changelog_message: ConfluentKafkaMessageProto):
+        self.store_partition.recover(changelog_message=changelog_message)
+
+    def set_watermarks(self, lowwater: int, highwater: int):
+        self._changelog_lowwater = lowwater
+        self._changelog_highwater = highwater
 
 
 class ChangelogWriter:
@@ -34,19 +130,50 @@ class ChangelogWriter:
 
 class ChangelogManager:
     """
-    A simple interface for adding changelog topics during store init and
-    generating changelog writers (generally for each new `Store` transaction).
+    A simple interface for managing all things related to changelog topics and is
+    primarily used by the StateStoreManager.
+
+    Facilitates creation of changelog topics and assigning their partitions during
+    rebalances, and handles recovery process loop calls from `Application`.
     """
 
-    def __init__(self, topic_manager: TopicManagerType, producer: RowProducer):
+    def __init__(
+        self,
+        topic_manager: TopicManagerType,
+        consumer: Consumer,
+        producer: RowProducer,
+    ):
         self._topic_manager = topic_manager
         self._producer = producer
+        self._recovery_manager = RecoveryManager(consumer)
 
     def add_changelog(self, source_topic_name: str, suffix: str, consumer_group: str):
         self._topic_manager.changelog_topic(
             source_topic_name=source_topic_name,
             suffix=suffix,
             consumer_group=consumer_group,
+        )
+
+    def assign_partition(
+        self,
+        source_topic_name: str,
+        partition: int,
+        store_partitions: Dict[str, StorePartition],
+    ):
+        self._recovery_manager.assign_partitions(
+            source_topic_name=source_topic_name,
+            partition=partition,
+            store_partitions={
+                self._topic_manager.changelog_topics[source_topic_name][
+                    suffix
+                ].name: store_partition
+                for suffix, store_partition in store_partitions.items()
+            },
+        )
+
+    def revoke_partition(self, source_topic_name, partition):
+        self._recovery_manager.revoke_partitions(
+            topic=source_topic_name, partition=partition
         )
 
     def get_writer(
@@ -57,3 +184,170 @@ class ChangelogManager:
             partition_num=partition_num,
             producer=self._producer,
         )
+
+    def do_recovery(self):
+        self._recovery_manager.do_recovery()
+
+
+class RecoveryManager:
+    """
+    Manages all aspects of recovery, including managing all topic partition assignments
+    (both source topic and changelogs), generating `RecoveryPartition`s when recovery
+    is required for a given changelog partition, and stopping/revoking said partitions
+    when it determines recovery is complete.
+
+    Important to note that a RecoveryPartition is only generated (and assigned to the
+    consumer) when recovery is necessary, else the partition in question is ignored.
+
+    It will revoke these partitions throughout recovery, which will NOT kick off
+    a rebalance of the consumer since this is done outside the consumer group protocol.
+
+    Recovery is always triggered from any source topic rebalance, which then the
+    `Application` switches its processing loop over to the `RecoveryManager`. The
+    `RecoveryManager` throws the `RecoveryComplete` exception when finished,
+     which is gracefully caught by the `Application`, resuming normal processing.
+    """
+
+    def __init__(self, consumer: Consumer):
+        self._consumer = consumer
+        self._pending_assigns: List[RecoveryPartition] = []
+        self._pending_revokes: List[RecoveryPartition] = []
+        self._partitions: Dict[int, Dict[str, RecoveryPartition]] = {}
+        self._recovery_method = self._recover
+        self._poll_attempts: int = 2
+        self._polls_remaining: int = self._poll_attempts
+
+    class RecoveryComplete(Exception):
+        ...
+
+    @property
+    def in_recovery_mode(self) -> bool:
+        return bool(self._partitions)
+
+    def do_recovery(self):
+        self._recovery_method()
+
+    def assign_partitions(
+        self,
+        source_topic_name: str,
+        partition: int,
+        store_partitions: Dict[str, StorePartition],
+    ):
+        p = None
+        for changelog, store_partition in store_partitions.items():
+            logger.debug(f"Assigning changelog:partition {changelog}:{partition}")
+            p = RecoveryPartition(
+                topic=source_topic_name,
+                changelog=changelog,
+                partition=partition,
+                store_partition=store_partition,
+            )
+            self._pending_assigns.append(p)
+        # Assign manually to immediately pause it (would assign unpaused automatically)
+        # TODO: consider doing all topic (not changelog) assign(s) during the
+        #  Application on_assign call (rather than one at a time here)
+        topic_p = [p.topic_partition]
+        self._consumer.incremental_assign(topic_p)
+        self._consumer.pause(topic_p)
+        self._recovery_method = self._rebalance
+
+    def _partition_cleanup(self, partition: int):
+        if not self._partitions[partition]:
+            del self._partitions[partition]
+
+    def revoke_partitions(self, topic: str, partition: int):
+        # TODO: consider doing all topic (not changelog) unassign(s) during the
+        #  Application on_revoke call (rather than one at a time here)
+        self._consumer.incremental_unassign([ConfluentPartition(topic, partition)])
+        if changelogs := self._partitions.get(partition, {}):
+            for changelog in list(changelogs.keys()):
+                self._pending_revokes.append(changelogs.pop(changelog))
+            self._consumer.pause([p.changelog_partition for p in self._pending_revokes])
+            self._partition_cleanup(partition)
+            self._recovery_method = self._rebalance
+
+    def _handle_pending_assigns(self):
+        assigns = []
+        # TODO: confirm pause needs to be here; if so, refine it to not pause the same
+        #  partition a bunch
+        self._consumer.pause([p.topic_partition for p in self._pending_assigns])
+        while self._pending_assigns:
+            p = self._pending_assigns.pop()
+            p.set_watermarks(
+                *self._consumer.get_watermark_offsets(p.changelog_partition, timeout=10)
+            )
+            if p.needs_recovery:
+                logger.info(
+                    f"topic:partition {p.changelog}:{p.partition} requires recovery"
+                )
+                assigns.append(p)
+                self._partitions.setdefault(p.partition, {})[p.changelog] = p
+            elif p.needs_offset_update:
+                # >0 changelog offset, but none are actually consumable
+                # this is unlikely to happen with At Least Once, but just in case...
+                p.update_offset()
+        if assigns:
+            self._consumer.incremental_assign(
+                [p.changelog_assignable_partition for p in assigns]
+            )
+
+    def _handle_pending_revokes(self):
+        self._consumer.incremental_unassign(
+            [p.changelog_partition for p in self._pending_revokes]
+        )
+        self._pending_revokes = []
+
+    def _rebalance(self):
+        """ """
+        logger.debug("performing a recovery rebalance...")
+        if self._pending_revokes:
+            self._handle_pending_revokes()
+        if self._pending_assigns:
+            self._handle_pending_assigns()
+        self._recovery_method = self._recover
+        self._polls_remaining = self._poll_attempts
+
+    def _update_partition_offsets(self):
+        """
+        update the offsets for assigned partitions, and then revoke them.
+
+        This is a safety measure for when, while recovering, the highwater and
+        changelog consumable offsets don't align: in this case, from failed
+        transactions with Exactly Once processing (stored offset < changelog highwater).
+        """
+        for p in (p_out := dict_values(self._partitions)):
+            if p.needs_offset_update:
+                p.update_offset()
+        self._pending_revokes.extend(p_out)
+        self._partitions = {}
+        self._handle_pending_revokes()
+
+    def _finalize_recovery(self):
+        logger.info("Finalizing recovery and resuming normal processing...")
+        if self._partitions:
+            self._update_partition_offsets()
+        self._consumer.resume(self._consumer.assignment())
+        self._polls_remaining = self._poll_attempts
+        raise self.RecoveryComplete
+
+    def _recover(self):
+        if not self.in_recovery_mode:
+            return self._finalize_recovery()
+
+        if (msg := self._consumer.poll(5)) is None:
+            self._polls_remaining -= 1
+            if not self._polls_remaining:
+                return self._finalize_recovery()
+            return
+
+        changelog = msg.topic()
+        p_num = msg.partition()
+
+        partition = self._partitions[p_num][changelog]
+        partition.recover(changelog_message=msg)
+
+        if not partition.needs_recovery:
+            logger.debug(f"recovery for {msg.topic()}: {msg.partition()} finished!")
+            self._pending_revokes.append(self._partitions[p_num].pop(changelog))
+            self._partition_cleanup(p_num)
+            self._handle_pending_revokes()

--- a/quixstreams/state/changelog.py
+++ b/quixstreams/state/changelog.py
@@ -17,10 +17,7 @@ class ChangelogWriter:
         self._partition_num = partition_num
         self._producer = producer
 
-    def produce(
-        self, key: bytes, cf_name: str = "default", value: Optional[bytes] = None
-    ):
-        # TODO-CF: remove default cf_name to ensure its passed?
+    def produce(self, key: bytes, cf_name: str, value: Optional[bytes] = None):
         msg = self._topic.serialize(key=key, value=value)
         self._producer.produce(
             key=msg.key,
@@ -37,6 +34,8 @@ class ChangelogManager:
     generating changelog writers (generally for each new `Store` transaction).
     """
 
+    _writer = ChangelogWriter
+
     def __init__(self, topic_manager: TopicManagerType, producer: RowProducer):
         self._topic_manager = topic_manager
         self._producer = producer
@@ -50,8 +49,8 @@ class ChangelogManager:
 
     def get_writer(
         self, source_topic_name: str, suffix: str, partition_num: int
-    ) -> ChangelogWriter:
-        return ChangelogWriter(
+    ) -> _writer:
+        return self._writer(
             topic=self._topic_manager.changelog_topics[source_topic_name][suffix],
             partition_num=partition_num,
             producer=self._producer,

--- a/quixstreams/state/changelog.py
+++ b/quixstreams/state/changelog.py
@@ -1,6 +1,5 @@
-from quixstreams.topic_manager import TopicManagerType
+from quixstreams.topic_manager import TopicManagerType, BytesTopic
 from quixstreams.rowproducer import RowProducer
-from quixstreams.models import Topic
 
 from typing import Optional
 
@@ -13,7 +12,7 @@ class ChangelogWriter:
     a changelog topic.
     """
 
-    def __init__(self, topic: Topic, partition_num: int, producer: RowProducer):
+    def __init__(self, topic: BytesTopic, partition_num: int, producer: RowProducer):
         self._topic = topic
         self._partition_num = partition_num
         self._producer = producer

--- a/quixstreams/state/changelog.py
+++ b/quixstreams/state/changelog.py
@@ -1,0 +1,44 @@
+from quixstreams.kafka import TopicAdmin
+from quixstreams.rowproducer import RowProducer
+from quixstreams.context import message_context
+from quixstreams.models import Topic
+
+from typing import Dict, Optional
+
+
+class ChangelogManager:
+    # TODO: simplify this?
+    def __init__(self, topic_admin: TopicAdmin, producer: RowProducer):
+        self._topic_admin = topic_admin
+        self._producer = producer
+        self._changelog_writers: Dict[str, ChangelogWriter] = {}
+
+    def add_changelog_topic(self, source_topic_name, suffix):
+        print(f"TOPIC ADMIN: {self._topic_admin.quix_config_builder}")
+        topic = self._topic_admin.changelog_topic(source_topic_name, suffix)
+        writer = ChangelogWriter(topic=topic, producer=self._producer)
+        self._changelog_writers[topic.name] = writer
+        return writer
+
+
+class ChangelogWriter:
+    def __init__(self, topic: Topic, producer: RowProducer):
+        self._topic = topic
+        self._producer = producer
+
+    @property
+    def key(self):
+        return message_context().key
+
+    @property
+    def partition(self):
+        return message_context().partition
+
+    @property
+    def topic(self):
+        return self._topic
+
+    def produce(self, key: bytes, value: Optional[bytes] = None):
+        # TODO: stuff with column families in the headers
+        msg = self.topic.serialize(key=key, value=value)
+        self._producer.produce(key=msg.key, value=msg.value, topic=self.topic.name)

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -70,10 +70,6 @@ class StateStoreManager:
         """
         return self._stores
 
-    @property
-    def changelog_manager(self):
-        return self._changelog_manager
-
     def get_store(
         self, topic: str, store_name: str = _DEFAULT_STATE_STORE_NAME
     ) -> Store:

--- a/quixstreams/state/rocksdb/metadata.py
+++ b/quixstreams/state/rocksdb/metadata.py
@@ -4,4 +4,5 @@ CHANGELOG_OFFSET_KEY = b"__changelog_offset__"
 LATEST_TIMESTAMP_KEY = b"__topic_latest_timestamp__"
 
 METADATA_CF_NAME = "__metadata__"
+CHANGELOG_CF_MESSAGE_HEADER = "__column_family__"
 EXPIRED_WINDOWS_CF_NAME = "__expired_windows__"

--- a/quixstreams/state/rocksdb/metadata.py
+++ b/quixstreams/state/rocksdb/metadata.py
@@ -1,5 +1,6 @@
 PREFIX_SEPARATOR = b"|"
 PROCESSED_OFFSET_KEY = b"__topic_offset__"
+CHANGELOG_OFFSET_KEY = b"__changelog_offset__"
 LATEST_TIMESTAMP_KEY = b"__topic_latest_timestamp__"
 
 METADATA_CF_NAME = "__metadata__"

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -155,11 +155,14 @@ class RocksDBStorePartition(StorePartition):
 
     def get_changelog_offset(self) -> Optional[int]:
         """
-        Get last produced offset for the given partition
+        Get last produced offset for the given changelog partition
         :return: offset or `None` if there's no produced offset yet
         """
-        changelog_bytes = self._db.get(_CHANGELOG_OFFSET_KEY, b"0")
-        return _int_from_int64_bytes(changelog_bytes) if changelog_bytes else 0
+        # TODO: this is an incomplete placeholder until recovery is implemented.
+        #   End functionality should be similar to "get_processed_offset"; recovery
+        #   ensures the offset is valid and sets it to a proper value if not
+        offset_bytes = self._db.get(_CHANGELOG_OFFSET_KEY)
+        return _int_from_int64_bytes(offset_bytes) if offset_bytes is not None else 0
 
     def close(self):
         """

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -17,13 +17,15 @@ __all__ = ("RocksDBStore",)
 
 
 class RocksDBStore(Store):
+    options_type = RocksDBOptionsType
+
     def __init__(
         self,
         name: str,
         topic: str,
         base_dir: str,
         changelog_manager: Optional[ChangelogManager] = None,
-        options: Optional[RocksDBOptionsType] = None,
+        options: Optional[options_type] = None,
         open_max_retries: int = 10,
         open_retry_backoff: float = 3.0,
     ):

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -9,6 +9,7 @@ from .partition import (
     RocksDBPartitionTransaction,
 )
 from .types import RocksDBOptionsType
+from ..changelog import ChangelogWriter
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,7 @@ class RocksDBStore(Store):
         name: str,
         topic: str,
         base_dir: str,
+        changelog_writer: Optional[ChangelogWriter] = None,
         options: Optional[RocksDBOptionsType] = None,
         open_max_retries: int = 10,
         open_retry_backoff: float = 3.0,
@@ -42,8 +44,8 @@ class RocksDBStore(Store):
         self._name = name
         self._topic = topic
         self._partitions_dir = Path(base_dir).absolute() / self._name / self._topic
-        self._transactions: Dict[int, RocksDBPartitionTransaction] = {}
         self._partitions: Dict[int, RocksDBStorePartition] = {}
+        self._changelog_writer = changelog_writer
         self._options = options
         self._open_max_retries = open_max_retries
         self._open_retry_backoff = open_retry_backoff
@@ -148,7 +150,7 @@ class RocksDBStore(Store):
             )
 
         store_partition = self._partitions[partition]
-        return store_partition.begin()
+        return store_partition.begin(self._changelog_writer)
 
     def close(self):
         """

--- a/quixstreams/state/rocksdb/store.py
+++ b/quixstreams/state/rocksdb/store.py
@@ -156,6 +156,8 @@ class RocksDBStore(Store):
                 suffix=self._name,
                 partition_num=partition,
             )
+            if self._changelog_manager
+            else None
         )
 
     def close(self):

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -2,6 +2,8 @@ from typing import Protocol, Any, Optional, Iterator, Callable, Dict, ClassVar
 
 from typing_extensions import Self
 
+from quixstreams.models import ConfluentKafkaMessageProto
+
 DumpsFunc = Callable[[Any], bytes]
 LoadsFunc = Callable[[bytes], Any]
 
@@ -90,7 +92,16 @@ class StorePartition(Protocol):
         State new `PartitionTransaction`
         """
 
+    def recover(self, changelog_message: ConfluentKafkaMessageProto):
+        ...
+
     def get_processed_offset(self) -> Optional[int]:
+        ...
+
+    def get_changelog_offset(self) -> Optional[int]:
+        ...
+
+    def set_changelog_offset(self, changelog_message: ConfluentKafkaMessageProto):
         ...
 
 
@@ -178,6 +189,46 @@ class PartitionTransaction(State):
         Flush the recent updates and last processed offset to the storage.
         :param offset: offset of the last processed message, optional.
         """
+
+    def __enter__(self):
+        ...
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        ...
+
+
+class PartitionRecoveryTransaction(Protocol):
+    """
+    A class for managing recovery for a StorePartition from a changelog message
+    """
+
+    @property
+    def failed(self) -> bool:
+        """
+        Return `True` if transaction failed to update data at some point.
+
+        Failed transactions cannot be re-used.
+        :return: bool
+        """
+
+    @property
+    def completed(self) -> bool:
+        """
+        Return `True` if transaction is completed.
+
+        Completed transactions cannot be re-used.
+        :return: bool
+        """
+        ...
+
+    def recover(self):
+        ...
+
+    def flush(self):
+        """
+        Flush the recent updates and last processed offset to the storage.
+        """
+        ...
 
     def __enter__(self):
         ...

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Any, Optional, Iterator, Callable, Dict
+from typing import Protocol, Any, Optional, Iterator, Callable, Dict, ClassVar
 
 from typing_extensions import Self
 
@@ -13,6 +13,8 @@ class Store(Protocol):
     It keeps track of individual store partitions and provides access to the
     partitions' transactions.
     """
+
+    options_type: ClassVar[object]
 
     @property
     def topic(self) -> str:
@@ -168,7 +170,7 @@ class PartitionTransaction(State):
         Normally, it's called by `StreamingDataFrame` internals to ensure that every
         message key is stored separately.
         :param prefix: key prefix
-        :return: context maager
+        :return: context manager
         """
 
     def maybe_flush(self, offset: Optional[int] = None):

--- a/quixstreams/topic_manager.py
+++ b/quixstreams/topic_manager.py
@@ -14,6 +14,18 @@ logger = logging.getLogger(__name__)
 __all__ = ("TopicManager",)
 
 
+class BytesTopic(Topic):
+    def __init__(self, name: str, config: Optional[TopicConfig] = None):
+        super().__init__(
+            name=name,
+            key_serializer="bytes",
+            value_serializer="bytes",
+            key_deserializer="bytes",
+            value_deserializer="bytes",
+            config=config,
+        )
+
+
 def dict_values(d: object) -> List:
     """
     Recursively unpacks a set of nested dicts to get a flattened list of leaves,
@@ -58,7 +70,7 @@ class TopicManagerType(Protocol):
 
     _admin: Optional[Admin]
     _topics: TopicMap
-    _changelog_topics: Dict[str, TopicMap]
+    _changelog_topics: Dict[str, Dict[str, BytesTopic]]
     _create_timeout: int
 
     class MissingAdmin(Exception):
@@ -79,11 +91,11 @@ class TopicManagerType(Protocol):
         return dict_values(self._topics)
 
     @property
-    def changelog_topics(self) -> Dict[str, TopicMap]:
+    def changelog_topics(self) -> Dict[str, Dict[str, BytesTopic]]:
         return self._changelog_topics
 
     @property
-    def changelog_topics_list(self) -> TopicList:
+    def changelog_topics_list(self) -> List[BytesTopic]:
         return dict_values(self._changelog_topics)
 
     @property
@@ -186,7 +198,7 @@ class TopicManagerType(Protocol):
         suffix: str,
         consumer_group: str,
         configs_to_import: Set[str] = None,
-    ) -> Topic:
+    ) -> BytesTopic:
         """
         Performs all the logic necessary to generate a changelog topic based on a
         "source topic" (aka input/consumed topic).
@@ -416,7 +428,7 @@ class TopicManagerBase(TopicManagerType, Protocol):
         suffix: str,
         consumer_group: str,
         configs_to_import: Set[str] = None,
-    ) -> Topic:
+    ) -> BytesTopic:
         """
         Performs all the logic necessary to generate a changelog topic based on a
         "source topic" (aka input/consumed topic).
@@ -469,12 +481,8 @@ class TopicManagerBase(TopicManagerType, Protocol):
                 f"set 'auto_create_topics=True')"
             )
         topic_config.update_extra_config(allowed=configs_to_import)
-        topic = Topic(
+        topic = BytesTopic(
             name=name,
-            key_serializer="bytes",
-            value_serializer="bytes",
-            key_deserializer="bytes",
-            value_deserializer="bytes",
             config=self._process_topic_configs(
                 topic_config,
                 extra_config_defaults=self._changelog_extra_config_defaults,

--- a/quixstreams/topic_manager.py
+++ b/quixstreams/topic_manager.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from typing import Dict, List, Mapping, Optional, Set, Literal, Protocol, ClassVar
 
 from quixstreams.platforms.quix import QuixKafkaConfigsBuilder
+from quixstreams.utils.dicts import dict_values
 from .kafka.admin import Admin
 from .models.serializers import DeserializerType, SerializerType
 from .models.topics import Topic, TopicConfig, TopicList, TopicMap
@@ -24,26 +25,6 @@ class BytesTopic(Topic):
             value_deserializer="bytes",
             config=config,
         )
-
-
-def dict_values(d: object) -> List:
-    """
-    Recursively unpacks a set of nested dicts to get a flattened list of leaves,
-    where "leaves" are the first non-dict item.
-
-    i.e {"a": {"b": {"c": 1}, "d": 2}, "e": 3} becomes [1, 2, 3]
-
-    :param d: initially, a dict (with potentially nested dicts)
-
-    :return: a list with all the leaves of the various contained dicts
-    """
-    if d:
-        if isinstance(d, dict):
-            return [i for v in d.values() for i in dict_values(v)]
-        elif isinstance(d, list):
-            return d
-        return [d]
-    return []
 
 
 def affirm_ready_for_create(topics: TopicList):
@@ -92,6 +73,11 @@ class TopicManagerType(Protocol):
 
     @property
     def changelog_topics(self) -> Dict[str, Dict[str, BytesTopic]]:
+        """
+        Changelogs stored as {source_topic_name: {suffix: Topic}}
+
+        returns:
+        """
         return self._changelog_topics
 
     @property

--- a/quixstreams/types.py
+++ b/quixstreams/types.py
@@ -1,7 +1,14 @@
-from typing import Protocol
+from typing import Protocol, Optional, List, Tuple, Dict, Union
 
 
 class TopicPartition(Protocol):
     topic: str
     partition: int
     offset: int
+
+
+HeaderValue = Optional[Union[str, bytes]]
+Headers = Union[
+    List[Tuple[str, HeaderValue]],
+    Dict[str, HeaderValue],
+]

--- a/quixstreams/utils/dicts.py
+++ b/quixstreams/utils/dicts.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+def dict_values(d: object) -> List:
+    """
+    Recursively unpacks a set of nested dicts to get a flattened list of leaves,
+    where "leaves" are the first non-dict item.
+
+    i.e {"a": {"b": {"c": 1}, "d": 2}, "e": 3} becomes [1, 2, 3]
+
+    :param d: initially, a dict (with potentially nested dicts)
+
+    :return: a list with all the leaves of the various contained dicts
+    """
+    if d:
+        if isinstance(d, dict):
+            return [i for v in d.values() for i in dict_values(v)]
+        elif isinstance(d, list):
+            return d
+        return [d]
+    return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ pytest_plugins = [
     "tests.test_quixstreams.fixtures",
     "tests.test_quixstreams.test_models.fixtures",
     "tests.test_quixstreams.test_platforms.test_quix.fixtures",
+    "tests.test_quixstreams.test_state.fixtures",
     "tests.test_quixstreams.test_state.test_rocksdb.fixtures",
 ]
 

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -44,7 +44,7 @@ from quixstreams.platforms.quix.config import (
 from quixstreams.rowconsumer import RowConsumer
 from quixstreams.rowproducer import RowProducer
 from quixstreams.state import StateStoreManager, ChangelogManager
-from quixstreams.topic_manager import TopicManager, TopicManagerType
+from quixstreams.topic_manager import TopicManager
 
 
 @pytest.fixture()
@@ -127,7 +127,7 @@ def topic_factory(kafka_admin_client):
     """
 
     def factory(
-        topic: str = None, num_partitions: int = 1, timeout: float = 10.0
+        topic: str = None, num_partitions: int = 1, timeout: float = 20.0
     ) -> (str, int):
         topic_name = topic or str(uuid.uuid4())
         futures = kafka_admin_client.create_topics(

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -794,4 +794,4 @@ class TestApplicationWithState:
         use_changelog_topics is set to `False`.
         """
         app = app_factory(use_changelog_topics=False)
-        assert app._state_manager._topic_manager is None
+        assert app._state_manager._changelog_manager is None

--- a/tests/test_quixstreams/test_models/fixtures.py
+++ b/tests/test_quixstreams/test_models/fixtures.py
@@ -5,7 +5,7 @@ from typing import Mapping, Union, List, Any
 
 import pytest
 
-from .utils import ConfluentKafkaMessageStub
+from ..utils import ConfluentKafkaMessageStub
 
 
 @pytest.fixture()

--- a/tests/test_quixstreams/test_models/test_serializers.py
+++ b/tests/test_quixstreams/test_models/test_serializers.py
@@ -48,7 +48,6 @@ class TestSerializers:
             (DoubleSerializer(), object()),
             (StringSerializer(), 123),
             (StringSerializer(), {"a": 123}),
-            (BytesSerializer(), "abc"),
             (JSONSerializer(), object()),
             (JSONSerializer(), complex(1, 2)),
         ],
@@ -110,7 +109,6 @@ class TestDeserializers:
             (IntegerDeserializer(), b"abc"),
             (IntegerDeserializer(), b'{"abc": "abc"}'),
             (DoubleDeserializer(), b"abc"),
-            (BytesDeserializer(), "abc"),
             (JSONDeserializer(), b"{"),
         ],
     )

--- a/tests/test_quixstreams/test_models/test_serializers.py
+++ b/tests/test_quixstreams/test_models/test_serializers.py
@@ -48,6 +48,7 @@ class TestSerializers:
             (DoubleSerializer(), object()),
             (StringSerializer(), 123),
             (StringSerializer(), {"a": 123}),
+            (BytesSerializer(), "abc"),
             (JSONSerializer(), object()),
             (JSONSerializer(), complex(1, 2)),
         ],
@@ -109,6 +110,7 @@ class TestDeserializers:
             (IntegerDeserializer(), b"abc"),
             (IntegerDeserializer(), b'{"abc": "abc"}'),
             (DoubleDeserializer(), b"abc"),
+            (BytesDeserializer(), "abc"),
             (JSONDeserializer(), b"{"),
         ],
     )

--- a/tests/test_quixstreams/test_models/test_topics.py
+++ b/tests/test_quixstreams/test_models/test_topics.py
@@ -311,8 +311,7 @@ class TestTopic:
         assert message.timestamp == 1234567890
 
     @pytest.mark.skip(
-        "Should this pass or fail? Currently fails because string serializer allows"
-        "NoneTypes (and returns a NoneType) when it probably shouldn't?"
+        "string serializer currently allows NoneTypes, probably shouldn't?"
     )
     def test_serialize_key_missing(self, topic_json_serdes_factory):
         topic = Topic(name="my_topic", key_serializer="string", value_serializer="json")

--- a/tests/test_quixstreams/test_models/test_topics.py
+++ b/tests/test_quixstreams/test_models/test_topics.py
@@ -323,6 +323,7 @@ class TestTopic:
                 timestamp_ms=1234567890,
             )
 
+    @pytest.mark.skip("skip until we do more type checking with serializers")
     def test_serialize_serialization_error(self, topic_json_serdes_factory):
         topic = Topic(name="my_topic", key_serializer="bytes", value_serializer="json")
         with pytest.raises(SerializationError):
@@ -386,7 +387,7 @@ class TestTopic:
 
     def test__get_serializer_strings_invalid(self):
         with pytest.raises(ValueError):
-            Topic("topic", key_serializer="fail_me_bro")
+            Topic("topic", key_serializer="fail_me_bro")  # type: ignore
 
     @pytest.mark.parametrize(
         "deserializer_str, expected_type", [(k, v) for k, v in DESERIALIZERS.items()]
@@ -399,4 +400,4 @@ class TestTopic:
 
     def test__get_deserializer_strings_invalid(self):
         with pytest.raises(ValueError):
-            Topic("topic", key_deserializer="fail_me_bro")
+            Topic("topic", key_deserializer="fail_me_bro")  # type: ignore

--- a/tests/test_quixstreams/test_models/test_topics.py
+++ b/tests/test_quixstreams/test_models/test_topics.py
@@ -22,7 +22,8 @@ from quixstreams.models.serializers import (
     SERIALIZERS,
     DESERIALIZERS,
 )
-from .utils import ConfluentKafkaMessageStub, int_to_bytes, float_to_bytes
+from .utils import int_to_bytes, float_to_bytes
+from ..utils import ConfluentKafkaMessageStub
 
 
 class JSONListDeserializer(JSONDeserializer):

--- a/tests/test_quixstreams/test_models/utils.py
+++ b/tests/test_quixstreams/test_models/utils.py
@@ -1,5 +1,4 @@
 import struct
-from typing import Optional, List, Tuple, Union
 
 
 def float_to_bytes(value: float) -> bytes:
@@ -8,65 +7,3 @@ def float_to_bytes(value: float) -> bytes:
 
 def int_to_bytes(value: int) -> bytes:
     return struct.pack(">i", value)
-
-
-class ConfluentKafkaMessageStub:
-    """
-    A stub object to mock `confluent_kafka.Message`.
-
-    Instances of `confluent_kafka.Message` cannot be directly created from Python,
-    see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
-
-    """
-
-    def __init__(
-        self,
-        topic: str = "test",
-        partition: int = 0,
-        offset: int = 0,
-        timestamp: Tuple[int, int] = (1, 123),
-        key: bytes = None,
-        value: bytes = None,
-        headers: Optional[List[Tuple[str, bytes]]] = None,
-        latency: float = None,
-        leader_epoch: int = None,
-    ):
-        self._topic = topic
-        self._partition = partition
-        self._offset = offset
-        self._timestamp = timestamp
-        self._key = key
-        self._value = value
-        self._headers = headers
-        self._latency = latency
-        self._leader_epoch = leader_epoch
-
-    def headers(self, *args, **kwargs) -> Optional[List[Tuple[str, bytes]]]:
-        return self._headers
-
-    def key(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
-        return self._key
-
-    def offset(self, *args, **kwargs) -> int:
-        return self._offset
-
-    def partition(self, *args, **kwargs) -> int:
-        return self._partition
-
-    def timestamp(self, *args, **kwargs) -> (int, int):
-        return self._timestamp
-
-    def topic(self, *args, **kwargs) -> str:
-        return self._topic
-
-    def value(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
-        return self._value
-
-    def latency(self, *args, **kwargs) -> Optional[float]:
-        return self._latency
-
-    def leader_epoch(self, *args, **kwargs) -> Optional[int]:
-        return self._leader_epoch
-
-    def __len__(self) -> int:
-        return len(self._value)

--- a/tests/test_quixstreams/test_state/fixtures.py
+++ b/tests/test_quixstreams/test_state/fixtures.py
@@ -2,10 +2,11 @@ import pytest
 import uuid
 
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import patch, create_autospec
 
-from quixstreams.kafka.admin import Admin
-from quixstreams.state.changelog import ChangelogWriter
+from quixstreams.kafka import Admin, Consumer
+from quixstreams.state.changelog import RecoveryPartition, RecoveryManager
+from quixstreams.state.types import StorePartition
 
 
 @pytest.fixture()
@@ -49,3 +50,23 @@ def changelog_writer_patched(changelog_writer_factory):
 @pytest.fixture()
 def changelog_writer_with_changelog(changelog_writer_factory, admin):
     return changelog_writer_factory(admin=admin)
+
+
+@pytest.fixture()
+def recovery_partition_store_mock(rocksdb_store_factory):
+    topic = str(uuid.uuid4())
+    store = create_autospec(StorePartition)()
+    store.get_changelog_offset.return_value = 15
+    recovery_partition = RecoveryPartition(
+        topic=topic, changelog=f"changelog__{topic}", partition=0, store_partition=store
+    )
+    recovery_partition._changelog_lowwater = 10
+    recovery_partition._changelog_highwater = 20
+    return recovery_partition
+
+
+@pytest.fixture()
+def recovery_manager_mock_consumer():
+    return RecoveryManager(
+        consumer=create_autospec(Consumer)("broker", "group", "latest")
+    )

--- a/tests/test_quixstreams/test_state/fixtures.py
+++ b/tests/test_quixstreams/test_state/fixtures.py
@@ -1,0 +1,51 @@
+import pytest
+import uuid
+
+from typing import Optional
+from unittest.mock import patch
+
+from quixstreams.kafka.admin import Admin
+from quixstreams.state.changelog import ChangelogWriter
+
+
+@pytest.fixture()
+def changelog_writer_factory(changelog_manager_factory):
+    """
+    Makes a changelog manager.
+
+    If admin is passed, will also create changelog for you
+    """
+
+    def factory(
+        source_topic_name: str = str(uuid.uuid4()),
+        suffix: str = "suffix",
+        partition_num: int = 0,
+        admin: Optional[Admin] = None,
+    ):
+        changelog_manager = changelog_manager_factory(admin=admin)
+        topic_manager = changelog_manager._topic_manager
+
+        kwargs = dict(source_topic_name=source_topic_name, suffix=suffix)
+        topic_manager.topic(
+            source_topic_name
+        )  # changelogs depend on topic objects existing
+        changelog_topic = topic_manager.changelog_topic(
+            **kwargs, consumer_group="group"
+        )
+        if admin:
+            topic_manager.create_topics([changelog_topic])
+        return changelog_manager.get_writer(**kwargs, partition_num=partition_num)
+
+    return factory
+
+
+@pytest.fixture()
+def changelog_writer_patched(changelog_writer_factory):
+    writer = changelog_writer_factory()
+    with patch.object(writer, "produce"):
+        yield writer
+
+
+@pytest.fixture()
+def changelog_writer_with_changelog(changelog_writer_factory, admin):
+    return changelog_writer_factory(admin=admin)

--- a/tests/test_quixstreams/test_state/test_changelog.py
+++ b/tests/test_quixstreams/test_state/test_changelog.py
@@ -4,7 +4,6 @@ import uuid
 from quixstreams.state.changelog import (
     ChangelogManager,
     ChangelogWriter,
-    _COLUMN_FAMILY_HEADER,
 )
 from quixstreams.topic_manager import BytesTopic
 
@@ -14,11 +13,12 @@ class TestChangelogWriter:
         self, topic_manager_admin_factory, row_producer_factory, consumer_factory
     ):
         p_num = 2
+        cf_header = "my_cf_header"
         cf = "my_cf"
         expected = {
             "key": b"my_key",
             "value": b"10",
-            "headers": [(_COLUMN_FAMILY_HEADER, cf.encode())],
+            "headers": [(cf_header, cf.encode())],
             "partition": p_num,
         }
         topic_manager = topic_manager_admin_factory()
@@ -31,7 +31,8 @@ class TestChangelogWriter:
             topic=topic, partition_num=p_num, producer=row_producer_factory()
         )
         writer.produce(
-            **{k: v for k, v in expected.items() if k in ["key", "value"]}, cf_name=cf
+            **{k: v for k, v in expected.items() if k in ["key", "value"]},
+            headers={cf_header: cf},
         )
         writer._producer.flush(5)
 

--- a/tests/test_quixstreams/test_state/test_changelog.py
+++ b/tests/test_quixstreams/test_state/test_changelog.py
@@ -1,11 +1,72 @@
-from unittest.mock import patch
+from unittest.mock import patch, create_autospec, call
 
+import pytest
 import uuid
+
 from quixstreams.state.changelog import (
-    ChangelogManager,
     ChangelogWriter,
+    RecoveryPartition,
+    ConfluentPartition,
 )
+from quixstreams.state.types import StorePartition
 from quixstreams.topic_manager import BytesTopic
+from ..utils import ConfluentKafkaMessageStub
+
+
+class TestRecoveryPartition:
+    def test_set_watermarks(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.set_watermarks(50, 100)
+        assert recovery_partition._changelog_lowwater == 50
+        assert recovery_partition._changelog_highwater == 100
+
+    def test_needs_recovery(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        assert recovery_partition.needs_recovery
+
+    def test_needs_recovery_caught_up(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.store_partition.get_changelog_offset.return_value = 20
+        assert not recovery_partition_store_mock.needs_recovery
+
+    def test_needs_recovery_no_valid_offsets(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.set_watermarks(100, 100)
+        assert not recovery_partition.needs_recovery
+        assert recovery_partition.needs_offset_update
+
+    def test_recover(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        msg = ConfluentKafkaMessageStub()
+        recovery_partition.recover(msg)
+        recovery_partition.store_partition.recover.assert_called_with(
+            changelog_message=msg
+        )
+
+    def test_update_offset(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        with patch.object(
+            recovery_partition, "OffsetUpdate", spec=recovery_partition.OffsetUpdate
+        ) as offset_update:
+            recovery_partition.update_offset()
+        offset_update.assert_called_with(recovery_partition.offset)
+        assert isinstance(
+            recovery_partition.store_partition.set_changelog_offset.call_args_list[
+                0
+            ].kwargs["changelog_message"],
+            recovery_partition.OffsetUpdate,
+        )
+
+    def test_update_offset_warn(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.store_partition.get_changelog_offset.return_value = (
+            recovery_partition._changelog_highwater + 1
+        )
+        with patch.object(
+            recovery_partition, "_warn_bad_offset", spec=recovery_partition.OffsetUpdate
+        ) as warn:
+            recovery_partition.update_offset()
+        warn.assert_called()
 
 
 class TestChangelogWriter:
@@ -45,11 +106,9 @@ class TestChangelogWriter:
 
 
 class TestChangelogManager:
-    def test_add_changelog(self, topic_manager_factory, row_producer_factory):
-        topic_manager = topic_manager_factory()
-        changelog_manager = ChangelogManager(
-            topic_manager=topic_manager, producer=row_producer_factory()
-        )
+    def test_add_changelog(self, changelog_manager_factory):
+        changelog_manager = changelog_manager_factory()
+        topic_manager = changelog_manager._topic_manager
         kwargs = dict(
             source_topic_name="my_source_topic",
             suffix="my_suffix",
@@ -59,12 +118,10 @@ class TestChangelogManager:
             changelog_manager.add_changelog(**kwargs)
         make_changelog.assert_called_with(**kwargs)
 
-    def test_get_writer(self, topic_manager_factory, row_producer_factory):
-        topic_manager = topic_manager_factory()
+    def test_get_writer(self, row_producer_factory, changelog_manager_factory):
         producer = row_producer_factory()
-        changelog_manager = ChangelogManager(
-            topic_manager=topic_manager, producer=producer
-        )
+        changelog_manager = changelog_manager_factory(producer=producer)
+        topic_manager = changelog_manager._topic_manager
 
         topic_name = "my_topic"
         suffix = "my_suffix"
@@ -79,3 +136,547 @@ class TestChangelogManager:
         assert writer._topic == changelog_topic
         assert writer._partition_num == p_num
         assert writer._producer == producer
+
+    def test_assign_partition(self, changelog_manager_mock_recovery):
+        source_topic = "topic_a"
+        suffixes = ["default", "rolling_10s"]
+        partition = 1
+        changelog_manager = changelog_manager_mock_recovery
+        topic_manager = changelog_manager._topic_manager
+        recovery_manager = changelog_manager._recovery_manager
+
+        topic_manager.topic(source_topic)
+        calls = []
+        suffix_partitions = {}
+        changelog_partitions = {}
+        for suffix in suffixes:
+            changelog = topic_manager.changelog_topic(
+                source_topic_name=source_topic, suffix=suffix, consumer_group="group"
+            )
+            suffix_partitions[suffix] = create_autospec(StorePartition)()
+            changelog_partitions[changelog.name] = suffix_partitions[suffix]
+
+        changelog_manager.assign_partition(
+            source_topic_name=source_topic,
+            partition=partition,
+            store_partitions=suffix_partitions,
+        )
+
+        recovery_manager.assign_partitions.assert_called_with(
+            source_topic_name=source_topic,
+            partition=partition,
+            store_partitions=changelog_partitions,
+        )
+
+    def test_revoke_partition(self, changelog_manager_mock_recovery):
+        source_topic = "topic_a"
+        suffixes = ["default", "rolling-10s"]
+        partition = 1
+        changelog_manager = changelog_manager_mock_recovery
+        topic_manager = changelog_manager._topic_manager
+        recovery_manager = changelog_manager._recovery_manager
+
+        topic_manager.topic(source_topic)
+        for s in suffixes:
+            topic_manager.changelog_topic(
+                source_topic_name=source_topic, suffix=s, consumer_group="group"
+            )
+
+        changelog_manager.revoke_partition(
+            source_topic_name=source_topic,
+            partition=partition,
+        )
+        calls = [
+            call(
+                topic=source_topic,
+                partition=partition,
+            )
+        ]
+        recovery_manager.revoke_partitions.assert_has_calls(calls)
+
+    def test_do_recovery(self, changelog_manager_mock_recovery):
+        changelog_manager = changelog_manager_mock_recovery
+        recovery_manager = changelog_manager._recovery_manager
+
+        changelog_manager.do_recovery()
+        recovery_manager.do_recovery.assert_called()
+
+
+class TestRecoveryManager:
+    def test_assign_partitions(self, recovery_manager_mock_consumer):
+        """
+        Assign a topic partition and queue up its respective changelog partitions for
+        assignment.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}"
+        partition_num = 1
+        store_partition = create_autospec(StorePartition)()
+        recovery_manager.assign_partitions(
+            source_topic_name=source_topic,
+            partition=partition_num,
+            store_partitions={changelog: store_partition},
+        )
+
+        assert recovery_manager._recovery_method == recovery_manager._rebalance
+        assert len(recovery_manager._pending_assigns) == 1
+        recovery_partition = recovery_manager._pending_assigns[0]
+        expected_confluent_partition = recovery_partition.topic_partition
+        assert isinstance(recovery_partition, RecoveryPartition)
+        assert recovery_partition.topic == source_topic
+        assert recovery_partition.changelog == changelog
+        assert recovery_partition.partition == partition_num
+        assert recovery_partition.store_partition == store_partition
+
+        assign_call = consumer.incremental_assign.call_args_list[0].args
+        assert len(assign_call) == 1
+        assert isinstance(assign_call[0], list)
+        assert len(assign_call[0]) == 1
+        assert isinstance(assign_call[0][0], ConfluentPartition)
+        assert expected_confluent_partition.topic == assign_call[0][0].topic
+        assert expected_confluent_partition.partition == assign_call[0][0].partition
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert expected_confluent_partition.topic == pause_call[0][0].topic
+        assert expected_confluent_partition.partition == pause_call[0][0].partition
+
+    def test_revoke_partitions(self, recovery_manager_mock_consumer):
+        """
+        Revoke a topic partition and queue up its respective changelog partitions (that
+        are currently recovering) for revoking.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}"
+        partition_num = 1
+        store_partition = create_autospec(StorePartition)()
+        recovery_manager._partitions = {
+            partition_num: {
+                changelog: RecoveryPartition(
+                    topic=source_topic,
+                    changelog=changelog,
+                    partition=partition_num,
+                    store_partition=store_partition,
+                ),
+            }
+        }
+
+        recovery_manager.revoke_partitions(
+            topic=source_topic,
+            partition=partition_num,
+        )
+
+        assert partition_num not in recovery_manager._partitions
+        assert recovery_manager._recovery_method == recovery_manager._rebalance
+        assert len(recovery_manager._pending_revokes) == 1
+        recovery_partition = recovery_manager._pending_revokes[0]
+        assert isinstance(recovery_partition, RecoveryPartition)
+        assert recovery_partition.topic == source_topic
+        assert recovery_partition.changelog == changelog
+        assert recovery_partition.partition == partition_num
+        assert recovery_partition.store_partition == store_partition
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert source_topic == unassign_call[0][0].topic
+        assert partition_num == unassign_call[0][0].partition
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert changelog == pause_call[0][0].topic
+        assert partition_num == pause_call[0][0].partition
+
+    def test_revoke_partition_not_assigned(self, recovery_manager_mock_consumer):
+        """
+        Revoke topic partition while skipping the changelog partition revoke since
+        it was never assigned to begin with (due to not needing recovery).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        partition_num = 1
+
+        recovery_manager.revoke_partitions(
+            topic=source_topic,
+            partition=partition_num,
+        )
+
+        assert recovery_manager._recovery_method == recovery_manager._recover
+        assert len(recovery_manager._pending_revokes) == 0
+        consumer.pause.assert_not_called()
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert source_topic == unassign_call[0][0].topic
+        assert partition_num == unassign_call[0][0].partition
+
+    def test__handle_pending_assigns(self, recovery_manager_mock_consumer):
+        """
+        Two changelog partitions (partition numbers 3 and 7) are pending assignment; p3
+        has no offsets to recover, and p7 does, so only p7 should end up assigned.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_nums = [3, 7]
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition,
+                store_partition=create_autospec(StorePartition)(),
+            )
+            for partition in partition_nums
+        ]
+        side_effects = []
+        for idx, p in enumerate(recovery_manager._pending_assigns):
+            p.store_partition.get_changelog_offset.return_value = 10 * idx
+            side_effects.append((0, 20 * idx))
+        side_effects.reverse()
+        consumer.get_watermark_offsets.side_effect = side_effects
+        not_recover = recovery_manager._pending_assigns[0]
+        should_recover = recovery_manager._pending_assigns[1]
+
+        recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 2
+        for idx, call in enumerate(pause_call[0]):
+            assert isinstance(call, ConfluentPartition)
+            assert source_topic == call.topic
+            assert call.partition == partition_nums[idx]
+
+        assign_call = consumer.incremental_assign.call_args_list[0].args
+        assert len(assign_call) == 1
+        assert isinstance(assign_call[0], list)
+        assert len(assign_call[0]) == 1
+        assert isinstance(assign_call[0][0], ConfluentPartition)
+        assert should_recover.changelog == assign_call[0][0].topic
+        assert should_recover.partition == assign_call[0][0].partition
+        assert should_recover.offset == assign_call[0][0].offset
+
+        assert (
+            recovery_manager._partitions[should_recover.partition][
+                should_recover.changelog
+            ]
+            == should_recover
+        )
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_assigns_no_assigns(self, recovery_manager_mock_consumer):
+        """
+        Handle pending assigns of changelog partitions where none of them actually
+        needed assigning since they were up-to-date.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition_num,
+                store_partition=create_autospec(StorePartition)(),
+            )
+        ]
+        consumer.get_watermark_offsets.side_effect = [(0, 10)]
+        not_recover = recovery_manager._pending_assigns[0]
+        not_recover.store_partition.get_changelog_offset.return_value = 10
+
+        recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert source_topic == pause_call[0][0].topic
+        assert pause_call[0][0].partition == partition_num
+
+        consumer.incremental_assign.assert_not_called()
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_assigns_update_offset(
+        self, recovery_manager_mock_consumer
+    ):
+        """
+        Handle pending assigns of changelog partitions where the partition does not
+        actually need recovery, but instead a simple offset update (due to some
+        processing error, or there being no offset to read).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition_num,
+                store_partition=create_autospec(StorePartition)(),
+            )
+        ]
+        consumer.get_watermark_offsets.side_effect = [(0, 10)]
+        not_recover = recovery_manager._pending_assigns[0]
+        not_recover.store_partition.get_changelog_offset.return_value = 20
+
+        with patch.object(
+            recovery_manager._pending_assigns[0], "update_offset"
+        ) as update_offset:
+            recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert source_topic == pause_call[0][0].topic
+        assert pause_call[0][0].partition == partition_num
+
+        consumer.incremental_assign.assert_not_called()
+        update_offset.assert_called()
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_revokes(self, recovery_manager_mock_consumer):
+        """
+        Handle pending revokes of changelog partitions.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        revoke = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._pending_revokes = [revoke]
+
+        recovery_manager._handle_pending_revokes()
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert revoke.changelog == unassign_call[0][0].topic
+        assert revoke.partition == unassign_call[0][0].partition
+
+        assert not recovery_manager._pending_revokes
+
+    def test__update_partition_offsets(self, recovery_manager_mock_consumer):
+        """
+        Partition offset updates are handled correctly.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_nums = [3, 7]
+        expected_pending_revokes = []
+        for partition in partition_nums:
+            rp = RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition,
+                store_partition=create_autospec(StorePartition)(),
+            )
+            rp.set_watermarks(0, 20)
+            rp.store_partition.get_changelog_offset.return_value = 18
+            recovery_manager._partitions.setdefault(partition, {})[changelog] = rp
+            expected_pending_revokes += [rp]
+
+        with patch.object(recovery_manager, "_handle_pending_revokes") as handle_revoke:
+            recovery_manager._update_partition_offsets()
+
+        for partition in expected_pending_revokes:
+            partition.store_partition.set_changelog_offset.assert_called()
+        # Confirm the revokes were added to pending successfully, though normally
+        # they'd get handled/removed right after if the method wasn't patched
+        assert recovery_manager._pending_revokes == expected_pending_revokes
+        handle_revoke.assert_called()
+
+    def test__finalize_recovery(self, recovery_manager_mock_consumer):
+        """
+        Finalize recovery, which raises an exception to break out of an Application
+        consume loop.
+
+        In this case, also tests when we have a remaining _partition with some offset
+        issues, updating it to current and revoking it before finishing recovery.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        assignment_result = "assignments"
+        consumer.assignment.return_value = assignment_result
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.set_watermarks(0, 20)
+        rp.store_partition.get_changelog_offset.return_value = 18
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with pytest.raises(recovery_manager.RecoveryComplete):
+            recovery_manager._finalize_recovery()
+
+        consumer.resume.assert_called_with(assignment_result)
+        consumer.incremental_unassign.assert_called()
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts
+        assert not recovery_manager._partitions
+
+    def test__rebalance(self, recovery_manager_mock_consumer):
+        """
+        Handle a rebalance call (as a result of an applicable assign or revoke call).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        recovery_manager._recovery_method = recovery_manager._rebalance
+        consumer = recovery_manager._consumer
+        consumer.get_watermark_offsets.return_value = (0, 20)
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.store_partition.get_changelog_offset.return_value = 10
+        # just testing that pending assign or revoke is called as expected
+        recovery_manager._pending_assigns = [rp]
+        recovery_manager._pending_revokes = [rp]
+
+        recovery_manager._rebalance()
+
+        consumer.incremental_unassign.assert_called()
+        consumer.incremental_assign.assert_called()
+        assert recovery_manager._recovery_method == recovery_manager._recover
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts
+
+    def test__recover(self, recovery_manager_mock_consumer):
+        """
+        Successfully recover from a changelog message, which is also the last one
+        for the partition, so revoke it afterward.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        highwater = 20
+        partition_num = 1
+        msg = ConfluentKafkaMessageStub(
+            topic=changelog, partition=partition_num, offset=highwater - 1
+        )
+        consumer.poll.return_value = msg
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.set_watermarks(0, highwater)
+        rp.store_partition.get_changelog_offset.return_value = highwater
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        recovery_manager._recover()
+
+        rp.store_partition.recover.assert_called_with(changelog_message=msg)
+        assert not recovery_manager._partitions
+        consumer.incremental_unassign.assert_called()
+
+    def test__recover_no_partitions(self, recovery_manager_mock_consumer):
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            finalize.side_effect = recovery_manager.RecoveryComplete()
+            with pytest.raises(recovery_manager.RecoveryComplete):
+                recovery_manager._recover()
+
+        finalize.assert_called()
+        consumer.poll.assert_not_called()
+
+    def test__recover_empty_poll(self, recovery_manager_mock_consumer):
+        """
+        Handle an empty poll.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        consumer.poll.return_value = None
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            recovery_manager._recover()
+
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts - 1
+        finalize.assert_not_called()
+        consumer.poll.assert_called()
+        rp.store_partition.recover.assert_not_called()
+
+    def test__recover_last_empty_poll(self, recovery_manager_mock_consumer):
+        """
+        Handle a final empty poll attempt, which ends recovery.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        recovery_manager._polls_remaining = 1
+        consumer = recovery_manager._consumer
+        consumer.poll.return_value = None
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            finalize.side_effect = recovery_manager.RecoveryComplete()
+            with pytest.raises(recovery_manager.RecoveryComplete):
+                recovery_manager._recover()
+
+        assert recovery_manager._polls_remaining == 0
+        finalize.assert_called()
+        consumer.poll.assert_called()

--- a/tests/test_quixstreams/test_state/test_changelog.py
+++ b/tests/test_quixstreams/test_state/test_changelog.py
@@ -1,0 +1,80 @@
+from unittest.mock import patch
+
+import uuid
+from quixstreams.state.changelog import (
+    ChangelogManager,
+    ChangelogWriter,
+    _COLUMN_FAMILY_HEADER,
+)
+from quixstreams.topic_manager import BytesTopic
+
+
+class TestChangelogWriter:
+    def test_produce(
+        self, topic_manager_admin_factory, row_producer_factory, consumer_factory
+    ):
+        p_num = 2
+        cf = "my_cf"
+        expected = {
+            "key": b"my_key",
+            "value": b"10",
+            "headers": [(_COLUMN_FAMILY_HEADER, cf.encode())],
+            "partition": p_num,
+        }
+        topic_manager = topic_manager_admin_factory()
+        topic = BytesTopic(
+            name=str(uuid.uuid4()), config=topic_manager.topic_config(num_partitions=3)
+        )
+        topic_manager.create_topics([topic])
+
+        writer = ChangelogWriter(
+            topic=topic, partition_num=p_num, producer=row_producer_factory()
+        )
+        writer.produce(
+            **{k: v for k, v in expected.items() if k in ["key", "value"]}, cf_name=cf
+        )
+        writer._producer.flush(5)
+
+        consumer = consumer_factory(auto_offset_reset="earliest")
+        consumer.subscribe([topic.name])
+        message = consumer.poll(10)
+
+        for k in expected:
+            assert getattr(message, k)() == expected[k]
+
+
+class TestChangelogManager:
+    def test_add_changelog(self, topic_manager_factory, row_producer_factory):
+        topic_manager = topic_manager_factory()
+        changelog_manager = ChangelogManager(
+            topic_manager=topic_manager, producer=row_producer_factory()
+        )
+        kwargs = dict(
+            source_topic_name="my_source_topic",
+            suffix="my_suffix",
+            consumer_group="my_group",
+        )
+        with patch.object(topic_manager, "changelog_topic") as make_changelog:
+            changelog_manager.add_changelog(**kwargs)
+        make_changelog.assert_called_with(**kwargs)
+
+    def test_get_writer(self, topic_manager_factory, row_producer_factory):
+        topic_manager = topic_manager_factory()
+        producer = row_producer_factory()
+        changelog_manager = ChangelogManager(
+            topic_manager=topic_manager, producer=producer
+        )
+
+        topic_name = "my_topic"
+        suffix = "my_suffix"
+        p_num = 1
+        kwargs = dict(source_topic_name=topic_name, suffix=suffix)
+        topic_manager.topic(topic_name)  # changelogs depend on topic objects existing
+        changelog_topic = topic_manager.changelog_topic(
+            **kwargs, consumer_group="group"
+        )
+
+        writer = changelog_manager.get_writer(**kwargs, partition_num=p_num)
+        assert writer._topic == changelog_topic
+        assert writer._partition_num == p_num
+        assert writer._producer == producer

--- a/tests/test_quixstreams/test_state/test_manager.py
+++ b/tests/test_quixstreams/test_state/test_manager.py
@@ -49,18 +49,19 @@ class TestStateStoreManager:
 
     def test_register_store(self, state_manager_changelogs):
         manager = state_manager_changelogs
-        topic = manager._topic_manager.topic(name="topic1")
+        topic_manager = manager._changelog_manager._topic_manager
+        topic = topic_manager.topic(name="topic1")
         store_name = "default"
         manager.register_store(topic.name, store_name=store_name)
 
         assert topic.name in manager._stores
-        assert store_name in manager._topic_manager.changelog_topics[topic.name]
+        assert store_name in topic_manager.changelog_topics[topic.name]
 
-    def test_register_store_no_topic_manager(self, state_manager):
+    def test_register_store_no_changelog_manager(self, state_manager):
         state_manager = state_manager
         state_manager.register_store("my_topic", store_name="default")
 
-        assert state_manager._topic_manager is None
+        assert state_manager._changelog_manager is None
 
     def test_assign_revoke_partitions_stores_registered(self, state_manager):
         state_manager.register_store("topic1", store_name="store1")

--- a/tests/test_quixstreams/test_state/test_rocksdb/fixtures.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/fixtures.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+from quixstreams.state import ChangelogManager
 from quixstreams.state.rocksdb import RocksDBStore
 from quixstreams.state.rocksdb.options import RocksDBOptions
 from quixstreams.state.rocksdb.partition import RocksDBStorePartition
@@ -36,9 +37,18 @@ def rocksdb_partition(rocksdb_partition_factory) -> RocksDBStorePartition:
 
 @pytest.fixture()
 def rocksdb_store_factory(tmp_path):
-    def factory(topic: Optional[str] = None, name: str = "default") -> RocksDBStore:
+    def factory(
+        topic: Optional[str] = None,
+        name: str = "default",
+        changelog_manager: Optional[ChangelogManager] = None,
+    ) -> RocksDBStore:
         topic = topic or str(uuid.uuid4())
-        return RocksDBStore(topic=topic, name=name, base_dir=str(tmp_path))
+        return RocksDBStore(
+            topic=topic,
+            name=name,
+            base_dir=str(tmp_path),
+            changelog_manager=changelog_manager,
+        )
 
     return factory
 

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_partition.py
@@ -19,7 +19,6 @@ from quixstreams.state.rocksdb import (
     ColumnFamilyDoesNotExist,
 )
 from quixstreams.state.rocksdb.serialization import serialize
-from quixstreams.state.rocksdb.partition import _CHANGELOG_OFFSET_KEY
 from quixstreams.utils.json import dumps
 
 TEST_KEYS = [

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_store.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_store.py
@@ -1,6 +1,9 @@
 import pytest
 
+from unittest.mock import patch
+
 from quixstreams.state.exceptions import PartitionNotAssignedError
+from quixstreams.state.changelog import ChangelogWriter
 
 
 class TestRocksDBStore:
@@ -35,6 +38,26 @@ class TestRocksDBStore:
         rocksdb_store.assign_partition(0)
         with rocksdb_store.start_partition_transaction(0) as tx:
             assert tx.get("key") == "value"
+        assert rocksdb_store._changelog_manager is None
+        assert tx._changelog_writer is None
+
+    def test_create_transaction_changelog(
+        self, rocksdb_store_factory, changelog_manager_factory
+    ):
+        p_num = 0
+        changelog_manager = changelog_manager_factory()
+        rocksdb_store = rocksdb_store_factory(changelog_manager=changelog_manager)
+        rocksdb_store.assign_partition(p_num)
+
+        with patch.object(changelog_manager, "get_writer") as writer:
+            with rocksdb_store.start_partition_transaction(p_num):
+                ...
+        writer.assert_called_with(
+            source_topic_name=rocksdb_store.topic,
+            suffix=rocksdb_store.name,
+            partition_num=p_num,
+        )
+        rocksdb_store.close()
 
     def test_get_transaction_partition_not_assigned(self, rocksdb_store):
         with pytest.raises(PartitionNotAssignedError):

--- a/tests/test_quixstreams/utils.py
+++ b/tests/test_quixstreams/utils.py
@@ -1,0 +1,63 @@
+from typing import Optional, List, Tuple, Union
+
+
+class ConfluentKafkaMessageStub:
+    """
+    A stub object to mock `confluent_kafka.Message`.
+
+    Instances of `confluent_kafka.Message` cannot be directly created from Python,
+    see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
+
+    """
+
+    def __init__(
+        self,
+        topic: str = "test",
+        partition: int = 0,
+        offset: int = 0,
+        timestamp: Tuple[int, int] = (1, 123),
+        key: bytes = None,
+        value: bytes = None,
+        headers: Optional[List[Tuple[str, bytes]]] = None,
+        latency: float = None,
+        leader_epoch: int = None,
+    ):
+        self._topic = topic
+        self._partition = partition
+        self._offset = offset
+        self._timestamp = timestamp
+        self._key = key
+        self._value = value
+        self._headers = headers
+        self._latency = latency
+        self._leader_epoch = leader_epoch
+
+    def headers(self, *args, **kwargs) -> Optional[List[Tuple[str, bytes]]]:
+        return self._headers
+
+    def key(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+        return self._key
+
+    def offset(self, *args, **kwargs) -> int:
+        return self._offset
+
+    def partition(self, *args, **kwargs) -> int:
+        return self._partition
+
+    def timestamp(self, *args, **kwargs) -> (int, int):
+        return self._timestamp
+
+    def topic(self, *args, **kwargs) -> str:
+        return self._topic
+
+    def value(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+        return self._value
+
+    def latency(self, *args, **kwargs) -> Optional[float]:
+        return self._latency
+
+    def leader_epoch(self, *args, **kwargs) -> Optional[int]:
+        return self._leader_epoch
+
+    def __len__(self) -> int:
+        return len(self._value)


### PR DESCRIPTION
## Overview

Built on top of `feature/recovery/topic-changelog-manage`

Produces state changes to a changelog topic, which is successfully expanded on/used by another recovery feature branch. This is here to keep the logic specific to just producing to the changelogs separate (since it can be).

Uses column families.