### PR TITLE
Bugfix: better handle Quix "External" topics

### DIFF
--- a/quixstreams/models/topics/manager.py
+++ b/quixstreams/models/topics/manager.py
@@ -84,13 +84,11 @@ class TopicManager:
     def all_topics(self) -> List[Topic]:
         return self.topics_list + self.changelog_topics_list
 
-    def _apply_topic_prefix(self, name: str) -> str:
+    def _resolve_topic_name(self, name: str) -> str:
         """
-        Apply a prefix to the given name, or return if it already contains it.
+        Here primarily for adjusting the topic name for Quix topics.
 
-        :param name: topic name
-
-        :return: name with prefix added as required
+        :return: name, no changes (identity function)
         """
         return name
 
@@ -164,7 +162,7 @@ class TopicManager:
 
         :return: Topic object with creation configs
         """
-        name = self._apply_topic_prefix(name)
+        name = self._resolve_topic_name(name)
         if len(name) > self._max_topic_name_len:
             raise TopicNameLengthExceeded(
                 f"Topic {name} exceeds the {self._max_topic_name_len} character limit"
@@ -220,7 +218,7 @@ class TopicManager:
         :return: `Topic` object (which is also stored on the TopicManager)
         """
 
-        topic_name = self._apply_topic_prefix(topic_name)
+        topic_name = self._resolve_topic_name(topic_name)
         name = self._format_changelog_name(consumer_group, topic_name, store_name)
         if len(name) > self._max_topic_name_len:
             raise TopicNameLengthExceeded(

--- a/quixstreams/platforms/quix/api.py
+++ b/quixstreams/platforms/quix/api.py
@@ -88,17 +88,15 @@ class QuixPortalApiService:
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
             try:
-                reason_text = e.response.json()
+                error_text = e.response.json()
             except requests.exceptions.JSONDecodeError:
-                reason_text = e.response.text
+                error_text = e.response.text
 
-            if reason_text:
-                e = (
-                    f'Error {e.response.status_code} for url "{e.response.url}": '
-                    f"{reason_text}"
-                )
-
-            raise QuixApiRequestFailure(e)
+            raise QuixApiRequestFailure(
+                status_code=e.response.status_code,
+                url=e.response.url,
+                error_text=error_text,
+            )
 
     def _init_session(self) -> SessionWithUrlBase:
         s = self.SessionWithUrlBase(self._portal_api)

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -434,7 +434,7 @@ class QuixKafkaConfigsBuilder:
             return self.api.get_topic(topic_name, workspace_id=self.workspace_id)
         except QuixApiRequestFailure as e:
             if e.status_code == 404:
-                return None
+                return
             raise
 
     def get_topics(self) -> List[dict]:

--- a/quixstreams/platforms/quix/config.py
+++ b/quixstreams/platforms/quix/config.py
@@ -422,10 +422,13 @@ class QuixKafkaConfigsBuilder:
         """
         return the topic ID (the actual cluster topic name) if it exists, else None
 
-        >NOTE: if the name registered in Quix is instead the workspace-prefixed version,
-        this returns None unless that exact name was created WITHOUT the Quix API.
+        >***NOTE***: if the name registered in Quix is instead the workspace-prefixed
+        version, this returns None unless that exact name was created WITHOUT the
+        Quix API.
 
         :param topic_name: name of the topic
+
+        :return: response dict of the topic info if topic found, else None
         """
         try:
             return self.api.get_topic(topic_name, workspace_id=self.workspace_id)

--- a/quixstreams/platforms/quix/exceptions.py
+++ b/quixstreams/platforms/quix/exceptions.py
@@ -26,7 +26,7 @@ class QuixApiRequestFailure(QuixException):
         self.url = url
         self.error_text = error_text
 
-    def __str__(self):
+    def __str__(self) -> str:
         str_out = f'Error {self.status_code} for url "{self.url}"'
         if self.error_text is not None:
             str_out = f"{str_out}: {self.error_text}"

--- a/quixstreams/platforms/quix/exceptions.py
+++ b/quixstreams/platforms/quix/exceptions.py
@@ -1,5 +1,6 @@
-from quixstreams.exceptions.base import QuixException
+from typing import Optional
 
+from quixstreams.exceptions.base import QuixException
 
 __all__ = (
     "MissingConnectionRequirements",
@@ -14,7 +15,22 @@ class MissingConnectionRequirements(QuixException): ...
 class UndefinedQuixWorkspaceId(QuixException): ...
 
 
-class QuixApiRequestFailure(QuixException): ...
+class QuixApiRequestFailure(QuixException):
+    def __init__(
+        self,
+        status_code: int,
+        url: str,
+        error_text: Optional[object] = None,
+    ):
+        self.status_code = status_code
+        self.url = url
+        self.error_text = error_text
+
+    def __str__(self):
+        str_out = f'Error {self.status_code} for url "{self.url}"'
+        if self.error_text is not None:
+            str_out = f"{str_out}: {self.error_text}"
+        return str_out
 
 
 class NoWorkspaceFound(QuixException): ...

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -55,13 +55,15 @@ class QuixTopicManager(TopicManager):
 
     def _apply_topic_prefix(self, name: str) -> str:
         """
-        Prepend workspace ID to a given topic name
+        Prepend workspace ID to a given topic name, if required.
 
         :param name: topic name
 
         :return: name with workspace ID prepended
         """
-        return self._quix_config_builder.get_topic_id(name)
+        if quix_topic := self._quix_config_builder.get_topic(name):
+            return quix_topic["id"]
+        return self._quix_config_builder.prepend_workspace_id(name)
 
     def _format_changelog_name(
         self, consumer_group: str, topic_name: str, store_name: str

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -53,13 +53,18 @@ class QuixTopicManager(TopicManager):
             topics, finalize_timeout_seconds=self._create_timeout
         )
 
-    def _apply_topic_prefix(self, name: str) -> str:
+    def _resolve_topic_name(self, name: str) -> str:
         """
-        Prepend workspace ID to a given topic name, if required.
+        Checks if provided topic name is registered via Quix API; if yes,
+        return its corresponding topic ID (AKA the actual topic name, usually
+        just has prepended workspace ID).
+
+        Otherwise, assume it doesn't exist and prepend the workspace ID to match the
+        topic naming pattern in Quix.
 
         :param name: topic name
 
-        :return: name with workspace ID prepended
+        :return: actual cluster topic name to use
         """
         if quix_topic := self._quix_config_builder.get_topic(name):
             return quix_topic["id"]

--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -61,7 +61,7 @@ class QuixTopicManager(TopicManager):
 
         :return: name with workspace ID prepended
         """
-        return self._quix_config_builder.prepend_workspace_id(name)
+        return self._quix_config_builder.get_topic_id(name)
 
     def _format_changelog_name(
         self, consumer_group: str, topic_name: str, store_name: str

--- a/tests/test_quixstreams/test_app.py
+++ b/tests/test_quixstreams/test_app.py
@@ -598,9 +598,11 @@ class TestQuixApplication:
         error_str = "Cannot provide both broker address and Quix SDK Token"
         assert error_str in e_info.value.args
 
-    def test_topic_name_and_config(self, quix_app_factory):
+    def test_topic_name_and_config(
+        self, quix_app_factory, quix_mock_config_builder_factory
+    ):
         """
-        Topic names created from Quix apps are prefixed by the workspace id
+        Topic names created with Quix API have workspace id prefixed
         Topic config has provided values else defaults
         """
         workspace_id = "my-workspace"

--- a/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
@@ -37,20 +37,8 @@ class MockResponse:
 
 
 @pytest.fixture()
-def mock_quix_portal_api_factory():
-    def mock_quix_portal_api():
-        api_obj = create_autospec(QuixPortalApiService)
-        api_obj.default_workspace_id = None
-        return api_obj
-
-    return mock_quix_portal_api
-
-
-@pytest.fixture()
-def quix_kafka_config_factory(mock_quix_portal_api_factory):
+def quix_kafka_config_factory():
     def mock_quix_kafka_configs(workspace_id: str = None, api_class=None, **kwargs):
-        if not api_class:
-            api_class = mock_quix_portal_api_factory()
         return QuixKafkaConfigsBuilder(
             quix_portal_api_service=api_class, workspace_id=workspace_id, **kwargs
         )

--- a/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
@@ -37,15 +37,5 @@ class MockResponse:
 
 
 @pytest.fixture()
-def quix_kafka_config_factory():
-    def mock_quix_kafka_configs(workspace_id: str = None, api_class=None, **kwargs):
-        return QuixKafkaConfigsBuilder(
-            quix_portal_api_service=api_class, workspace_id=workspace_id, **kwargs
-        )
-
-    return mock_quix_kafka_configs
-
-
-@pytest.fixture()
 def mock_response_factory():
     return MockResponse

--- a/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
@@ -43,8 +43,11 @@ def mock_quix_portal_api_factory():
             api_responses = {}
         api_obj = create_autospec(QuixPortalApiService)
         api_obj.default_workspace_id = None
-        for call, data in api_responses.items():
-            api_obj.__getattribute__(call).return_value = data
+        for call, result in api_responses.items():
+            if isinstance(result, Exception):
+                api_obj.__getattribute__(call).side_effect = result
+            else:
+                api_obj.__getattribute__(call).return_value = result
         return api_obj
 
     return mock_quix_portal_api

--- a/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/fixtures.py
@@ -38,16 +38,9 @@ class MockResponse:
 
 @pytest.fixture()
 def mock_quix_portal_api_factory():
-    def mock_quix_portal_api(api_responses: dict = None):
-        if not api_responses:
-            api_responses = {}
+    def mock_quix_portal_api():
         api_obj = create_autospec(QuixPortalApiService)
         api_obj.default_workspace_id = None
-        for call, result in api_responses.items():
-            if isinstance(result, Exception):
-                api_obj.__getattribute__(call).side_effect = result
-            else:
-                api_obj.__getattribute__(call).return_value = result
         return api_obj
 
     return mock_quix_portal_api
@@ -55,11 +48,9 @@ def mock_quix_portal_api_factory():
 
 @pytest.fixture()
 def quix_kafka_config_factory(mock_quix_portal_api_factory):
-    def mock_quix_kafka_configs(
-        workspace_id: str = None, api_responses: dict = None, api_class=None, **kwargs
-    ):
+    def mock_quix_kafka_configs(workspace_id: str = None, api_class=None, **kwargs):
         if not api_class:
-            api_class = mock_quix_portal_api_factory(api_responses)
+            api_class = mock_quix_portal_api_factory()
         return QuixKafkaConfigsBuilder(
             quix_portal_api_service=api_class, workspace_id=workspace_id, **kwargs
         )

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -30,10 +30,10 @@ class TestQuixKafkaConfigsBuilder:
     def test_search_for_workspace_id(self, quix_kafka_config_factory):
         api_data_stub = {"workspaceId": "myworkspace12345", "name": "my workspace"}
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspace.return_value = api_data_stub
 
-        result = cfg_factory.search_for_workspace("my workspace")
+        result = cfg_builder.search_for_workspace("my workspace")
         api.get_workspace.assert_called()
         assert result == api_data_stub
 
@@ -44,11 +44,11 @@ class TestQuixKafkaConfigsBuilder:
             {"workspaceId": "myotherworkspace67890", "name": "my other workspace"},
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspaces.return_value = api_data_stub
         api.get_workspace.side_effect = HTTPError
 
-        result = cfg_factory.search_for_workspace("my workspace")
+        result = cfg_builder.search_for_workspace("my workspace")
         api.get_workspace.assert_called_with(workspace_id="my workspace")
         api.get_workspaces.assert_called()
         assert result == matching_ws
@@ -79,17 +79,17 @@ class TestQuixKafkaConfigsBuilder:
             "branchProtected": False,
         }
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         with patch.object(
-            cfg_factory, "search_for_workspace", return_value=deepcopy(api_data)
+            cfg_builder, "search_for_workspace", return_value=deepcopy(api_data)
         ) as get_ws:
-            cfg_factory.get_workspace_info()
+            cfg_builder.get_workspace_info()
 
-        get_ws.assert_called_with(workspace_name_or_id=cfg_factory.workspace_id)
-        assert cfg_factory.workspace_id == api_data["workspaceId"]
-        assert cfg_factory.quix_broker_config == api_data["broker"]
-        assert cfg_factory.quix_broker_settings == api_data["brokerSettings"]
-        assert cfg_factory.workspace_meta == {
+        get_ws.assert_called_with(workspace_name_or_id=cfg_builder.workspace_id)
+        assert cfg_builder.workspace_id == api_data["workspaceId"]
+        assert cfg_builder.quix_broker_config == api_data["broker"]
+        assert cfg_builder.quix_broker_settings == api_data["brokerSettings"]
+        assert cfg_builder.workspace_meta == {
             "name": "12345",
             "status": "Ready",
             "brokerType": "SharedKafka",
@@ -106,12 +106,12 @@ class TestQuixKafkaConfigsBuilder:
     def test_get_workspace_info_no_wid_not_found(self, quix_kafka_config_factory):
         api_data_stub = []
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspace.return_value = api_data_stub
 
         with pytest.raises(NoWorkspaceFound):
-            cfg_factory.get_workspace_info()
-        api.get_workspace.assert_called_with(cfg_factory.workspace_id)
+            cfg_builder.get_workspace_info()
+        api.get_workspace.assert_called_with(cfg_builder.workspace_id)
 
     def test_get_workspace_info_no_wid_one_ws(self, quix_kafka_config_factory):
         api_data_stub = {
@@ -140,18 +140,18 @@ class TestQuixKafkaConfigsBuilder:
         }
         api = create_autospec(QuixPortalApiService)
         api.default_workspace_id = None
-        cfg_factory = quix_kafka_config_factory(api_class=api)
+        cfg_builder = quix_kafka_config_factory(api_class=api)
         with patch.object(
-            cfg_factory,
+            cfg_builder,
             "search_for_topic_workspace",
             return_value=deepcopy(api_data_stub),
         ) as search:
-            cfg_factory.get_workspace_info(known_workspace_topic="a_topic")
+            cfg_builder.get_workspace_info(known_workspace_topic="a_topic")
             search.assert_called_with("a_topic")
-        assert cfg_factory.workspace_id == api_data_stub["workspaceId"]
-        assert cfg_factory.quix_broker_config == api_data_stub["broker"]
-        assert cfg_factory.quix_broker_settings == api_data_stub["brokerSettings"]
-        assert cfg_factory.workspace_meta == {
+        assert cfg_builder.workspace_id == api_data_stub["workspaceId"]
+        assert cfg_builder.quix_broker_config == api_data_stub["broker"]
+        assert cfg_builder.quix_broker_settings == api_data_stub["brokerSettings"]
+        assert cfg_builder.workspace_meta == {
             "name": "12345",
             "status": "Ready",
             "brokerType": "SharedKafka",
@@ -189,21 +189,21 @@ class TestQuixKafkaConfigsBuilder:
         }
         api = create_autospec(QuixPortalApiService)
         api.default_workspace_id = None
-        cfg_factory = quix_kafka_config_factory(api_class=api)
+        cfg_builder = quix_kafka_config_factory(api_class=api)
         with patch.object(
-            cfg_factory,
+            cfg_builder,
             "search_for_topic_workspace",
             return_value=deepcopy(api_data_stub),
         ) as search:
-            cfg_factory.get_workspace_info(known_workspace_topic="a_topic")
+            cfg_builder.get_workspace_info(known_workspace_topic="a_topic")
             search.assert_called_with("a_topic")
-        assert cfg_factory.workspace_id == api_data_stub["workspaceId"]
-        assert cfg_factory.quix_broker_config == api_data_stub["broker"]
-        assert cfg_factory.quix_broker_settings == {
+        assert cfg_builder.workspace_id == api_data_stub["workspaceId"]
+        assert cfg_builder.quix_broker_config == api_data_stub["broker"]
+        assert cfg_builder.quix_broker_settings == {
             "brokerType": "SharedKafka",
             "syncTopics": False,
         }
-        assert cfg_factory.workspace_meta == {
+        assert cfg_builder.workspace_meta == {
             "name": "12345",
             "status": "Ready",
             "brokerType": "SharedKafka",
@@ -230,11 +230,11 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspaces.return_value = api_data_stub
 
         with pytest.raises(MultipleWorkspaces):
-            cfg_factory.search_for_topic_workspace(None)
+            cfg_builder.search_for_topic_workspace(None)
         api.get_workspaces.assert_called()
 
     def test_search_for_topic_workspace_no_match(self, quix_kafka_config_factory):
@@ -253,13 +253,13 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspaces.return_value = api_data_stub
 
         with patch.object(
-            cfg_factory, "search_workspace_for_topic", return_value=None
+            cfg_builder, "search_workspace_for_topic", return_value=None
         ) as search:
-            cfg_factory.search_for_topic_workspace("topic")
+            cfg_builder.search_for_topic_workspace("topic")
             api.get_workspaces.assert_called()
             search.assert_has_calls([call("12345", "topic"), call("67890", "topic")])
 
@@ -279,12 +279,12 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspaces.return_value = api_data_stub
 
-        with patch.object(cfg_factory, "search_workspace_for_topic") as search:
+        with patch.object(cfg_builder, "search_workspace_for_topic") as search:
             search.side_effect = [None, "67890"]
-            result = cfg_factory.search_for_topic_workspace("topic_3")
+            result = cfg_builder.search_for_topic_workspace("topic_3")
             api.get_workspaces.assert_called()
             search.assert_has_calls(
                 [call("12345", "topic_3"), call("67890", "topic_3")]
@@ -311,10 +311,10 @@ class TestQuixKafkaConfigsBuilder:
         ]
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
 
-        result = cfg_factory.search_workspace_for_topic(
+        result = cfg_builder.search_workspace_for_topic(
             workspace_id="12345", topic="topic_2"
         )
         api.get_topics.assert_called_with("12345")
@@ -334,10 +334,10 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
 
-        result = cfg_factory.search_workspace_for_topic(
+        result = cfg_builder.search_workspace_for_topic(
             workspace_id="12345", topic="12345-topic_2"
         )
         api.get_topics.assert_called_with("12345")
@@ -355,9 +355,9 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
-        result = cfg_factory.search_workspace_for_topic(
+        result = cfg_builder.search_workspace_for_topic(
             workspace_id="12345", topic="topic_3"
         )
         api.get_topics.assert_called_with("12345")
@@ -366,9 +366,9 @@ class TestQuixKafkaConfigsBuilder:
     def test_get_workspace_ssl_cert(self, quix_kafka_config_factory, tmp_path):
         api_data_stub = b"my cool cert stuff"
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspace_certificate.return_value = api_data_stub
-        cfg_factory.get_workspace_ssl_cert(extract_to_folder=tmp_path)
+        cfg_builder.get_workspace_ssl_cert(extract_to_folder=tmp_path)
 
         with open(tmp_path / "ca.cert", "r") as f:
             s = f.read()
@@ -376,37 +376,37 @@ class TestQuixKafkaConfigsBuilder:
 
     def test_get_workspace_ssl_cert_empty(self, quix_kafka_config_factory, tmp_path):
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_workspace_certificate.return_value = None
-        assert cfg_factory.get_workspace_ssl_cert(extract_to_folder=tmp_path) is None
+        assert cfg_builder.get_workspace_ssl_cert(extract_to_folder=tmp_path) is None
 
     def test__set_workspace_cert_has_path(self, quix_kafka_config_factory):
         path = Path(getcwd()) / "certificates" / "12345"
         expected = (path / "ca.cert").as_posix()
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
 
         with patch.object(
-            cfg_factory, "get_workspace_ssl_cert", return_value=expected
+            cfg_builder, "get_workspace_ssl_cert", return_value=expected
         ) as get_cert:
-            r = cfg_factory._set_workspace_cert()
+            r = cfg_builder._set_workspace_cert()
             get_cert.assert_called_with(extract_to_folder=path)
-        assert cfg_factory.workspace_cert_path == r == expected
+        assert cfg_builder.workspace_cert_path == r == expected
 
     def test__set_workspace_cert_path(self, quix_kafka_config_factory, tmp_path):
         expected = (tmp_path / "ca.cert").as_posix()
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(
+        cfg_builder = quix_kafka_config_factory(
             workspace_id="12345",
             api_class=api,
             workspace_cert_path=expected,
         )
         with patch.object(
-            cfg_factory, "get_workspace_ssl_cert", return_value=expected
+            cfg_builder, "get_workspace_ssl_cert", return_value=expected
         ) as get_cert:
-            r = cfg_factory._set_workspace_cert()
+            r = cfg_builder._set_workspace_cert()
             get_cert.assert_called_with(extract_to_folder=tmp_path)
-        assert cfg_factory.workspace_cert_path == r == expected
+        assert cfg_builder.workspace_cert_path == r == expected
 
     @pytest.mark.parametrize(
         "quix_security_protocol, rdkafka_security_protocol",
@@ -436,8 +436,8 @@ class TestQuixKafkaConfigsBuilder:
         quix_kafka_config_factory,
     ):
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        cfg_factory._quix_broker_config = {
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder._quix_broker_config = {
             "address": "address1,address2",
             "securityMode": quix_security_protocol,
             "sslPassword": "",
@@ -447,14 +447,14 @@ class TestQuixKafkaConfigsBuilder:
             "hasCertificate": True,
         }
 
-        with patch.object(cfg_factory, "get_workspace_info") as get_ws:
-            with patch.object(cfg_factory, "_set_workspace_cert") as set_cert:
+        with patch.object(cfg_builder, "get_workspace_info") as get_ws:
+            with patch.object(cfg_builder, "_set_workspace_cert") as set_cert:
                 set_cert.return_value = "/mock/dir/ca.cert"
-                cfg_factory.get_confluent_broker_config(known_topic="topic")
+                cfg_builder.get_confluent_broker_config(known_topic="topic")
 
         get_ws.assert_called_with(known_workspace_topic="topic")
         set_cert.assert_called()
-        assert cfg_factory.confluent_broker_config == {
+        assert cfg_builder.confluent_broker_config == {
             "sasl.mechanisms": rdkafka_sasl_mechanisms,
             "security.protocol": rdkafka_security_protocol,
             "bootstrap.servers": "address1,address2",
@@ -467,25 +467,25 @@ class TestQuixKafkaConfigsBuilder:
 
     def test_prepend_workspace_id(self, quix_kafka_config_factory):
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        assert cfg_factory.prepend_workspace_id("topic") == "12345-topic"
-        assert cfg_factory.prepend_workspace_id("12345-topic") == "12345-topic"
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        assert cfg_builder.prepend_workspace_id("topic") == "12345-topic"
+        assert cfg_builder.prepend_workspace_id("12345-topic") == "12345-topic"
 
     def test_strip_workspace_id_prefix(self, quix_kafka_config_factory):
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        assert cfg_factory.strip_workspace_id_prefix("12345-topic") == "topic"
-        assert cfg_factory.strip_workspace_id_prefix("topic") == "topic"
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        assert cfg_builder.strip_workspace_id_prefix("12345-topic") == "topic"
+        assert cfg_builder.strip_workspace_id_prefix("topic") == "topic"
 
     def test_get_confluent_client_config(self, quix_kafka_config_factory):
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         topics = ["topic_1", "topic_2"]
         group_id = "my_consumer_group"
         with patch.object(
-            cfg_factory, "get_confluent_broker_config", return_value={"cfgs": "here"}
+            cfg_builder, "get_confluent_broker_config", return_value={"cfgs": "here"}
         ) as cfg:
-            result = cfg_factory.get_confluent_client_configs(topics, group_id)
+            result = cfg_builder.get_confluent_client_configs(topics, group_id)
             cfg.assert_called_with("topic_1")
         assert result == (
             {"cfgs": "here"},
@@ -531,9 +531,9 @@ class TestQuixKafkaConfigsBuilder:
             },
         ]
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
-        assert cfg_factory.get_topics() == api_data_stub
+        assert cfg_builder.get_topics() == api_data_stub
 
     def test_create_topics(
         self, quix_kafka_config_factory, topic_manager_topic_factory
@@ -561,13 +561,13 @@ class TestQuixKafkaConfigsBuilder:
         topic_d = topic_manager_topic_factory("12345-topic_d")
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         stack = ExitStack()
-        create_topic = stack.enter_context(patch.object(cfg_factory, "_create_topic"))
-        get_topics = stack.enter_context(patch.object(cfg_factory, "get_topics"))
+        create_topic = stack.enter_context(patch.object(cfg_builder, "_create_topic"))
+        get_topics = stack.enter_context(patch.object(cfg_builder, "get_topics"))
         get_topics.return_value = get_topics_return
-        finalize = stack.enter_context(patch.object(cfg_factory, "_finalize_create"))
-        cfg_factory.create_topics(
+        finalize = stack.enter_context(patch.object(cfg_builder, "_finalize_create"))
+        cfg_builder.create_topics(
             [topic_b, topic_c, topic_d], finalize_timeout_seconds=1
         )
         stack.close()
@@ -592,14 +592,14 @@ class TestQuixKafkaConfigsBuilder:
         mock_response.text = "already exists"
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         stack = ExitStack()
-        create_topic = stack.enter_context(patch.object(cfg_factory, "_create_topic"))
+        create_topic = stack.enter_context(patch.object(cfg_builder, "_create_topic"))
         create_topic.side_effect = HTTPError(response=mock_response)
-        get_topics = stack.enter_context(patch.object(cfg_factory, "get_topics"))
+        get_topics = stack.enter_context(patch.object(cfg_builder, "get_topics"))
         get_topics.return_value = get_topics_return
-        finalize = stack.enter_context(patch.object(cfg_factory, "_finalize_create"))
-        cfg_factory.create_topics([topic_b])
+        finalize = stack.enter_context(patch.object(cfg_builder, "_finalize_create"))
+        cfg_builder.create_topics([topic_b])
         stack.close()
         create_topic.assert_called_once_with(topic_b)
         finalize.assert_called_with({topic_b.name}, timeout=None)
@@ -637,10 +637,10 @@ class TestQuixKafkaConfigsBuilder:
             return lambda: next(n)
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        with patch.object(cfg_factory, "get_topics") as get_topics:
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        with patch.object(cfg_builder, "get_topics") as get_topics:
             get_topics.side_effect = side_effect()
-            cfg_factory._finalize_create(
+            cfg_builder._finalize_create(
                 {"12345-topic_b", "12345-topic_c", "12345-topic_d"}
             )
         assert get_topics.call_count == 2
@@ -674,12 +674,12 @@ class TestQuixKafkaConfigsBuilder:
         ]
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        with patch.object(cfg_factory, "get_topics") as get_topics:
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        with patch.object(cfg_builder, "get_topics") as get_topics:
             topics = {"12345-topic_b", "12345-topic_c", "12345-topic_d"}
             get_topics.return_value = data
             with pytest.raises(QuixCreateTopicFailure) as e:
-                cfg_factory._finalize_create(topics)
+                cfg_builder._finalize_create(topics)
         assert get_topics.call_count == 1
         for topic in ["topic_c", "topic_d"]:
             assert topic in str(e)
@@ -700,11 +700,11 @@ class TestQuixKafkaConfigsBuilder:
         ]
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
-        with patch.object(cfg_factory, "get_topics") as get_topics:
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        with patch.object(cfg_builder, "get_topics") as get_topics:
             get_topics.return_value = get_topics_return
             with pytest.raises(QuixCreateTopicTimeout) as e:
-                cfg_factory._finalize_create(
+                cfg_builder._finalize_create(
                     {"12345-topic_b", "12345-topic_c", "12345-topic_d"}, timeout=1
                 )
         e = e.value.args[0]
@@ -742,10 +742,10 @@ class TestQuixKafkaConfigsBuilder:
         topic_d = topic_manager_topic_factory("12345-topic_d")
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
 
-        cfg_factory.confirm_topics_exist([topic_b, topic_c, topic_d])
+        cfg_builder.confirm_topics_exist([topic_b, topic_c, topic_d])
 
     def test_confirm_topics_exist_topics_missing(
         self, quix_kafka_config_factory, topic_manager_topic_factory
@@ -768,11 +768,11 @@ class TestQuixKafkaConfigsBuilder:
         topic_d = topic_manager_topic_factory("12345-topic_d")
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topics.return_value = api_data_stub
 
         with pytest.raises(MissingQuixTopics) as e:
-            cfg_factory.confirm_topics_exist([topic_b, topic_c, topic_d])
+            cfg_builder.confirm_topics_exist([topic_b, topic_c, topic_d])
         e = e.value.args[0]
         assert "topic_c" in e and "topic_d" in e
         assert "topic_b" not in e
@@ -798,10 +798,10 @@ class TestQuixKafkaConfigsBuilder:
             },
         }
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topic.return_value = api_data_stub
 
-        assert cfg_factory.get_topic(topic_name) == api_data_stub
+        assert cfg_builder.get_topic(topic_name) == api_data_stub
 
     def test_get_topic_does_not_exist(self, quix_kafka_config_factory):
         """
@@ -815,10 +815,10 @@ class TestQuixKafkaConfigsBuilder:
         )
 
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topic.side_effect = api_error
 
-        assert cfg_factory.get_topic(topic_name) is None
+        assert cfg_builder.get_topic(topic_name) is None
 
     def test_get_topic_error(self, quix_kafka_config_factory):
         """
@@ -831,10 +831,10 @@ class TestQuixKafkaConfigsBuilder:
             error_text="Access Denied",
         )
         api = create_autospec(QuixPortalApiService)
-        cfg_factory = quix_kafka_config_factory(workspace_id="12345", api_class=api)
+        cfg_builder = quix_kafka_config_factory(workspace_id="12345", api_class=api)
         api.get_topic.side_effect = api_error
 
         with pytest.raises(QuixApiRequestFailure) as e:
-            cfg_factory.get_topic(topic_name)
+            cfg_builder.get_topic(topic_name)
 
         assert e.value.status_code == api_error.status_code

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -114,7 +114,7 @@ class TestQuixKafkaConfigsBuilder:
         api.get_workspace.assert_called_with(cfg_factory.workspace_id)
 
     def test_get_workspace_info_no_wid_one_ws(self, quix_kafka_config_factory):
-        api_response = {
+        api_data_stub = {
             "workspaceId": "12345",
             "name": "12345",
             "status": "Ready",
@@ -139,17 +139,18 @@ class TestQuixKafkaConfigsBuilder:
             "branchProtected": False,
         }
         api = create_autospec(QuixPortalApiService)
+        api.default_workspace_id = None
         cfg_factory = quix_kafka_config_factory(api_class=api)
         with patch.object(
             cfg_factory,
             "search_for_topic_workspace",
-            return_value=deepcopy(api_response),
+            return_value=deepcopy(api_data_stub),
         ) as search:
             cfg_factory.get_workspace_info(known_workspace_topic="a_topic")
             search.assert_called_with("a_topic")
-        assert cfg_factory.workspace_id == api_response["workspaceId"]
-        assert cfg_factory.quix_broker_config == api_response["broker"]
-        assert cfg_factory.quix_broker_settings == api_response["brokerSettings"]
+        assert cfg_factory.workspace_id == api_data_stub["workspaceId"]
+        assert cfg_factory.quix_broker_config == api_data_stub["broker"]
+        assert cfg_factory.quix_broker_settings == api_data_stub["brokerSettings"]
         assert cfg_factory.workspace_meta == {
             "name": "12345",
             "status": "Ready",
@@ -166,7 +167,7 @@ class TestQuixKafkaConfigsBuilder:
 
     def test_get_workspace_info_no_wid_one_ws_v1(self, quix_kafka_config_factory):
         """Confirm a workspace v1 response is handled correctly"""
-        api_response = {
+        api_data_stub = {
             "workspaceId": "12345",
             "name": "12345",
             "status": "Ready",
@@ -187,16 +188,17 @@ class TestQuixKafkaConfigsBuilder:
             "branchProtected": False,
         }
         api = create_autospec(QuixPortalApiService)
+        api.default_workspace_id = None
         cfg_factory = quix_kafka_config_factory(api_class=api)
         with patch.object(
             cfg_factory,
             "search_for_topic_workspace",
-            return_value=deepcopy(api_response),
+            return_value=deepcopy(api_data_stub),
         ) as search:
             cfg_factory.get_workspace_info(known_workspace_topic="a_topic")
             search.assert_called_with("a_topic")
-        assert cfg_factory.workspace_id == api_response["workspaceId"]
-        assert cfg_factory.quix_broker_config == api_response["broker"]
+        assert cfg_factory.workspace_id == api_data_stub["workspaceId"]
+        assert cfg_factory.quix_broker_config == api_data_stub["broker"]
         assert cfg_factory.quix_broker_settings == {
             "brokerType": "SharedKafka",
             "syncTopics": False,


### PR DESCRIPTION
Now properly handle Quix "External" topics by querying the Quix API for the `id` name when a `Topic`-based object is created, otherwise assume it requires a `workspace_id`-appended version created.