### PR TITLE
Rebuild state from changelog

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -548,16 +548,11 @@ class Application:
     def _process_messages(self, dataframe_composed, start_state_transaction):
         # Serve producer callbacks
         self._producer.poll(self._producer_poll_timeout)
-        print(f"PROCESS: POLL ROW")
         rows = self._consumer.poll_row(timeout=self._consumer_poll_timeout)
 
         if rows is None:
-            print("PROCESS: NO ROW; DONE")
             return
 
-        print(self._consumer.assignment())
-        print(f"ROW: {rows.topic, rows.partition}")
-        print(f"PROCESS: CONTINUE")
         # Deserializer may return multiple rows for a single message
         rows = rows if isinstance(rows, list) else [rows]
         if not rows:
@@ -609,7 +604,6 @@ class Application:
         try:
             self._state_manager.do_recovery()
         except RecoveryManager.RecoveryComplete:
-            print("FINISHED RECOVERING")
             self._run_mode = self._processing
 
     def _do_run_mode(self):
@@ -733,7 +727,6 @@ class Application:
         """
         Revoke partitions from consumer and state
         """
-        print(f"CONSUMER REVOKE: {topic_partitions}")
         if self._state_manager.stores:
             if self._state_manager.using_changelogs:
                 self._run_mode = self._recovery
@@ -745,7 +738,6 @@ class Application:
         """
         Dropping lost partitions from consumer and state
         """
-        print(f"CONSUMER LOST: {topic_partitions}")
         if self._state_manager.stores:
             if self._state_manager.using_changelogs:
                 self._run_mode = self._recovery

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import signal
+from functools import partial
 from typing import Optional, List, Callable, Literal, Mapping
 
 from confluent_kafka import TopicPartition
@@ -30,9 +31,12 @@ from .platforms.quix import (
 )
 from .rowconsumer import RowConsumer
 from .rowproducer import RowProducer
-from .state import StateStoreManager, ChangelogManager
+from .state import StateStoreManager
+from .state.changelog import ChangelogManager, RecoveryManager
 from .state.rocksdb import RocksDBOptionsType
 from .topic_manager import TopicManager, TopicManagerType
+
+from time import sleep
 
 __all__ = ("Application",)
 
@@ -85,7 +89,7 @@ class Application:
         consumer_group: str,
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
-        assignment_strategy: AssignmentStrategy = "range",
+        assignment_strategy: AssignmentStrategy = "cooperative-sticky",
         partitioner: Partitioner = "murmur2",
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
@@ -182,6 +186,8 @@ class Application:
         self._quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None
         self._auto_create_topics = auto_create_topics
         self._topic_validation = topic_validation
+        self._processing = lambda: None
+        self._run_mode = None
 
         if not topic_manager:
             topic_manager = TopicManager()
@@ -203,6 +209,7 @@ class Application:
                     extra_config=producer_extra_config,
                     on_error=on_producer_error,
                 ),
+                consumer=self._consumer,
             )
             if use_changelog_topics
             else None
@@ -223,7 +230,7 @@ class Application:
         consumer_group: str,
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
-        assignment_strategy: AssignmentStrategy = "range",
+        assignment_strategy: AssignmentStrategy = "cooperative-sticky",
         partitioner: Partitioner = "murmur2",
         consumer_extra_config: Optional[dict] = None,
         producer_extra_config: Optional[dict] = None,
@@ -539,6 +546,77 @@ class Application:
                 validation_level=self._topic_validation
             )
 
+    def _process_messages(self, dataframe_composed, start_state_transaction):
+        # Serve producer callbacks
+        self._producer.poll(self._producer_poll_timeout)
+        print(f"PROCESS: POLL ROW")
+        rows = self._consumer.poll_row(timeout=self._consumer_poll_timeout)
+
+        if rows is None:
+            print("PROCESS: NO ROW; DONE")
+            return
+
+        print(self._consumer.assignment())
+        print(f"ROW: {rows.topic, rows.partition}")
+        print(f"PROCESS: CONTINUE")
+        sleep(2)
+        # Deserializer may return multiple rows for a single message
+        rows = rows if isinstance(rows, list) else [rows]
+        if not rows:
+            return
+
+        first_row = rows[0]
+        topic_name, partition, offset = (
+            first_row.topic,
+            first_row.partition,
+            first_row.offset,
+        )
+        # Create a new contextvars.Context and set the current MessageContext
+        # (it's the same across multiple rows)
+        context = copy_context()
+        context.run(set_message_context, first_row.context)
+
+        with start_state_transaction(
+            topic=topic_name, partition=partition, offset=offset
+        ):
+            for row in rows:
+                try:
+                    # Execute StreamingDataFrame in a context
+                    context.run(dataframe_composed, row.value)
+                except Filtered:
+                    # The message was filtered by StreamingDataFrame
+                    continue
+                except Exception as exc:
+                    # TODO: This callback might be triggered because of Producer
+                    #  errors too because they happen within ".process()"
+                    to_suppress = self._on_processing_error(exc, row, logger)
+                    if not to_suppress:
+                        raise
+
+        # Store the message offset after it's successfully processed
+        self._consumer.store_offsets(
+            offsets=[
+                TopicPartition(
+                    topic=topic_name,
+                    partition=partition,
+                    offset=offset + 1,
+                )
+            ]
+        )
+
+        if self._on_message_processed is not None:
+            self._on_message_processed(topic_name, partition, offset)
+
+    def _recovery(self):
+        try:
+            self._state_manager.changelog_manager.do_recovery()
+        except RecoveryManager.RecoveryComplete:
+            print("FINISHED RECOVERING")
+            self._run_mode = self._processing
+
+    def _do_run_mode(self):
+        return self._run_mode()
+
     def run(
         self,
         dataframe: StreamingDataFrame,
@@ -607,60 +685,13 @@ class Application:
             self._running = True
 
             dataframe_composed = dataframe.compose()
+            self._processing = partial(
+                self._process_messages, dataframe_composed, start_state_transaction
+            )
+            self._run_mode = self._processing
+
             while self._running:
-                # Serve producer callbacks
-                self._producer.poll(self._producer_poll_timeout)
-                rows = self._consumer.poll_row(timeout=self._consumer_poll_timeout)
-
-                if rows is None:
-                    continue
-
-                # Deserializer may return multiple rows for a single message
-                rows = rows if isinstance(rows, list) else [rows]
-                if not rows:
-                    continue
-
-                first_row = rows[0]
-                topic_name, partition, offset = (
-                    first_row.topic,
-                    first_row.partition,
-                    first_row.offset,
-                )
-                # Create a new contextvars.Context and set the current MessageContext
-                # (it's the same across multiple rows)
-                context = copy_context()
-                context.run(set_message_context, first_row.context)
-
-                with start_state_transaction(
-                    topic=topic_name, partition=partition, offset=offset
-                ):
-                    for row in rows:
-                        try:
-                            # Execute StreamingDataFrame in a context
-                            context.run(dataframe_composed, row.value)
-                        except Filtered:
-                            # The message was filtered by StreamingDataFrame
-                            continue
-                        except Exception as exc:
-                            # TODO: This callback might be triggered because of Producer
-                            #  errors too because they happen within ".process()"
-                            to_suppress = self._on_processing_error(exc, row, logger)
-                            if not to_suppress:
-                                raise
-
-                # Store the message offset after it's successfully processed
-                self._consumer.store_offsets(
-                    offsets=[
-                        TopicPartition(
-                            topic=topic_name,
-                            partition=partition,
-                            offset=offset + 1,
-                        )
-                    ]
-                )
-
-                if self._on_message_processed is not None:
-                    self._on_message_processed(topic_name, partition, offset)
+                self._do_run_mode()
 
             logger.info("Stop processing of StreamingDataFrame")
 
@@ -671,6 +702,8 @@ class Application:
         :param topic_partitions: list of `TopicPartition` from Kafka
         """
         if self._state_manager.stores:
+            if self._state_manager.changelog_manager:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: assigning state store partitions")
             for tp in topic_partitions:
                 # Assign store partitions
@@ -702,7 +735,10 @@ class Application:
         """
         Revoke partitions from consumer and state
         """
+        print(f"CONSUMER REVOKE: {topic_partitions}")
         if self._state_manager.stores:
+            if self._state_manager.changelog_manager:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: revoking state store partitions")
             for tp in topic_partitions:
                 self._state_manager.on_partition_revoke(tp)
@@ -711,7 +747,10 @@ class Application:
         """
         Dropping lost partitions from consumer and state
         """
+        print(f"CONSUMER LOST: {topic_partitions}")
         if self._state_manager.stores:
+            if self._state_manager.changelog_manager:
+                self._run_mode = self._recovery
             logger.debug(f"Rebalancing: dropping lost state store partitions")
             for tp in topic_partitions:
                 self._state_manager.on_partition_lost(tp)

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -559,7 +559,6 @@ class Application:
         print(self._consumer.assignment())
         print(f"ROW: {rows.topic, rows.partition}")
         print(f"PROCESS: CONTINUE")
-        sleep(2)
         # Deserializer may return multiple rows for a single message
         rows = rows if isinstance(rows, list) else [rows]
         if not rows:
@@ -615,6 +614,7 @@ class Application:
             self._run_mode = self._processing
 
     def _do_run_mode(self):
+        sleep(0.5)
         return self._run_mode()
 
     def run(

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -36,7 +36,6 @@ from .state.changelog import ChangelogManager, RecoveryManager
 from .state.rocksdb import RocksDBOptionsType
 from .topic_manager import TopicManager, TopicManagerType
 
-from time import sleep
 
 __all__ = ("Application",)
 
@@ -608,13 +607,12 @@ class Application:
 
     def _recovery(self):
         try:
-            self._state_manager.changelog_manager.do_recovery()
+            self._state_manager.do_recovery()
         except RecoveryManager.RecoveryComplete:
             print("FINISHED RECOVERING")
             self._run_mode = self._processing
 
     def _do_run_mode(self):
-        sleep(0.5)
         return self._run_mode()
 
     def run(
@@ -702,7 +700,7 @@ class Application:
         :param topic_partitions: list of `TopicPartition` from Kafka
         """
         if self._state_manager.stores:
-            if self._state_manager.changelog_manager:
+            if self._state_manager.using_changelogs:
                 self._run_mode = self._recovery
             logger.debug(f"Rebalancing: assigning state store partitions")
             for tp in topic_partitions:
@@ -737,7 +735,7 @@ class Application:
         """
         print(f"CONSUMER REVOKE: {topic_partitions}")
         if self._state_manager.stores:
-            if self._state_manager.changelog_manager:
+            if self._state_manager.using_changelogs:
                 self._run_mode = self._recovery
             logger.debug(f"Rebalancing: revoking state store partitions")
             for tp in topic_partitions:
@@ -749,7 +747,7 @@ class Application:
         """
         print(f"CONSUMER LOST: {topic_partitions}")
         if self._state_manager.stores:
-            if self._state_manager.changelog_manager:
+            if self._state_manager.using_changelogs:
                 self._run_mode = self._recovery
             logger.debug(f"Rebalancing: dropping lost state store partitions")
             for tp in topic_partitions:

--- a/quixstreams/kafka/consumer.py
+++ b/quixstreams/kafka/consumer.py
@@ -502,6 +502,12 @@ class Consumer:
         """
         return self._consumer.set_sasl_credentials(username, password)
 
+    def incremental_assign(self, partitions: List[TopicPartition]):
+        return self._consumer.incremental_assign(partitions)
+
+    def incremental_unassign(self, partitions: List[TopicPartition]):
+        return self._consumer.incremental_unassign(partitions)
+
     def close(self):
         """
         Close down and terminate the Kafka Consumer.

--- a/quixstreams/models/topics.py
+++ b/quixstreams/models/topics.py
@@ -271,8 +271,18 @@ class Topic:
         )
 
     def deserialize(self, message: ConfluentKafkaMessageProto):
