### PR TITLE
Remove need for Application.Quix()

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -658,8 +658,6 @@ class Application:
           is stateful and is running in Quix Cloud
         """
         # Ensure that state management is enabled if application is stateful
-        # and is running in Quix Cloud
-        logger.info("APPLICATION IS CONNECTED TO THE QUIX PLATFORM")
         if self._state_manager.stores:
             check_state_management_enabled()
 

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -91,8 +91,8 @@ class Application:
 
     def __init__(
         self,
-        consumer_group: str = "quixstreams-default",
         broker_address: Optional[str] = None,
+        consumer_group: str = "quixstreams-default",
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
         partitioner: Partitioner = "murmur2",
@@ -160,10 +160,15 @@ class Application:
         :param on_producer_error: triggered when RowProducer fails to serialize
             or to produce a message to Kafka.
         """
-
+        broker_address = broker_address or environ.get("QUIXSTREAMS_BROKER_ADDRESS")
         configure_logging(loglevel=loglevel)
         self._quix_config_builder = None
         if self.is_quix_app:
+            if broker_address is not None:
+                raise ValueError(
+                    "Cannot provide a 'broker_address' when "
+                    "'Quix__Sdk__Token' is also defined in environment"
+                )
             quix_config_builder = QuixKafkaConfigsBuilder()
             self._topic_manager_class = lambda **kwargs: QuixTopicManager(
                 **kwargs, quix_config_builder=quix_config_builder

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1,10 +1,11 @@
 import contextlib
 import logging
 import signal
+
+from os import environ
 from typing import Optional, List, Callable
 
 from confluent_kafka import TopicPartition
-from typing_extensions import Self
 
 from .context import set_message_context, copy_context
 from .core.stream import Filtered
@@ -90,8 +91,8 @@ class Application:
 
     def __init__(
         self,
-        broker_address: str,
         consumer_group: str = "quixstreams-default",
+        broker_address: Optional[str] = None,
         auto_offset_reset: AutoOffsetReset = "latest",
         auto_commit_enable: bool = True,
         partitioner: Partitioner = "murmur2",
@@ -159,7 +160,32 @@ class Application:
         :param on_producer_error: triggered when RowProducer fails to serialize
             or to produce a message to Kafka.
         """
+
         configure_logging(loglevel=loglevel)
+        self._quix_config_builder = None
+        if self.is_quix_app:
+            quix_config_builder = QuixKafkaConfigsBuilder()
+            self._topic_manager_class = lambda **kwargs: QuixTopicManager(
+                **kwargs, quix_config_builder=quix_config_builder
+            )
+            quix_configs = quix_config_builder.get_confluent_broker_config()
+
+            # Check if the state dir points to the mounted PVC while running on Quix
+            # Otherwise, the state won't be shared and replicas won't be able to
+            # recover the same state.
+            check_state_dir(state_dir=state_dir)
+
+            broker_address = quix_configs.pop("bootstrap.servers")
+            # Quix platform prefixes consumer group with workspace id
+            consumer_group = quix_config_builder.prepend_workspace_id(consumer_group)
+            consumer_extra_config = {**quix_configs, **(consumer_extra_config or {})}
+            producer_extra_config = {**quix_configs, **(producer_extra_config or {})}
+            self._set_quix_config_builder(quix_config_builder)
+        else:
+            self._topic_manager_class = TopicManager
+            if broker_address is None:
+                raise ValueError("A 'broker_address' must be provided")
+
         self._broker_address = broker_address
         self._consumer_group = consumer_group
         self._auto_offset_reset = auto_offset_reset
@@ -194,7 +220,7 @@ class Application:
         self._do_recovery_check = False
 
         if not topic_manager:
-            topic_manager = TopicManager(
+            topic_manager = self._topic_manager_class(
                 topic_admin=TopicAdmin(
                     broker_address=broker_address,
                     extra_config=producer_extra_config,
@@ -229,165 +255,9 @@ class Application:
     def _set_quix_config_builder(self, config_builder: QuixKafkaConfigsBuilder):
         self._quix_config_builder = config_builder
 
-    @classmethod
-    def Quix(
-        cls,
-        consumer_group: str = "quixstreams-default",
-        auto_offset_reset: AutoOffsetReset = "latest",
-        auto_commit_enable: bool = True,
-        partitioner: Partitioner = "murmur2",
-        consumer_extra_config: Optional[dict] = None,
-        producer_extra_config: Optional[dict] = None,
-        state_dir: str = "state",
-        rocksdb_options: Optional[RocksDBOptionsType] = None,
-        on_consumer_error: Optional[ConsumerErrorCallback] = None,
-        on_processing_error: Optional[ProcessingErrorCallback] = None,
-        on_producer_error: Optional[ProducerErrorCallback] = None,
-        on_message_processed: Optional[MessageProcessedCallback] = None,
-        consumer_poll_timeout: float = 1.0,
-        producer_poll_timeout: float = 0.0,
-        loglevel: Optional[LogLevel] = "INFO",
-        quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None,
-        auto_create_topics: bool = True,
-        use_changelog_topics: bool = True,
-        topic_manager: Optional[QuixTopicManager] = None,
-    ) -> Self:
-        """
-        Initialize an Application to work with Quix platform,
-        assuming environment is properly configured (by default in the platform).
-
-        It takes the credentials from the environment and configures consumer and
-        producer to properly connect to the Quix platform.
-
-        >***NOTE:*** Quix platform requires `consumer_group` and topic names to be
-            prefixed with workspace id.
-            If the application is created via `Application.Quix()`, the real consumer
-            group will be `<workspace_id>-<consumer_group>`,
-            and the real topic names will be `<workspace_id>-<topic_name>`.
-
-
-
-        Example Snippet:
-
-        ```python
-        from quixstreams import Application
-
-        # Set up an `app = Application.Quix` and `sdf = StreamingDataFrame`;
-        # add some operations to `sdf` and then run everything. Also shows off how to
-        # use the quix-specific serializers and deserializers.
-
-        app = Application.Quix()
-        input_topic = app.topic("topic-in", value_deserializer="quix")
-        output_topic = app.topic("topic-out", value_serializer="quix_timeseries")
-        df = app.dataframe(topic_in)
-        df = df.to_topic(output_topic)
-
-        app.run(dataframe=df)
-        ```
-
-        :param consumer_group: Kafka consumer group.
-            Passed as `group.id` to `confluent_kafka.Consumer`.
-            Default - "quixstreams-default".
-              >***NOTE:*** The consumer group will be prefixed by Quix workspace id.
-        :param auto_offset_reset: Consumer `auto.offset.reset` setting
-        :param auto_commit_enable: If true, periodically commit offset of
-            the last message handed to the application. Default - `True`.
-        :param partitioner: A function to be used to determine the outgoing message
-            partition.
-        :param consumer_extra_config: A dictionary with additional options that
-            will be passed to `confluent_kafka.Consumer` as is.
-        :param producer_extra_config: A dictionary with additional options that
-            will be passed to `confluent_kafka.Producer` as is.
-        :param state_dir: path to the application state directory.
-            Default - ".state".
-        :param rocksdb_options: RocksDB options.
-            If `None`, the default options will be used.
-        :param consumer_poll_timeout: timeout for `RowConsumer.poll()`. Default - 1.0s
-        :param producer_poll_timeout: timeout for `RowProducer.poll()`. Default - 0s.
-        :param on_message_processed: a callback triggered when message is successfully
-            processed.
-        :param loglevel: a log level for "quixstreams" logger.
-            Should be a string or None.
-            If `None` is passed, no logging will be configured.
-            You may pass `None` and configure "quixstreams" logger
-            externally using `logging` library.
-            Default - "INFO".
-        :param auto_create_topics: Create all `Topic`s made via Application.topic()
-            Default - `True`
-        :param use_changelog_topics: Use changelog topics to back stateful operations
-            Default - `True`
-        :param topic_manager: A QuixTopicManager instance
-
-        ***Error Handlers***
-
-        To handle errors, `Application` accepts callbacks triggered when
-            exceptions occur on different stages of stream processing. If the callback
-            returns `True`, the exception will be ignored. Otherwise, the exception
-            will be propagated and the processing will eventually stop.
-        :param on_consumer_error: triggered when internal `RowConsumer` fails to poll
-            Kafka or cannot deserialize a message.
-        :param on_processing_error: triggered when exception is raised within
-            `StreamingDataFrame.process()`.
-        :param on_producer_error: triggered when RowProducer fails to serialize
-            or to produce a message to Kafka.
-
-
-        ***Quix-specific Parameters***
-
-        :param quix_config_builder: instance of `QuixKafkaConfigsBuilder` to be used
-            instead of the default one.
-
-        :return: `Application` object
-        """
-        configure_logging(loglevel=loglevel)
-        quix_config_builder = quix_config_builder or QuixKafkaConfigsBuilder()
-        quix_configs = quix_config_builder.get_confluent_broker_config()
-
-        # Check if the state dir points to the mounted PVC while running on Quix
-        # Otherwise, the state won't be shared and replicas won't be able to
-        # recover the same state.
-        check_state_dir(state_dir=state_dir)
-
-        broker_address = quix_configs.pop("bootstrap.servers")
-        # Quix platform prefixes consumer group with workspace id
-        consumer_group = quix_config_builder.prepend_workspace_id(consumer_group)
-        consumer_extra_config = {**quix_configs, **(consumer_extra_config or {})}
-        producer_extra_config = {**quix_configs, **(producer_extra_config or {})}
-
-        if topic_manager is None:
-            topic_admin = TopicAdmin(
-                broker_address=broker_address,
-                extra_config=producer_extra_config,
-            )
-            topic_manager = QuixTopicManager(
-                topic_admin=topic_admin, quix_config_builder=quix_config_builder
-            )
-        app = cls(
-            broker_address=broker_address,
-            consumer_group=consumer_group,
-            consumer_extra_config=consumer_extra_config,
-            producer_extra_config=producer_extra_config,
-            auto_offset_reset=auto_offset_reset,
-            auto_commit_enable=auto_commit_enable,
-            partitioner=partitioner,
-            on_consumer_error=on_consumer_error,
-            on_processing_error=on_processing_error,
-            on_producer_error=on_producer_error,
-            on_message_processed=on_message_processed,
-            consumer_poll_timeout=consumer_poll_timeout,
-            producer_poll_timeout=producer_poll_timeout,
-            state_dir=state_dir,
-            rocksdb_options=rocksdb_options,
-            auto_create_topics=auto_create_topics,
-            use_changelog_topics=use_changelog_topics,
-            topic_manager=topic_manager,
-        )
-        app._set_quix_config_builder(quix_config_builder)
-        return app
-
     @property
     def is_quix_app(self) -> bool:
-        return self._quix_config_builder is not None
+        return environ.get("Quix__Sdk__Token") is not None
 
     def topic(
         self,

--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -160,9 +160,9 @@ class Application:
         :param on_producer_error: triggered when RowProducer fails to serialize
             or to produce a message to Kafka.
         """
-        broker_address = broker_address or environ.get("QUIXSTREAMS_BROKER_ADDRESS")
         configure_logging(loglevel=loglevel)
-        self._quix_config_builder = None
+
+        broker_address = broker_address or environ.get("QUIXSTREAMS_BROKER_ADDRESS")
         if self.is_quix_app:
             if broker_address is not None:
                 raise ValueError(
@@ -185,7 +185,6 @@ class Application:
             consumer_group = quix_config_builder.prepend_workspace_id(consumer_group)
             consumer_extra_config = {**quix_configs, **(consumer_extra_config or {})}
             producer_extra_config = {**quix_configs, **(producer_extra_config or {})}
-            self._set_quix_config_builder(quix_config_builder)
         else:
             self._topic_manager_class = TopicManager
             if broker_address is None:
@@ -220,7 +219,6 @@ class Application:
         self._running = False
         self._on_processing_error = on_processing_error or default_on_processing_error
         self._on_message_processed = on_message_processed
-        self._quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None
         self._auto_create_topics = auto_create_topics
         self._do_recovery_check = False
 
@@ -256,9 +254,6 @@ class Application:
                 else None
             ),
         )
-
-    def _set_quix_config_builder(self, config_builder: QuixKafkaConfigsBuilder):
-        self._quix_config_builder = config_builder
 
     @property
     def is_quix_app(self) -> bool:

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -28,15 +28,15 @@ class QuixPortalApiService:
 
     def __init__(
         self,
+        auth_token: str,
         portal_api: Optional[str] = None,
-        auth_token: Optional[str] = None,
         api_version: Optional[str] = None,
         default_workspace_id: Optional[str] = None,
     ):
+        self._auth_token = auth_token
         self._portal_api = (
             portal_api or QUIX_ENVIRONMENT.portal_api or DEFAULT_PORTAL_API_URL
         )
-        self._auth_token = auth_token or QUIX_ENVIRONMENT.sdk_token
         self._default_workspace_id = (
             default_workspace_id or QUIX_ENVIRONMENT.workspace_id
         )
@@ -69,14 +69,6 @@ class QuixPortalApiService:
         self._default_workspace_id = value
 
     def _init_session(self) -> SessionWithUrlBase:
-        if not (self._portal_api and self._auth_token):
-            missing = filter(
-                None,
-                [self._portal_api or "portal_api", self._auth_token or "auth_token"],
-            )
-            raise self.MissingConnectionRequirements(
-                f"Using the API requires a portal and token. Missing: {missing}"
-            )
         s = self.SessionWithUrlBase(self._portal_api)
         s.hooks = {"response": lambda r, *args, **kwargs: r.raise_for_status()}
         s.headers.update(

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -99,18 +99,27 @@ class QuixKafkaConfigsBuilder:
     # TODO: Consider a workspace class?
     def __init__(
         self,
-        quix_portal_api_service: Optional[QuixPortalApiService] = None,
+        quix_sdk_token: Optional[str] = None,
         workspace_id: Optional[str] = None,
         workspace_cert_path: Optional[str] = None,
+        quix_portal_api_service: Optional[QuixPortalApiService] = None,
     ):
         """
         :param quix_portal_api_service: A QuixPortalApiService instance (else generated)
         :param workspace_id: A valid Quix Workspace ID (else searched for)
         :param workspace_cert_path: path to an existing workspace cert (else retrieved)
         """
-        self.api = quix_portal_api_service or QuixPortalApiService(
-            default_workspace_id=workspace_id
-        )
+        if quix_sdk_token:
+            self.api = QuixPortalApiService(
+                default_workspace_id=workspace_id, auth_token=quix_sdk_token
+            )
+        elif quix_portal_api_service:
+            self.api = quix_portal_api_service
+        else:
+            raise ValueError(
+                'Either "quix_sdk_token" or "quix_portal_api_service" must be provided'
+            )
+
         try:
             self._workspace_id = workspace_id or self.api.default_workspace_id
         except self.api.UndefinedQuixWorkspaceId:

--- a/quixstreams/platforms/quix/env.py
+++ b/quixstreams/platforms/quix/env.py
@@ -53,14 +53,6 @@ class QuixEnvironment:
         return os.environ.get(self.PORTAL_API)
 
     @property
-    def sdk_token(self) -> Optional[str]:
-        """
-        Return Quix SDK token if set
-        :return: sdk token or None
-        """
-        return os.environ.get(self.SDK_TOKEN)
-
-    @property
     def state_dir(self) -> str:
         """
         Return application state directory on Quix.

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List
 
 from quixstreams.models.topics import TopicManager, TopicAdmin, Topic
 from .config import QuixKafkaConfigsBuilder
@@ -30,8 +30,8 @@ class QuixTopicManager(TopicManager):
     def __init__(
         self,
         topic_admin: TopicAdmin,
+        quix_config_builder: QuixKafkaConfigsBuilder,
         create_timeout: int = 60,
-        quix_config_builder: Optional[QuixKafkaConfigsBuilder] = None,
     ):
         """
         :param topic_admin: an `Admin` instance
@@ -40,7 +40,7 @@ class QuixTopicManager(TopicManager):
             generated for you.
         """
         super().__init__(create_timeout=create_timeout, topic_admin=topic_admin)
-        self._quix_config_builder = quix_config_builder or QuixKafkaConfigsBuilder()
+        self._quix_config_builder = quix_config_builder
 
     def _create_topics(self, topics: List[Topic]):
         """

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -455,8 +455,8 @@ class TestQuixApplication:
         Topic names created from Quix apps are prefixed by the workspace id
         Topic config has provided values else defaults
         """
-        app = quix_app_factory()
-        builder = app._quix_config_builder
+        workspace_id = "my-workspace"
+        app = quix_app_factory(workspace_id=workspace_id)
         topic_manager = app._topic_manager
 
         initial_topic_name = "input_topic"
@@ -465,7 +465,7 @@ class TestQuixApplication:
             initial_topic_name,
             config=topic_manager.topic_config(num_partitions=topic_partitions),
         )
-        expected_name = f"{builder.workspace_id}-{initial_topic_name}"
+        expected_name = f"{workspace_id}-{initial_topic_name}"
         expected_topic = topic_manager.topics[expected_name]
         assert topic.name == expected_name
         assert expected_name in topic_manager.topics
@@ -528,7 +528,8 @@ class TestQuixApplication:
             executor.submit(_stop_app_on_timeout, app, 10.0)
             app.run(sdf)
 
-        warning = str(warned.list[0].message)
+        warnings = [w for w in warned.list if w.category is RuntimeWarning]
+        warning = str(warnings[0].message)
         assert "State Management feature is disabled" in warning
 
     def test_quix_app_stateful_quix_deployment_state_dir_mismatch_warning(
@@ -545,8 +546,8 @@ class TestQuixApplication:
         )
         with pytest.warns(RuntimeWarning) as warned:
             quix_app_factory()
-
-        warning = str(warned.list[0].message)
+        warnings = [w for w in warned.list if w.category is RuntimeWarning]
+        warning = str(warnings[0].message)
         assert "does not match the state directory" in warning
 
 


### PR DESCRIPTION
`Application` now can be used as a Quix application WITHOUT `Application.Quix()`:
- use the NEW `quix_sdk_token` argument (or set the same environment variable as before, `Quix__Sdk__Token`) to generate the same behavior as `Application.Quix()`
-  `broker_address` is now  "optional" to enable this behavior
    - `quix_sdk_token`  and `broker_address` are required, exclusive OR's:  only one MUST be set.
- `Application.Quix()` will be deprecated some time in the future


Added Deprecation warning to `Application.Quix()`
- Kept the old tests around (including fixtures...renamed them to not clash) but they are ready to be deleted after we remove it
- It will continue to work as before if you are currently using it, but we recommend changing to `Application` now.


Added new env vars, which maps to the following Application args:
- `Quix__Broker__Address` - `broker_address`
- `Quix__Consumer__Group` - `consumer_group`