### PR TITLE
fix tutorial bullets for correct rendering in website version

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,12 +1,11 @@
 # Quix Streams Tutorials
 
-This folder contains a few basic application patterns with accompanying walkthroughs 
+Here are a few basic application patterns with accompanying walkthroughs 
 to get you started with the Quix Streams library.
 
 ## Running a Tutorial
 
-Should you wish to run one of the tutorials, follow the instructions as
-listed at the bottom of it's `./tutorial.md`.
+Should you wish to run one of the tutorials, follow its instructions at the bottom.
 
 Besides a Kafka instance to connect to, most of them likely fit the pattern of:
 

--- a/docs/tutorials/anomaly-detection/tutorial.md
+++ b/docs/tutorials/anomaly-detection/tutorial.md
@@ -178,7 +178,9 @@ Now we get a window result (mean) along with its start/end timestamp:
 We don't particularly care about the window itself in our case, just the result...so we extract the "value" with `SDF.apply()` and [`SDF.filter(F)`](../../processing.md#streamingdataframefilter), where `F` is our "should_alert" function. 
 
 For `SDF.filter(F)`, if the (_**boolean**_-ed) return value of `F` is: 
+
 - `True` -> continue processing this event
+
 - `False` -> stop ALL further processing of this event (including produces!)
 
 In our case, this example event would then stop since `bool(None)` is `False`.

--- a/docs/tutorials/purchase-filtering/tutorial.md
+++ b/docs/tutorials/purchase-filtering/tutorial.md
@@ -191,8 +191,11 @@ Now we "and" these steps, which translates to your typical `A and B`
 (and returns a boolean).
 
 A few notes around `&` (and): 
+
 - It is considered an SDF operation.
+
 - You MUST use `&` for and, `|` for or
+
 - Your respective objects (i.e. `A`, `B`) must be wrapped in parentheses.
 
 Ultimately, when executed, the result of `&` will be _boolean_. This is important for...
@@ -206,7 +209,9 @@ sdf = sdf[X]
 Ultimately, this is a filtering operation: whenever `X` is an SDF operation(s) result, it acts like Pandas row filtering.
 
 As such, SDF filtering interprets the SDF operation `&` _boolean_ result as follows:
+
 - `True` -> continue processing this event
+
 - `False` -> stop ALL further processing of this event (including produces!)
 
 So, any events that don't satisfy these conditions will be filtered as desired!

--- a/docs/tutorials/word-count/tutorial.md
+++ b/docs/tutorials/word-count/tutorial.md
@@ -144,7 +144,9 @@ to this:
 
 
 NOTE: two VERY important and related points around the `expand=True` argument:
+
 1. it tells SDF "hey, this .apply() returns _**multiple independent**_ events!"
+
 2. Our `F` returns a `list` (or a non-dict iterable of some kind), hence the "expand"!
 
 
@@ -161,7 +163,9 @@ sdf = sdf.filter(should_skip)
 Now we filter out some "filler" words using [`SDF.filter(F)`](../../processing.md#streamingdataframefilter), where `F` is our `should_skip` function. 
 
 For `SDF.filter(F)`, if the (_**boolean**_-ed) return value of `F` is: 
+
 - `True` -> continue processing this event
+
 - `False` -> stop ALL further processing of this event (including produces!)
 
 Remember that each word is now an independent event now due to our previous expand, so our


### PR DESCRIPTION
There were some spacing issues with bullets in the tutorials causing them to not render correctly in the website version of the doc.

Adding spaces fixes them.

Also minor language cleanup on the tutorial landing page to have it fit better with docs being on the website.