-        # TODO: Implement SerDes for raw messages
-        raise NotImplementedError
+        # TODO: confirm this is a valid context
+        ctx = SerializationContext(topic="", headers=message.headers())
+        return KafkaMessage(
+            key=self._key_deserializer(key, ctx=ctx)
+            if (key := message.key())
+            else None,
+            value=self._value_serializer(value, ctx=ctx)
+            if (value := message.value())
+            else None,
+            headers=message.headers(),
+            timestamp=message.timestamp(),
+        )
 
     def __repr__(self):
         return f'<{self.__class__} name="{self._name}"> '

--- a/quixstreams/state/changelog.py
+++ b/quixstreams/state/changelog.py
@@ -1,8 +1,57 @@
-from typing import Optional
+from typing import Optional, Dict, List
 
-from quixstreams.rowproducer import RowProducer
 from quixstreams.topic_manager import TopicManagerType, BytesTopic
+from quixstreams.rowconsumer import RowConsumer
+from quixstreams.rowproducer import RowProducer
+from quixstreams.models import Topic
+from quixstreams.state.types import StorePartition
 from quixstreams.types import Headers
+
+from confluent_kafka import TopicPartition as ConfluentPartition
+
+
+class RecoveryPartition:
+    def __init__(
+        self, topic: str, changelog: str, partition: int, state_store: StorePartition
+    ):
+        self.topic = topic
+        self.changelog = changelog
+        self.partition = partition
+        self.state_store = state_store
+        self._changelog_lowwater: Optional[int] = None
+        self._changelog_highwater: Optional[int] = None
+
+    @property
+    def offset(self) -> int:
+        return self.state_store.get_changelog_offset()
+
+    @property
+    def as_partition(self) -> ConfluentPartition:
+        return ConfluentPartition(self.topic, self.partition)
+
+    @property
+    def topic_partition(self) -> ConfluentPartition:
+        return ConfluentPartition(self.topic, self.partition)
+
+    @property
+    def changelog_partition(self) -> ConfluentPartition:
+        return ConfluentPartition(self.changelog, self.partition)
+
+    @property
+    def changelog_assignable_partition(self):
+        return ConfluentPartition(self.changelog, self.partition, self.offset)
+
+    @property
+    def needs_recovery(self):
+        has_consumable_offsets = self._changelog_lowwater != self._changelog_highwater
+        state_is_behind = self._changelog_highwater - self.offset
+        return has_consumable_offsets and state_is_behind
+
+    def set_watermarks(self, lowwater: int, highwater: int):
+        self._changelog_lowwater = lowwater
+        self._changelog_highwater = highwater
+
+_COLUMN_FAMILY_HEADER = "__column_family__"
 
 
 class ChangelogWriter:
@@ -33,6 +82,17 @@ class ChangelogWriter:
 
 
 class ChangelogManager:
