### PR TITLE
add SDF.print(), allow inplace for SDF.update() and SDF.to_topic()

### DIFF
--- a/docs/processing.md
+++ b/docs/processing.md
@@ -501,6 +501,9 @@ For example, to log input data, or to update a counter in the State.
 The return of the callback passed to `.update()` will be ignored, and the original input
 will be sent to downstream operations instead.
 
+Because of the in-place nature of `.update()`, reassigning the operation to an `sdf` 
+again is OPTIONAL. 
+
 **Example:**
 
 ```python
@@ -508,8 +511,9 @@ will be sent to downstream operations instead.
 # The updated list will be passed downstream
 sdf = sdf.update(lambda some_list: some_list.append(1))
 
-# Using .update() to print a value to the console
-sdf = sdf.update(lambda value: print("Received value: ", value))
+# OR instead (no reassignment):
+sdf.update(lambda some_list: some_list.append(1))
+
 ```
 
 ### StreamingDataFrame.filter()

--- a/docs/processing.md
+++ b/docs/processing.md
@@ -501,8 +501,12 @@ For example, to log input data, or to update a counter in the State.
 The return of the callback passed to `.update()` will be ignored, and the original input
 will be sent to downstream operations instead.
 
-Because of the in-place nature of `.update()`, reassigning the operation to an `sdf` 
-again is OPTIONAL. 
+This operation occurs in-place, meaning reassigning the operation to your `sdf` is 
+entirely OPTIONAL; the original `StreamingDataFrame` is still returned to allow the 
+chaining of commands like `sdf.update().print()`.
+
+> Note: chains that include any non-inplace function will still require reassignment: 
+> `sdf = sdf.update().filter().print()`
 
 **Example:**
 

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -283,12 +283,16 @@ class StreamingDataFrame(BaseStreaming):
         The result of the function will be ignored, and the original value will be
         passed downstream.
 
+        Reassignment is OPTIONAL for this operation (is applied regardless).
+
 
         Example Snippet:
 
         ```python
         # Stores a value and mutates a list by appending a new item to it.
         # Also prints to console.
+
+        logger = logging.get_logger()
 
         def func(values: list, state: State):
             value = values[0]
@@ -298,7 +302,8 @@ class StreamingDataFrame(BaseStreaming):
 
         sdf = StreamingDataframe()
         sdf = sdf.update(func, stateful=True)
-        sdf = sdf.update(lambda value: print("Received value: ", value))
+        # does not require reassigning
+        sdf.update(lambda v: logger.info("message value is {v}"))
         ```
 
         :param func: function to update value
@@ -546,6 +551,8 @@ class StreamingDataFrame(BaseStreaming):
         """
         Produce current value to a topic. You can optionally specify a new key.
 
+        Reassignment is OPTIONAL for this operation (is applied regardless).
+
         Example Snippet:
 
         ```python
@@ -560,7 +567,8 @@ class StreamingDataFrame(BaseStreaming):
 
         sdf = app.dataframe(input_topic)
         sdf = sdf.to_topic(output_topic_0)
-        sdf = sdf.to_topic(output_topic_1, key=lambda data: data["a_field"])
+        # does not require reassigning
+        sdf.to_topic(output_topic_1, key=lambda data: data["a_field"])
         ```
 
         :param topic: instance of `Topic`
@@ -680,7 +688,7 @@ class StreamingDataFrame(BaseStreaming):
 
         Can also output a more dict-friendly format with `pretty=True`.
 
-        Reassignment is OPTIONAL for this function (is applied regardless).
+        Reassignment is OPTIONAL for this operation (is applied regardless).
 
         > NOTE: prints the current (edited) values, not the original values.
 

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -684,7 +684,7 @@ class StreamingDataFrame(BaseStreaming):
         stream = self.stream.add_transform(func=_set_headers_callback)
         return self.__dataframe_clone__(stream=stream)
 
-    def print(self, pretty: bool = False, metadata: bool = False) -> Self:
+    def print(self, pretty: bool = True, metadata: bool = False) -> Self:
         """
         Print out the current message value (and optionally, the message metadata) to
         stdout (console) (like the built-in `print` function).

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -283,7 +283,8 @@ class StreamingDataFrame(BaseStreaming):
         The result of the function will be ignored, and the original value will be
         passed downstream.
 