+    def __init__(
+        self,
+        topic_manager: TopicManagerType,
+        consumer: RowConsumer,
+        producer: RowProducer,
+    ):
+        self._topic_manager = topic_manager
+        self._consumer = consumer
+        self._producer = producer
+        self._recovery_manager = RecoveryManager(consumer)
+
     """
     A simple interface for adding changelog topics during store init and
     generating changelog writers (generally for each new `Store` transaction).
@@ -49,6 +109,25 @@ class ChangelogManager:
             consumer_group=consumer_group,
         )
 
+    def assign_partition(
+        self, source_topic_name: str, partition: int, state_store: StorePartition
+    ):
+        for topic in self._topic_manager.changelog_topics[source_topic_name].values():
+            print(f"CHANGELOG: ADDING PARTITION {topic.name}: {partition}")
+            self._recovery_manager.assign_partition(
+                source_topic_name=source_topic_name,
+                changelog=topic.name,
+                partition=partition,
+                state_store=state_store,
+            )
+
+    def revoke_partition(self, source_topic_name, partition):
+        for topic in self._topic_manager.changelog_topics[source_topic_name].values():
+            print(f"CHANGELOG: REVOKING PARTITION {topic.name}: {partition}")
+            self._recovery_manager.revoke_partition(
+                topic=source_topic_name, changelog=topic.name, partition=partition
+            )
+
     def get_writer(
         self, source_topic_name: str, suffix: str, partition_num: int
     ) -> ChangelogWriter:
@@ -57,3 +136,144 @@ class ChangelogManager:
             partition_num=partition_num,
             producer=self._producer,
         )
+
+    def do_recovery(self):
+        print("DO RECOVERY")
+        self._recovery_manager.do_recovery()
+
+
+class RecoveryManager:
+    def __init__(self, consumer: RowConsumer):
+        self._consumer = consumer
+        self._pending_assigns: List[RecoveryPartition] = []
+        self._pending_revokes: List[RecoveryPartition] = []
+        self._partitions: Dict[int, Dict[str, RecoveryPartition]] = {}
+        self._recovery_method = self._recover
+        self._topic_changelog_map: Dict[str, str] = {}
+
+    class RecoveryComplete(Exception):
+        ...
+
+    @property
+    def in_recovery_mode(self) -> bool:
+        return bool(self._partitions)
+
+    def do_recovery(self):
+        return self._recovery_method()
+
+    def assign_partition(
+        self,
+        source_topic_name: str,
+        changelog: str,
+        partition: int,
+        state_store: StorePartition,
+    ):
+        print("RECOVERY: ADD PARTITION")
+        p = RecoveryPartition(
+            topic=source_topic_name,
+            changelog=changelog,
+            partition=partition,
+            state_store=state_store,
+        )
+        topic_p = p.topic_partition
+        # Assign manually to immediately pause it (would assign unpaused automatically)
+        # TODO: consider doing all topic (not changelog) assign(s) during the
+        #  Application on_assign call (rather than one at a time here)
+        self._consumer.incremental_assign([topic_p])
+        self._consumer.pause([topic_p])
+        self._pending_assigns.append(p)
+        self._recovery_method = self._rebalance
+
+    def _partition_cleanup(self, partition: int):
+        if not self._partitions[partition]:
+            del self._partitions[partition]
+
+    def revoke_partition(self, topic: str, changelog: str, partition: int):
+        print("RECOVERY: REVOKE PARTITION")
+        # TODO: consider doing all topic (not changelog) unassign(s) during the
+        #  Application on_revoke call (rather than one at a time here)
+        self._consumer.incremental_unassign([ConfluentPartition(topic, partition)])
+        print(f"CURRENT PARTITIONS: {self._partitions}")
+        if recovery_p := self._partitions.get(partition, {}).pop(changelog, None):
+            # pause for later revoke (will revoke all partitions at the same time)
+            self._consumer.pause([recovery_p.changelog_partition])
+            self._pending_revokes.append(recovery_p)
+            print(f"PENDING REVOKES: {self._pending_revokes}")
+            if self._pending_revokes:
+                self._partition_cleanup(partition)
+                self._recovery_method = self._rebalance
+
+    def _handle_pending_assigns(self):
+        print("RECOVERY: HANDLE PENDING ASSIGNS")
+        if self._pending_assigns:
+            assigns = []
+            self._consumer.pause([p.as_partition for p in self._pending_assigns])
+            while self._pending_assigns:
+                p = self._pending_assigns.pop()
+                p.set_watermarks(
+                    *self._consumer.get_watermark_offsets(
+                        p.changelog_partition, timeout=10
+                    )
+                )
+                if p.needs_recovery:
+                    print(f"ADDING PARTITION {p.changelog}: {p.partition}")
+                    assigns.append(p)
+                    self._partitions.setdefault(p.partition, {})[p.changelog] = p
+            if assigns:
+                self._consumer.incremental_assign(
+                    [p.changelog_assignable_partition for p in assigns]
+                )
+        self._recovery_method = self._recover
+
+    def _handle_pending_revokes(self):
+        print("RECOVERY: HANDLE PENDING REVOKES")
+        if self._pending_revokes:
+            self._consumer.incremental_unassign(
+                [p.changelog_partition for p in self._pending_revokes]
+            )
+            print(
+                f"REVOKED PARTITIONS {[(p.changelog, p.partition) for p in self._pending_revokes]}"
+            )
+            self._pending_revokes = []
+
+    def _rebalance(self):
+        """ """
+        print("RECOVERY: REBALANCE")
+        self._handle_pending_revokes()
+        self._handle_pending_assigns()
+        self._recovery_method = self._recover
+
+    def _finalize_recovery(self):
+        print("RECOVERY: FINALIZE RECOVERY")
+        self._consumer.resume(self._consumer.assignment())
+        raise self.RecoveryComplete
+
+    def _recover(self):
+        print("RECOVERY: RECOVER")
+        if not self.in_recovery_mode:
+            self._finalize_recovery()
+
+        print("POLLING")
+        if not (msg := self._consumer.poll(5)):
+            print("NO MESSAGES")
+            return
+
+        print(self._consumer.assignment())
+        print(
+            f"RECOVERY MESSAGE: {msg.key()}, {msg.value()}, {msg.topic()}: {msg.partition()}"
+        )
+        changelog = msg.topic()
+        p_num = msg.partition()
+
+        partition = self._partitions[p_num][changelog]
+        with partition.state_store.recover(msg.offset()) as transaction:
+            if msg.value():
+                transaction.set(key=msg.key(), value=msg.value())
+            else:
+                transaction.delete(key=msg.key())
+
+        if not partition.needs_recovery:
+            print(f"RECOVERY FOR {msg.topic()}: {msg.partition()} finished!")
+            self._pending_revokes.append(self._partitions[p_num].pop(changelog))
+            self._partition_cleanup(p_num)
+            self._handle_pending_revokes()

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -70,6 +70,10 @@ class StateStoreManager:
         """
         return self._stores
 
+    @property
+    def changelog_manager(self):
+        return self._changelog_manager
+
     def get_store(
         self, topic: str, store_name: str = _DEFAULT_STATE_STORE_NAME
     ) -> Store:
@@ -107,7 +111,13 @@ class StateStoreManager:
                     suffix=store_name,
                     consumer_group=self._group_id,
                 )
-            self._stores.setdefault(topic_name, {})[store_name] = RocksDBStore(
+            writer = None
+            if self._changelog_manager:
+                writer = self._changelog_manager.add_changelog_topic(
+                    source_topic_name=topic_name,
+                    suffix=store_name,
+                )
+            store = RocksDBStore(
                 name=store_name,
                 topic=topic_name,
                 changelog_manager=self._changelog_manager,

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -111,13 +111,7 @@ class StateStoreManager:
                     suffix=store_name,
                     consumer_group=self._group_id,
                 )
-            writer = None
-            if self._changelog_manager:
-                writer = self._changelog_manager.add_changelog_topic(
-                    source_topic_name=topic_name,
-                    suffix=store_name,
-                )
-            store = RocksDBStore(
+            self._stores.setdefault(topic_name, {})[store_name] = RocksDBStore(
                 name=store_name,
                 topic=topic_name,
                 changelog_manager=self._changelog_manager,

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -11,6 +11,7 @@ from quixstreams.state.types import (
     DumpsFunc,
     LoadsFunc,
     PartitionTransaction,
+    PartitionRecovery,
     StorePartition,
 )
 from .exceptions import (
@@ -103,6 +104,18 @@ class RocksDBStorePartition(StorePartition):
             dumps=self._dumps,
             loads=self._loads,
             changelog_writer=changelog_writer,
+        )
+
+    def recover(self, offset) -> "RocksDBPartitionRecovery":
+        """
+        Create a new `RocksDBTransaction` object.
+        Using `RocksDBTransaction` is a recommended way for accessing the data.
+
+        :return: an instance of `RocksDBTransaction`
+        """
+        return RocksDBPartitionRecovery(
+            partition=self,
+            offset=offset,
         )
 
     def write(self, batch: WriteBatch):
@@ -627,3 +640,103 @@ class RocksDBPartitionTransaction(PartitionTransaction):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_val is None and not self._failed:
             self.maybe_flush()
+
+
+class RocksDBPartitionRecovery(PartitionRecovery):
+    __slots__ = ("_partition", "_batch", "_failed", "_completed", "_offset")
+
+    def __init__(
+        self,
+        partition: RocksDBStorePartition,
+        offset: int,
+    ):
+        self._partition = partition
+        self._batch = rocksdict.WriteBatch(raw_mode=True)
+        self._offset = offset
+        self._failed = False
+        self._completed = False
+
+    @_validate_transaction_state
+    def set(self, key: bytes, value: bytes):
+        """
+        Set a key to the store.
+
+        :param key: key to store in DB
+        :param value: value to store in DB
+        """
+        try:
+            self._batch.put(key, value)
+        except Exception:
+            self._failed = True
+            raise
+
+    @_validate_transaction_state
+    def delete(self, key: bytes):
+        """
+        Delete a key to the store.
+
+        :param key: key to delete from DB
+        """
+        try:
+            self._batch.delete(key)
+        except Exception:
+            self._failed = True
+            raise
+
+    @property
+    def completed(self) -> bool:
+        """
+        Check if the transaction is completed.
+
+        It doesn't indicate whether transaction is successful or not.
+        Use `RocksDBTransaction.failed` for that.
+
+        The completed transaction should not be re-used.
+
+        :return: `True` if transaction is completed, `False` otherwise.
+        """
+        return self._completed
+
+    @property
+    def failed(self) -> bool:
+        """
+        Check if the transaction has failed.
+
+        The failed transaction should not be re-used because the update cache
+        and
+
+        :return: `True` if transaction is failed, `False` otherwise.
+        """
+        return self._failed
+
+    @_validate_transaction_state
+    def flush(self):
+        """
+        Flush the recent updates to the database and empty the update cache.
+        It writes the WriteBatch to RocksDB and marks itself as finished.
+
+        If writing fails, the transaction will be also marked as "failed" and
+        cannot be used anymore.
+
+        >***NOTE:*** If no keys have been modified during the transaction
+            (i.e no "set" or "delete" have been called at least once), it will
+            not flush ANY data to the database including the offset in order to optimize
+            I/O.
+        """
+        try:
+            self._batch.put(
+                _CHANGELOG_OFFSET_KEY, _int_to_int64_bytes(self._offset + 1)
+            )
+            self._partition.write(self._batch)
+        except Exception:
+            self._failed = True
+            raise
+        finally:
+            self._completed = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_val is None and not self._failed:
+            self.flush()

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -665,6 +665,8 @@ class RocksDBPartitionRecovery(PartitionRecovery):
         :param value: value to store in DB
         """
         try:
+            # TODO-CF: ADD cf_name ARG AND UNCOMMENT/REPLACE
+            # self._batch.put(key, value, cf_name)
             self._batch.put(key, value)
         except Exception:
             self._failed = True
@@ -678,6 +680,8 @@ class RocksDBPartitionRecovery(PartitionRecovery):
         :param key: key to delete from DB
         """
         try:
+            # TODO-CF: ADD cf_name ARG AND UNCOMMENT/REPLACE
+            # self._batch.delete(key, cf_name)
             self._batch.delete(key)
         except Exception:
             self._failed = True

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -98,7 +98,10 @@ class StorePartition(Protocol):
     def get_processed_offset(self) -> Optional[int]:
         ...
 
-    def get_changelog_offset(self) -> int:
+    def get_changelog_offset(self) -> Optional[int]:
+        ...
+
+    def set_changelog_offset(self, changelog_message: ConfluentKafkaMessageProto):
         ...
 
 

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -90,7 +90,13 @@ class StorePartition(Protocol):
         State new `PartitionTransaction`
         """
 
+    def recover(self, offset) -> "PartitionRecovery":
+        ...
+
     def get_processed_offset(self) -> Optional[int]:
+        ...
+
+    def get_changelog_offset(self) -> int:
         ...
 
 
@@ -178,6 +184,50 @@ class PartitionTransaction(State):
         Flush the recent updates and last processed offset to the storage.
         :param offset: offset of the last processed message, optional.
         """
+
+    def __enter__(self):
+        ...
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        ...
+
+
+class PartitionRecovery(Protocol):
+    """
+    A transaction class to perform simple key-value operations like
+    "get", "set", "delete" and "exists" on a single storage partition.
+    """
+
+    @property
+    def failed(self) -> bool:
+        """
+        Return `True` if transaction failed to update data at some point.
+
+        Failed transactions cannot be re-used.
+        :return: bool
+        """
+
+    @property
+    def completed(self) -> bool:
+        """
+        Return `True` if transaction is completed.
+
+        Completed transactions cannot be re-used.
+        :return: bool
+        """
+        ...
+
+    def set(self, key: bytes, value: bytes):
+        ...
+
+    def delete(self, key: bytes):
+        ...
+
+    def flush(self):
+        """
+        Flush the recent updates and last processed offset to the storage.
+        """
+        ...
 
     def __enter__(self):
         ...

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -2,6 +2,8 @@ from typing import Protocol, Any, Optional, Iterator, Callable, Dict, ClassVar
 
 from typing_extensions import Self
 
+from quixstreams.models import ConfluentKafkaMessageProto
+
 DumpsFunc = Callable[[Any], bytes]
 LoadsFunc = Callable[[bytes], Any]
 
@@ -90,7 +92,7 @@ class StorePartition(Protocol):
         State new `PartitionTransaction`
         """
 
-    def recover(self, offset) -> "PartitionRecovery":
+    def recover(self, changelog_message: ConfluentKafkaMessageProto):
         ...
 
     def get_processed_offset(self) -> Optional[int]:
@@ -192,10 +194,9 @@ class PartitionTransaction(State):
         ...
 
 
-class PartitionRecovery(Protocol):
+class PartitionRecoveryTransaction(Protocol):
     """
-    A transaction class to perform simple key-value operations like
-    "get", "set", "delete" and "exists" on a single storage partition.
+    A class for managing recovery for a StorePartition from a changelog message
     """
 
     @property
@@ -217,10 +218,7 @@ class PartitionRecovery(Protocol):
         """
         ...
 
-    def set(self, key: bytes, value: bytes):
-        ...
-
-    def delete(self, key: bytes):
+    def recover(self):
         ...
 
     def flush(self):

--- a/quixstreams/topic_manager.py
+++ b/quixstreams/topic_manager.py
@@ -5,6 +5,7 @@ from abc import abstractmethod
 from typing import Dict, List, Mapping, Optional, Set, Literal, Protocol, ClassVar
 
 from quixstreams.platforms.quix import QuixKafkaConfigsBuilder
+from quixstreams.utils.dicts import dict_values
 from .kafka.admin import Admin
 from .models.serializers import DeserializerType, SerializerType
 from .models.topics import Topic, TopicConfig, TopicList, TopicMap
@@ -24,26 +25,6 @@ class BytesTopic(Topic):
             value_deserializer="bytes",
             config=config,
         )
-
-
-def dict_values(d: object) -> List:
-    """
-    Recursively unpacks a set of nested dicts to get a flattened list of leaves,
-    where "leaves" are the first non-dict item.
-
-    i.e {"a": {"b": {"c": 1}, "d": 2}, "e": 3} becomes [1, 2, 3]
-
-    :param d: initially, a dict (with potentially nested dicts)
-
-    :return: a list with all the leaves of the various contained dicts
-    """
-    if d:
-        if isinstance(d, dict):
-            return [i for v in d.values() for i in dict_values(v)]
-        elif isinstance(d, list):
-            return d
-        return [d]
-    return []
 
 
 def affirm_ready_for_create(topics: TopicList):
@@ -92,6 +73,11 @@ class TopicManagerType(Protocol):
 
     @property
     def changelog_topics(self) -> Dict[str, Dict[str, BytesTopic]]:
+        """
+        Changelogs stored as {source_topic_name: {suffix: Topic}}
+
+        returns:
+        """
         return self._changelog_topics
 
     @property

--- a/quixstreams/utils/dicts.py
+++ b/quixstreams/utils/dicts.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+def dict_values(d: object) -> List:
+    """
+    Recursively unpacks a set of nested dicts to get a flattened list of leaves,
+    where "leaves" are the first non-dict item.
+
+    i.e {"a": {"b": {"c": 1}, "d": 2}, "e": 3} becomes [1, 2, 3]
+
+    :param d: initially, a dict (with potentially nested dicts)
+
+    :return: a list with all the leaves of the various contained dicts
+    """
+    if d:
+        if isinstance(d, dict):
+            return [i for v in d.values() for i in dict_values(v)]
+        elif isinstance(d, list):
+            return d
+        return [d]
+    return []

--- a/tests/test_quixstreams/fixtures.py
+++ b/tests/test_quixstreams/fixtures.py
@@ -1,7 +1,7 @@
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional, Literal, Union
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, patch
 
 import pytest
 from confluent_kafka.admin import (
@@ -326,12 +326,20 @@ def state_manager(state_manager_factory) -> StateStoreManager:
 
 
 @pytest.fixture()
-def changelog_manager_factory(topic_manager_factory, row_producer_factory):
+def changelog_manager_factory(
+    topic_manager_factory,
+    row_producer_factory,
+    row_consumer_factory,
+):
     def factory(
-        admin: Optional[Admin] = None, producer: RowProducer = row_producer_factory()
+        admin: Optional[Admin] = None,
+        producer: RowProducer = row_producer_factory(),
+        consumer: RowConsumer = row_consumer_factory(),
     ):
         return ChangelogManager(
-            topic_manager=topic_manager_factory(admin=admin), producer=producer
+            topic_manager=topic_manager_factory(admin=admin),
+            producer=producer,
+            consumer=consumer,
         )
 
     return factory
@@ -350,7 +358,66 @@ def state_manager_changelogs(
 
 
 @pytest.fixture()
-def quix_app_factory(random_consumer_group, kafka_container, tmp_path):
+def quix_mock_config_builder_factory(kafka_container):
+    def factory(workspace_id: Optional[str] = None):
+        if not workspace_id:
+            workspace_id = "my_ws"
+        cfg_builder = create_autospec(QuixKafkaConfigsBuilder)
+        cfg_builder._workspace_id = workspace_id
+        cfg_builder.workspace_id = workspace_id
+        cfg_builder.get_confluent_broker_config.side_effect = lambda: {
+            "bootstrap.servers": kafka_container.broker_address
+        }
+        # Slight change to ws stuff in case you pass a blank workspace (which makes
+        #  some things easier
+        cfg_builder.prepend_workspace_id.side_effect = (
+            lambda s: prepend_workspace_id(workspace_id, s) if workspace_id else s
+        )
+        cfg_builder.strip_workspace_id_prefix.side_effect = (
+            lambda s: strip_workspace_id_prefix(workspace_id, s) if workspace_id else s
+        )
+        return cfg_builder
+
+    return factory
+
+
+@pytest.fixture()
+def quix_topic_manager_factory(quix_mock_config_builder_factory, topic_manager_factory):
+    """
+    Allows for creating topics with a test cluster while keeping the workspace aspects
+    """
+
+    def factory(admin: Optional[Admin] = None, workspace_id: Optional[str] = None):
+        topic_manager = topic_manager_factory(admin)
+        quix_topic_manager = topic_manager_factory(admin).Quix(
+            quix_config_builder=quix_mock_config_builder_factory(
+                workspace_id=workspace_id
+            )
+        )
+        quix_topic_manager._create_topics = topic_manager._create_topics
+        patcher = patch.object(quix_topic_manager, "_topic_replication", 1)
+        patcher.start()
+        return quix_topic_manager
+
+    return factory
+
+
+@pytest.fixture()
+def quix_app_factory(
+    random_consumer_group,
+    kafka_container,
+    tmp_path,
+    admin,
+    quix_mock_config_builder_factory,
+    quix_topic_manager_factory,
+):
+    """
+    For doing testing with Application.Quix() against a local cluster.
+
+    Almost all behavior is standard, except the quix_config_builder is mocked out, and
+    thus topic creation is handled with the Admin client.
+    """
+
     def factory(
         auto_offset_reset: AutoOffsetReset = "latest",
         consumer_extra_config: Optional[dict] = None,
@@ -363,27 +430,15 @@ def quix_app_factory(random_consumer_group, kafka_container, tmp_path):
         auto_create_topics: bool = True,
         use_changelog_topics: bool = True,
         topic_validation: Optional[Literal["exists", "required", "all"]] = None,
-        topic_manager: Optional[TopicManager] = None,
         workspace_id: str = "my_ws",
     ) -> Application:
-        cfg_builder = create_autospec(QuixKafkaConfigsBuilder)
-        cfg_builder._workspace_id = workspace_id
-        cfg_builder.workspace_id = workspace_id
-        cfg_builder.get_confluent_broker_config.side_effect = lambda: {
-            "bootstrap.servers": kafka_container.broker_address
-        }
-        cfg_builder.prepend_workspace_id.side_effect = lambda s: prepend_workspace_id(
-            workspace_id, s
-        )
-        cfg_builder.strip_workspace_id_prefix.side_effect = (
-            lambda s: strip_workspace_id_prefix(workspace_id, s)
-        )
         state_dir = state_dir or (tmp_path / "state").absolute()
-
         return Application.Quix(
             consumer_group=random_consumer_group,
             state_dir=state_dir,
-            quix_config_builder=cfg_builder,
+            quix_config_builder=quix_mock_config_builder_factory(
+                workspace_id=workspace_id
+            ),
             auto_offset_reset=auto_offset_reset,
             consumer_extra_config=consumer_extra_config,
             producer_extra_config=producer_extra_config,
@@ -394,7 +449,9 @@ def quix_app_factory(random_consumer_group, kafka_container, tmp_path):
             auto_create_topics=auto_create_topics,
             use_changelog_topics=use_changelog_topics,
             topic_validation=topic_validation,
-            topic_manager=topic_manager,
+            topic_manager=quix_topic_manager_factory(
+                admin=admin, workspace_id=workspace_id
+            ),
         )
 
     return factory
@@ -454,7 +511,6 @@ def topic_manager_topic_factory(topic_manager_admin_factory):
             "value_deserializer": value_deserializer,
             "config": topic_manager.topic_config(num_partitions=partitions),
         }
-        topic_manager = topic_manager_admin_factory()
         topic = topic_manager.topic(
             name, **{k: v for k, v in topic_args.items() if v is not None}
         )

--- a/tests/test_quixstreams/test_models/fixtures.py
+++ b/tests/test_quixstreams/test_models/fixtures.py
@@ -5,7 +5,7 @@ from typing import Mapping, Union, List, Any
 
 import pytest
 
-from .utils import ConfluentKafkaMessageStub
+from ..utils import ConfluentKafkaMessageStub
 
 
 @pytest.fixture()

--- a/tests/test_quixstreams/test_models/test_topics.py
+++ b/tests/test_quixstreams/test_models/test_topics.py
@@ -22,7 +22,8 @@ from quixstreams.models.serializers import (
     SERIALIZERS,
     DESERIALIZERS,
 )
-from .utils import ConfluentKafkaMessageStub, int_to_bytes, float_to_bytes
+from .utils import int_to_bytes, float_to_bytes
+from ..utils import ConfluentKafkaMessageStub
 
 
 class JSONListDeserializer(JSONDeserializer):

--- a/tests/test_quixstreams/test_models/utils.py
+++ b/tests/test_quixstreams/test_models/utils.py
@@ -1,5 +1,4 @@
 import struct
-from typing import Optional, List, Tuple, Union
 
 
 def float_to_bytes(value: float) -> bytes:
@@ -8,65 +7,3 @@ def float_to_bytes(value: float) -> bytes:
 
 def int_to_bytes(value: int) -> bytes:
     return struct.pack(">i", value)
-
-
-class ConfluentKafkaMessageStub:
-    """
-    A stub object to mock `confluent_kafka.Message`.
-
-    Instances of `confluent_kafka.Message` cannot be directly created from Python,
-    see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
-
-    """
-
-    def __init__(
-        self,
-        topic: str = "test",
-        partition: int = 0,
-        offset: int = 0,
-        timestamp: Tuple[int, int] = (1, 123),
-        key: bytes = None,
-        value: bytes = None,
-        headers: Optional[List[Tuple[str, bytes]]] = None,
-        latency: float = None,
-        leader_epoch: int = None,
-    ):
-        self._topic = topic
-        self._partition = partition
-        self._offset = offset
-        self._timestamp = timestamp
-        self._key = key
-        self._value = value
-        self._headers = headers
-        self._latency = latency
-        self._leader_epoch = leader_epoch
-
-    def headers(self, *args, **kwargs) -> Optional[List[Tuple[str, bytes]]]:
-        return self._headers
-
-    def key(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
-        return self._key
-
-    def offset(self, *args, **kwargs) -> int:
-        return self._offset
-
-    def partition(self, *args, **kwargs) -> int:
-        return self._partition
-
-    def timestamp(self, *args, **kwargs) -> (int, int):
-        return self._timestamp
-
-    def topic(self, *args, **kwargs) -> str:
-        return self._topic
-
-    def value(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
-        return self._value
-
-    def latency(self, *args, **kwargs) -> Optional[float]:
-        return self._latency
-
-    def leader_epoch(self, *args, **kwargs) -> Optional[int]:
-        return self._leader_epoch
-
-    def __len__(self) -> int:
-        return len(self._value)

--- a/tests/test_quixstreams/test_state/fixtures.py
+++ b/tests/test_quixstreams/test_state/fixtures.py
@@ -2,10 +2,11 @@ import pytest
 import uuid
 
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import patch, create_autospec
 
-from quixstreams.kafka.admin import Admin
-from quixstreams.state.changelog import ChangelogWriter
+from quixstreams.kafka import Admin, Consumer
+from quixstreams.state.changelog import RecoveryPartition, RecoveryManager
+from quixstreams.state.types import StorePartition
 
 
 @pytest.fixture()
@@ -49,3 +50,23 @@ def changelog_writer_patched(changelog_writer_factory):
 @pytest.fixture()
 def changelog_writer_with_changelog(changelog_writer_factory, admin):
     return changelog_writer_factory(admin=admin)
+
+
+@pytest.fixture()
+def recovery_partition_store_mock(rocksdb_store_factory):
+    topic = str(uuid.uuid4())
+    store = create_autospec(StorePartition)()
+    store.get_changelog_offset.return_value = 15
+    recovery_partition = RecoveryPartition(
+        topic=topic, changelog=f"changelog__{topic}", partition=0, store_partition=store
+    )
+    recovery_partition._changelog_lowwater = 10
+    recovery_partition._changelog_highwater = 20
+    return recovery_partition
+
+
+@pytest.fixture()
+def recovery_manager_mock_consumer():
+    return RecoveryManager(
+        consumer=create_autospec(Consumer)("broker", "group", "latest")
+    )

--- a/tests/test_quixstreams/test_state/test_changelog.py
+++ b/tests/test_quixstreams/test_state/test_changelog.py
@@ -1,9 +1,72 @@
-from unittest.mock import patch
+from unittest.mock import patch, create_autospec, call
 
+import pytest
 import uuid
 
-from quixstreams.state.changelog import ChangelogWriter
+from quixstreams.state.changelog import (
+    ChangelogWriter,
+    RecoveryPartition,
+    ConfluentPartition,
+)
+from quixstreams.state.types import StorePartition
 from quixstreams.topic_manager import BytesTopic
+from ..utils import ConfluentKafkaMessageStub
+
+
+class TestRecoveryPartition:
+    def test_set_watermarks(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.set_watermarks(50, 100)
+        assert recovery_partition._changelog_lowwater == 50
+        assert recovery_partition._changelog_highwater == 100
+
+    def test_needs_recovery(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        assert recovery_partition.needs_recovery
+
+    def test_needs_recovery_caught_up(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.store_partition.get_changelog_offset.return_value = 20
+        assert not recovery_partition_store_mock.needs_recovery
+
+    def test_needs_recovery_no_valid_offsets(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.set_watermarks(100, 100)
+        assert not recovery_partition.needs_recovery
+        assert recovery_partition.needs_offset_update
+
+    def test_recover(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        msg = ConfluentKafkaMessageStub()
+        recovery_partition.recover(msg)
+        recovery_partition.store_partition.recover.assert_called_with(
+            changelog_message=msg
+        )
+
+    def test_update_offset(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        with patch.object(
+            recovery_partition, "OffsetUpdate", spec=recovery_partition.OffsetUpdate
+        ) as offset_update:
+            recovery_partition.update_offset()
+        offset_update.assert_called_with(recovery_partition.offset)
+        assert isinstance(
+            recovery_partition.store_partition.set_changelog_offset.call_args_list[
+                0
+            ].kwargs["changelog_message"],
+            recovery_partition.OffsetUpdate,
+        )
+
+    def test_update_offset_warn(self, recovery_partition_store_mock):
+        recovery_partition = recovery_partition_store_mock
+        recovery_partition.store_partition.get_changelog_offset.return_value = (
+            recovery_partition._changelog_highwater + 1
+        )
+        with patch.object(
+            recovery_partition, "_warn_bad_offset", spec=recovery_partition.OffsetUpdate
+        ) as warn:
+            recovery_partition.update_offset()
+        warn.assert_called()
 
 
 class TestChangelogWriter:
@@ -73,3 +136,547 @@ class TestChangelogManager:
         assert writer._topic == changelog_topic
         assert writer._partition_num == p_num
         assert writer._producer == producer
+
+    def test_assign_partition(self, changelog_manager_mock_recovery):
+        source_topic = "topic_a"
+        suffixes = ["default", "rolling_10s"]
+        partition = 1
+        changelog_manager = changelog_manager_mock_recovery
+        topic_manager = changelog_manager._topic_manager
+        recovery_manager = changelog_manager._recovery_manager
+
+        topic_manager.topic(source_topic)
+        calls = []
+        suffix_partitions = {}
+        changelog_partitions = {}
+        for suffix in suffixes:
+            changelog = topic_manager.changelog_topic(
+                source_topic_name=source_topic, suffix=suffix, consumer_group="group"
+            )
+            suffix_partitions[suffix] = create_autospec(StorePartition)()
+            changelog_partitions[changelog.name] = suffix_partitions[suffix]
+
+        changelog_manager.assign_partition(
+            source_topic_name=source_topic,
+            partition=partition,
+            store_partitions=suffix_partitions,
+        )
+
+        recovery_manager.assign_partitions.assert_called_with(
+            source_topic_name=source_topic,
+            partition=partition,
+            store_partitions=changelog_partitions,
+        )
+
+    def test_revoke_partition(self, changelog_manager_mock_recovery):
+        source_topic = "topic_a"
+        suffixes = ["default", "rolling-10s"]
+        partition = 1
+        changelog_manager = changelog_manager_mock_recovery
+        topic_manager = changelog_manager._topic_manager
+        recovery_manager = changelog_manager._recovery_manager
+
+        topic_manager.topic(source_topic)
+        for s in suffixes:
+            topic_manager.changelog_topic(
+                source_topic_name=source_topic, suffix=s, consumer_group="group"
+            )
+
+        changelog_manager.revoke_partition(
+            source_topic_name=source_topic,
+            partition=partition,
+        )
+        calls = [
+            call(
+                topic=source_topic,
+                partition=partition,
+            )
+        ]
+        recovery_manager.revoke_partitions.assert_has_calls(calls)
+
+    def test_do_recovery(self, changelog_manager_mock_recovery):
+        changelog_manager = changelog_manager_mock_recovery
+        recovery_manager = changelog_manager._recovery_manager
+
+        changelog_manager.do_recovery()
+        recovery_manager.do_recovery.assert_called()
+
+
+class TestRecoveryManager:
+    def test_assign_partitions(self, recovery_manager_mock_consumer):
+        """
+        Assign a topic partition and queue up its respective changelog partitions for
+        assignment.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}"
+        partition_num = 1
+        store_partition = create_autospec(StorePartition)()
+        recovery_manager.assign_partitions(
+            source_topic_name=source_topic,
+            partition=partition_num,
+            store_partitions={changelog: store_partition},
+        )
+
+        assert recovery_manager._recovery_method == recovery_manager._rebalance
+        assert len(recovery_manager._pending_assigns) == 1
+        recovery_partition = recovery_manager._pending_assigns[0]
+        expected_confluent_partition = recovery_partition.topic_partition
+        assert isinstance(recovery_partition, RecoveryPartition)
+        assert recovery_partition.topic == source_topic
+        assert recovery_partition.changelog == changelog
+        assert recovery_partition.partition == partition_num
+        assert recovery_partition.store_partition == store_partition
+
+        assign_call = consumer.incremental_assign.call_args_list[0].args
+        assert len(assign_call) == 1
+        assert isinstance(assign_call[0], list)
+        assert len(assign_call[0]) == 1
+        assert isinstance(assign_call[0][0], ConfluentPartition)
+        assert expected_confluent_partition.topic == assign_call[0][0].topic
+        assert expected_confluent_partition.partition == assign_call[0][0].partition
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert expected_confluent_partition.topic == pause_call[0][0].topic
+        assert expected_confluent_partition.partition == pause_call[0][0].partition
+
+    def test_revoke_partitions(self, recovery_manager_mock_consumer):
+        """
+        Revoke a topic partition and queue up its respective changelog partitions (that
+        are currently recovering) for revoking.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}"
+        partition_num = 1
+        store_partition = create_autospec(StorePartition)()
+        recovery_manager._partitions = {
+            partition_num: {
+                changelog: RecoveryPartition(
+                    topic=source_topic,
+                    changelog=changelog,
+                    partition=partition_num,
+                    store_partition=store_partition,
+                ),
+            }
+        }
+
+        recovery_manager.revoke_partitions(
+            topic=source_topic,
+            partition=partition_num,
+        )
+
+        assert partition_num not in recovery_manager._partitions
+        assert recovery_manager._recovery_method == recovery_manager._rebalance
+        assert len(recovery_manager._pending_revokes) == 1
+        recovery_partition = recovery_manager._pending_revokes[0]
+        assert isinstance(recovery_partition, RecoveryPartition)
+        assert recovery_partition.topic == source_topic
+        assert recovery_partition.changelog == changelog
+        assert recovery_partition.partition == partition_num
+        assert recovery_partition.store_partition == store_partition
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert source_topic == unassign_call[0][0].topic
+        assert partition_num == unassign_call[0][0].partition
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert changelog == pause_call[0][0].topic
+        assert partition_num == pause_call[0][0].partition
+
+    def test_revoke_partition_not_assigned(self, recovery_manager_mock_consumer):
+        """
+        Revoke topic partition while skipping the changelog partition revoke since
+        it was never assigned to begin with (due to not needing recovery).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        partition_num = 1
+
+        recovery_manager.revoke_partitions(
+            topic=source_topic,
+            partition=partition_num,
+        )
+
+        assert recovery_manager._recovery_method == recovery_manager._recover
+        assert len(recovery_manager._pending_revokes) == 0
+        consumer.pause.assert_not_called()
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert source_topic == unassign_call[0][0].topic
+        assert partition_num == unassign_call[0][0].partition
+
+    def test__handle_pending_assigns(self, recovery_manager_mock_consumer):
+        """
+        Two changelog partitions (partition numbers 3 and 7) are pending assignment; p3
+        has no offsets to recover, and p7 does, so only p7 should end up assigned.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_nums = [3, 7]
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition,
+                store_partition=create_autospec(StorePartition)(),
+            )
+            for partition in partition_nums
+        ]
+        side_effects = []
+        for idx, p in enumerate(recovery_manager._pending_assigns):
+            p.store_partition.get_changelog_offset.return_value = 10 * idx
+            side_effects.append((0, 20 * idx))
+        side_effects.reverse()
+        consumer.get_watermark_offsets.side_effect = side_effects
+        not_recover = recovery_manager._pending_assigns[0]
+        should_recover = recovery_manager._pending_assigns[1]
+
+        recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 2
+        for idx, call in enumerate(pause_call[0]):
+            assert isinstance(call, ConfluentPartition)
+            assert source_topic == call.topic
+            assert call.partition == partition_nums[idx]
+
+        assign_call = consumer.incremental_assign.call_args_list[0].args
+        assert len(assign_call) == 1
+        assert isinstance(assign_call[0], list)
+        assert len(assign_call[0]) == 1
+        assert isinstance(assign_call[0][0], ConfluentPartition)
+        assert should_recover.changelog == assign_call[0][0].topic
+        assert should_recover.partition == assign_call[0][0].partition
+        assert should_recover.offset == assign_call[0][0].offset
+
+        assert (
+            recovery_manager._partitions[should_recover.partition][
+                should_recover.changelog
+            ]
+            == should_recover
+        )
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_assigns_no_assigns(self, recovery_manager_mock_consumer):
+        """
+        Handle pending assigns of changelog partitions where none of them actually
+        needed assigning since they were up-to-date.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition_num,
+                store_partition=create_autospec(StorePartition)(),
+            )
+        ]
+        consumer.get_watermark_offsets.side_effect = [(0, 10)]
+        not_recover = recovery_manager._pending_assigns[0]
+        not_recover.store_partition.get_changelog_offset.return_value = 10
+
+        recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert source_topic == pause_call[0][0].topic
+        assert pause_call[0][0].partition == partition_num
+
+        consumer.incremental_assign.assert_not_called()
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_assigns_update_offset(
+        self, recovery_manager_mock_consumer
+    ):
+        """
+        Handle pending assigns of changelog partitions where the partition does not
+        actually need recovery, but instead a simple offset update (due to some
+        processing error, or there being no offset to read).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        recovery_manager._pending_assigns = [
+            RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition_num,
+                store_partition=create_autospec(StorePartition)(),
+            )
+        ]
+        consumer.get_watermark_offsets.side_effect = [(0, 10)]
+        not_recover = recovery_manager._pending_assigns[0]
+        not_recover.store_partition.get_changelog_offset.return_value = 20
+
+        with patch.object(
+            recovery_manager._pending_assigns[0], "update_offset"
+        ) as update_offset:
+            recovery_manager._handle_pending_assigns()
+
+        pause_call = consumer.pause.call_args_list[0].args
+        assert len(pause_call) == 1
+        assert isinstance(pause_call[0], list)
+        assert len(pause_call[0]) == 1
+        assert isinstance(pause_call[0][0], ConfluentPartition)
+        assert source_topic == pause_call[0][0].topic
+        assert pause_call[0][0].partition == partition_num
+
+        consumer.incremental_assign.assert_not_called()
+        update_offset.assert_called()
+        assert not_recover.partition not in recovery_manager._partitions
+        assert not recovery_manager._pending_assigns
+
+    def test__handle_pending_revokes(self, recovery_manager_mock_consumer):
+        """
+        Handle pending revokes of changelog partitions.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 3
+        revoke = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._pending_revokes = [revoke]
+
+        recovery_manager._handle_pending_revokes()
+
+        unassign_call = consumer.incremental_unassign.call_args_list[0].args
+        assert len(unassign_call) == 1
+        assert isinstance(unassign_call[0], list)
+        assert len(unassign_call[0]) == 1
+        assert isinstance(unassign_call[0][0], ConfluentPartition)
+        assert revoke.changelog == unassign_call[0][0].topic
+        assert revoke.partition == unassign_call[0][0].partition
+
+        assert not recovery_manager._pending_revokes
+
+    def test__update_partition_offsets(self, recovery_manager_mock_consumer):
+        """
+        Partition offset updates are handled correctly.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_nums = [3, 7]
+        expected_pending_revokes = []
+        for partition in partition_nums:
+            rp = RecoveryPartition(
+                topic=source_topic,
+                changelog=changelog,
+                partition=partition,
+                store_partition=create_autospec(StorePartition)(),
+            )
+            rp.set_watermarks(0, 20)
+            rp.store_partition.get_changelog_offset.return_value = 18
+            recovery_manager._partitions.setdefault(partition, {})[changelog] = rp
+            expected_pending_revokes += [rp]
+
+        with patch.object(recovery_manager, "_handle_pending_revokes") as handle_revoke:
+            recovery_manager._update_partition_offsets()
+
+        for partition in expected_pending_revokes:
+            partition.store_partition.set_changelog_offset.assert_called()
+        # Confirm the revokes were added to pending successfully, though normally
+        # they'd get handled/removed right after if the method wasn't patched
+        assert recovery_manager._pending_revokes == expected_pending_revokes
+        handle_revoke.assert_called()
+
+    def test__finalize_recovery(self, recovery_manager_mock_consumer):
+        """
+        Finalize recovery, which raises an exception to break out of an Application
+        consume loop.
+
+        In this case, also tests when we have a remaining _partition with some offset
+        issues, updating it to current and revoking it before finishing recovery.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        assignment_result = "assignments"
+        consumer.assignment.return_value = assignment_result
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.set_watermarks(0, 20)
+        rp.store_partition.get_changelog_offset.return_value = 18
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with pytest.raises(recovery_manager.RecoveryComplete):
+            recovery_manager._finalize_recovery()
+
+        consumer.resume.assert_called_with(assignment_result)
+        consumer.incremental_unassign.assert_called()
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts
+        assert not recovery_manager._partitions
+
+    def test__rebalance(self, recovery_manager_mock_consumer):
+        """
+        Handle a rebalance call (as a result of an applicable assign or revoke call).
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        recovery_manager._recovery_method = recovery_manager._rebalance
+        consumer = recovery_manager._consumer
+        consumer.get_watermark_offsets.return_value = (0, 20)
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.store_partition.get_changelog_offset.return_value = 10
+        # just testing that pending assign or revoke is called as expected
+        recovery_manager._pending_assigns = [rp]
+        recovery_manager._pending_revokes = [rp]
+
+        recovery_manager._rebalance()
+
+        consumer.incremental_unassign.assert_called()
+        consumer.incremental_assign.assert_called()
+        assert recovery_manager._recovery_method == recovery_manager._recover
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts
+
+    def test__recover(self, recovery_manager_mock_consumer):
+        """
+        Successfully recover from a changelog message, which is also the last one
+        for the partition, so revoke it afterward.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        highwater = 20
+        partition_num = 1
+        msg = ConfluentKafkaMessageStub(
+            topic=changelog, partition=partition_num, offset=highwater - 1
+        )
+        consumer.poll.return_value = msg
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        rp.set_watermarks(0, highwater)
+        rp.store_partition.get_changelog_offset.return_value = highwater
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        recovery_manager._recover()
+
+        rp.store_partition.recover.assert_called_with(changelog_message=msg)
+        assert not recovery_manager._partitions
+        consumer.incremental_unassign.assert_called()
+
+    def test__recover_no_partitions(self, recovery_manager_mock_consumer):
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            finalize.side_effect = recovery_manager.RecoveryComplete()
+            with pytest.raises(recovery_manager.RecoveryComplete):
+                recovery_manager._recover()
+
+        finalize.assert_called()
+        consumer.poll.assert_not_called()
+
+    def test__recover_empty_poll(self, recovery_manager_mock_consumer):
+        """
+        Handle an empty poll.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        consumer = recovery_manager._consumer
+        consumer.poll.return_value = None
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            recovery_manager._recover()
+
+        assert recovery_manager._polls_remaining == recovery_manager._poll_attempts - 1
+        finalize.assert_not_called()
+        consumer.poll.assert_called()
+        rp.store_partition.recover.assert_not_called()
+
+    def test__recover_last_empty_poll(self, recovery_manager_mock_consumer):
+        """
+        Handle a final empty poll attempt, which ends recovery.
+        """
+        recovery_manager = recovery_manager_mock_consumer
+        recovery_manager._polls_remaining = 1
+        consumer = recovery_manager._consumer
+        consumer.poll.return_value = None
+        source_topic = "source_topic"
+        changelog = f"changelog__{source_topic}__default"
+        partition_num = 1
+        rp = RecoveryPartition(
+            topic=source_topic,
+            changelog=changelog,
+            partition=partition_num,
+            store_partition=create_autospec(StorePartition)(),
+        )
+        recovery_manager._partitions.setdefault(partition_num, {})[changelog] = rp
+
+        with patch.object(recovery_manager, "_finalize_recovery") as finalize:
+            finalize.side_effect = recovery_manager.RecoveryComplete()
+            with pytest.raises(recovery_manager.RecoveryComplete):
+                recovery_manager._recover()
+
+        assert recovery_manager._polls_remaining == 0
+        finalize.assert_called()
+        consumer.poll.assert_called()

--- a/tests/test_quixstreams/test_state/test_changelog.py
+++ b/tests/test_quixstreams/test_state/test_changelog.py
@@ -1,10 +1,8 @@
 from unittest.mock import patch
 
 import uuid
-from quixstreams.state.changelog import (
-    ChangelogManager,
-    ChangelogWriter,
-)
+
+from quixstreams.state.changelog import ChangelogWriter
 from quixstreams.topic_manager import BytesTopic
 
 
@@ -45,11 +43,9 @@ class TestChangelogWriter:
 
 
 class TestChangelogManager:
-    def test_add_changelog(self, topic_manager_factory, row_producer_factory):
-        topic_manager = topic_manager_factory()
-        changelog_manager = ChangelogManager(
-            topic_manager=topic_manager, producer=row_producer_factory()
-        )
+    def test_add_changelog(self, changelog_manager_factory):
+        changelog_manager = changelog_manager_factory()
+        topic_manager = changelog_manager._topic_manager
         kwargs = dict(
             source_topic_name="my_source_topic",
             suffix="my_suffix",
@@ -59,12 +55,10 @@ class TestChangelogManager:
             changelog_manager.add_changelog(**kwargs)
         make_changelog.assert_called_with(**kwargs)
 
-    def test_get_writer(self, topic_manager_factory, row_producer_factory):
-        topic_manager = topic_manager_factory()
+    def test_get_writer(self, row_producer_factory, changelog_manager_factory):
         producer = row_producer_factory()
-        changelog_manager = ChangelogManager(
-            topic_manager=topic_manager, producer=producer
-        )
+        changelog_manager = changelog_manager_factory(producer=producer)
+        topic_manager = changelog_manager._topic_manager
 
         topic_name = "my_topic"
         suffix = "my_suffix"

--- a/tests/test_quixstreams/utils.py
+++ b/tests/test_quixstreams/utils.py
@@ -1,0 +1,63 @@
+from typing import Optional, List, Tuple, Union
+
+
+class ConfluentKafkaMessageStub:
+    """
+    A stub object to mock `confluent_kafka.Message`.
+
+    Instances of `confluent_kafka.Message` cannot be directly created from Python,
+    see https://github.com/confluentinc/confluent-kafka-python/issues/1535.
+
+    """
+
+    def __init__(
+        self,
+        topic: str = "test",
+        partition: int = 0,
+        offset: int = 0,
+        timestamp: Tuple[int, int] = (1, 123),
+        key: bytes = None,
+        value: bytes = None,
+        headers: Optional[List[Tuple[str, bytes]]] = None,
+        latency: float = None,
+        leader_epoch: int = None,
+    ):
+        self._topic = topic
+        self._partition = partition
+        self._offset = offset
+        self._timestamp = timestamp
+        self._key = key
+        self._value = value
+        self._headers = headers
+        self._latency = latency
+        self._leader_epoch = leader_epoch
+
+    def headers(self, *args, **kwargs) -> Optional[List[Tuple[str, bytes]]]:
+        return self._headers
+
+    def key(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+        return self._key
+
+    def offset(self, *args, **kwargs) -> int:
+        return self._offset
+
+    def partition(self, *args, **kwargs) -> int:
+        return self._partition
+
+    def timestamp(self, *args, **kwargs) -> (int, int):
+        return self._timestamp
+
+    def topic(self, *args, **kwargs) -> str:
+        return self._topic
+
+    def value(self, *args, **kwargs) -> Optional[Union[str, bytes]]:
+        return self._value
+
+    def latency(self, *args, **kwargs) -> Optional[float]:
+        return self._latency
+
+    def leader_epoch(self, *args, **kwargs) -> Optional[int]:
+        return self._leader_epoch
+
+    def __len__(self) -> int:
+        return len(self._value)


### PR DESCRIPTION
A PR built on top of the `feature/recovery/changelog-produce-cf` branch.

Has logic to recover from changelog topics by reading from them and updating each underlying state store.