-        Reassignment is OPTIONAL for this operation (is applied regardless).
+        This operation occurs in-place, meaning reassignment is entirely OPTIONAL: the
+        original `StreamingDataFrame` is returned for chaining (`sdf.update().print()`).
 
 
         Example Snippet:
@@ -552,7 +553,8 @@ class StreamingDataFrame(BaseStreaming):
         """
         Produce current value to a topic. You can optionally specify a new key.
 
-        Reassignment is OPTIONAL for this operation (is applied regardless).
+        This operation occurs in-place, meaning reassignment is entirely OPTIONAL: the
+        original `StreamingDataFrame` is returned for chaining (`sdf.update().print()`).
 
         Example Snippet:
 
@@ -689,7 +691,8 @@ class StreamingDataFrame(BaseStreaming):
 
         Can also output a more dict-friendly format with `pretty=True`.
 
-        Reassignment is OPTIONAL for this operation (is applied regardless).
+        This operation occurs in-place, meaning reassignment is entirely OPTIONAL: the
+        original `StreamingDataFrame` is returned for chaining (`sdf.update().print()`).
 
         > NOTE: prints the current (edited) values, not the original values.
 
@@ -715,7 +718,7 @@ class StreamingDataFrame(BaseStreaming):
         """
         print_args = ["value", "key", "timestamp", "headers"]
         if pretty:
-            printer = functools.partial(pprint.pprint, indent=2)
+            printer = functools.partial(pprint.pprint, indent=2, sort_dicts=False)
         else:
             printer = print
         return self._add_update(

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -713,13 +713,13 @@ class StreamingDataFrame(BaseStreaming):
         :param metadata: Whether to additionally print the key, timestamp, and headers
         :return: the updated StreamingDataFrame instance (reassignment NOT required).
         """
-        _PRINT_ARGS = ["value", "key", "timestamp", "headers"]
+        print_args = ["value", "key", "timestamp", "headers"]
         if pretty:
             printer = functools.partial(pprint.pprint, indent=2)
         else:
             printer = print
         return self._add_update(
-            lambda *args: printer({_PRINT_ARGS[i]: args[i] for i in range(len(args))}),
+            lambda *args: printer({print_args[i]: args[i] for i in range(len(args))}),
             metadata=metadata,
         )
 

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -293,8 +293,6 @@ class StreamingDataFrame(BaseStreaming):
         # Stores a value and mutates a list by appending a new item to it.
         # Also prints to console.
 
-        logger = logging.get_logger()
-
         def func(values: list, state: State):
             value = values[0]
             if value != state.get("my_store_key"):
@@ -304,7 +302,7 @@ class StreamingDataFrame(BaseStreaming):
         sdf = StreamingDataframe()
         sdf = sdf.update(func, stateful=True)
         # does not require reassigning
-        sdf.update(lambda v: logger.info("message value is {v}"))
+        sdf.update(lambda v: v.append(1))
         ```
 
         :param func: function to update value

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -312,6 +312,7 @@ class StreamingDataFrame(BaseStreaming):
         :param metadata: if True, the callback will receive key, timestamp and headers
             along with the value.
             Default - `False`.
+        :return: the updated StreamingDataFrame instance (reassignment NOT required).
         """
         if stateful:
             self._register_store()
@@ -576,7 +577,7 @@ class StreamingDataFrame(BaseStreaming):
             If passed, the return type of this callable must be serializable
             by `key_serializer` defined for this Topic object.
             By default, the current message key will be used.
-
+        :return: the updated StreamingDataFrame instance (reassignment NOT required).
         """
         return self._add_update(
             lambda value, orig_key, timestamp, headers: self._produce(

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -477,6 +477,27 @@ class TestStreamingDataFrameUpdate:
         assert sdf_id_4 == sdf_id_5
         assert sdf_tree_4 != sdf_tree_5
 
+    def test_chaining_inplace_with_non_inplace(self, dataframe_factory):
+        """
+        When chaining together inplace and non-inplace, reassigning must happen else
+        everything starting with the non-inplace will be lost.
+        """
+        sdf = dataframe_factory()
+        sdf.update(lambda v: v.append(1)).apply(lambda v: v + [2]).update(
+            lambda v: v.append(3)
+        )
+        sdf = sdf.apply(lambda v: v + [4])
+
+        value = []
+        key, timestamp, headers = b"key", 0, []
+
+        assert sdf.test(value, key, timestamp, headers)[0] == (
+            [1, 4],
+            key,
+            timestamp,
+            headers,
+        )
+
 
 class TestStreamingDataFrameToTopic:
     @pytest.mark.parametrize("reassign", [True, False])

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -1,3 +1,4 @@
+import json
 import operator
 import uuid
 from collections import namedtuple
@@ -369,6 +370,26 @@ class TestStreamingDataFrame:
         )[0]
         assert result == expected
 
+    @pytest.mark.parametrize(
+        "metadata,expected",
+        [
+            (False, str({"value": {"x": 1}})),
+            (
+                True,
+                str({"value": {"x": 1}, "key": b"key", "timestamp": 0, "headers": []}),
+            ),
+        ],
+    )
+    def test_print(self, dataframe_factory, metadata, expected, capsys):
+        sdf = dataframe_factory()
+        sdf.print(metadata=metadata)
+
+        value = {"x": 1}
+        key, timestamp, headers = b"key", 0, []
+        sdf.test(value=value, key=key, timestamp=timestamp, headers=headers)
+
+        assert expected in capsys.readouterr().out
+
 
 class TestStreamingDataFrameApplyExpand:
     def test_apply_expand(self, dataframe_factory):
@@ -418,7 +439,47 @@ class TestStreamingDataFrameApplyExpand:
             _ = sdf[sdf.apply(lambda v: [v, v], expand=True)]
 
 
+class TestStreamingDataFrameUpdate:
+    def test_update_no_reassign(self, dataframe_factory):
+        """
+        "Update" operations should be applied regardless of a reassignment,
+        and anything else requires assignment.
+        """
+        sdf = dataframe_factory()
+        sdf_tree_1 = sdf.stream.tree()
+        sdf_id_1 = id(sdf)
+
+        # non-update non-reassignment (no change!)
+        sdf.apply(lambda v: v)
+        sdf_tree_2 = sdf.stream.tree()
+        sdf_id_2 = id(sdf)
+        assert sdf_id_1 == sdf_id_2
+        assert sdf_tree_1 == sdf_tree_2
+
+        # non-update reassignment
+        sdf = sdf.apply(lambda v: v)
+        sdf_tree_3 = sdf.stream.tree()
+        sdf_id_3 = id(sdf)
+        assert sdf_id_2 != sdf_id_3
+        assert sdf_tree_2 != sdf_tree_3
+
+        # update non-reassignment
+        sdf.update(lambda v: v)
+        sdf_tree_4 = sdf.stream.tree()
+        sdf_id_4 = id(sdf)
+        assert sdf_id_3 == sdf_id_4
+        assert sdf_tree_3 != sdf_tree_4
+
+        # update reassignment
+        sdf = sdf.update(lambda v: v)
+        sdf_tree_5 = sdf.stream.tree()
+        sdf_id_5 = id(sdf)
+        assert sdf_id_4 == sdf_id_5
+        assert sdf_tree_4 != sdf_tree_5
+
+
 class TestStreamingDataFrameToTopic:
+    @pytest.mark.parametrize("reassign", [True, False])
     def test_to_topic(
         self,
         dataframe_factory,
@@ -426,6 +487,7 @@ class TestStreamingDataFrameToTopic:
         row_producer_factory,
         topic_manager_topic_factory,
         message_context_factory,
+        reassign,
     ):
         topic = topic_manager_topic_factory(
             key_serializer="str",
@@ -436,7 +498,10 @@ class TestStreamingDataFrameToTopic:
         producer = row_producer_factory()
 
         sdf = dataframe_factory(producer=producer)
-        sdf = sdf.to_topic(topic)
+        if reassign:
+            sdf = sdf.to_topic(topic)
+        else:
+            sdf.to_topic(topic)
 
         value = {"x": 1, "y": 2}
         key, timestamp = "key", 10


### PR DESCRIPTION
- Added `SDF.print(pretty: bool, metadata: bool)`, which prints the value, and optionally metadata
- Enables `SDF.print()`, `SDF.update()` and `SDF.to_topic()` to be used without reassigning them (and you can chain them as normal)

```python
sdf = SDF()
sdf = sdf.apply(a_func)
sdf.update(other_func).print(metadata=True).to_topic(my_topic)
```