### PR TITLE
added fix for Series manipulations attempted across branches

### DIFF
--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -533,8 +533,7 @@ class StreamingDataFrame(BaseStreaming):
         self._registry.register_groupby(source_sdf=self, new_sdf=groupby_sdf)
         return groupby_sdf
 
-    @staticmethod
-    def contains(key: str) -> StreamingSeries:
+    def contains(self, key: str) -> StreamingSeries:
         """
         Check if the key is present in the Row value.
 
@@ -556,7 +555,7 @@ class StreamingDataFrame(BaseStreaming):
         """
 
         return StreamingSeries.from_apply_callback(
-            lambda value, key_, timestamp, headers: key in value
+            lambda value, key_, timestamp, headers: key in value, sdf_id=id(self)
         )
 
     @_ensure_unlocked
@@ -1156,6 +1155,12 @@ class StreamingDataFrame(BaseStreaming):
             )
         elif isinstance(item, StreamingSeries):
             # Update an item key with a result of another series
+            if id(self) != item.sdf_id:
+                raise InvalidOperation(
+                    "Column-setting operations must originate from target SDF; "
+                    'ex: `sdf1["x"] = sdf1["y"] + 1`, NOT `sdf1["x"] = sdf2["y"] + 1` '
+                )
+
             series_composed = item.compose_returning()
             self._add_update(
                 lambda value, key, timestamp, headers: operator.setitem(
@@ -1200,7 +1205,7 @@ class StreamingDataFrame(BaseStreaming):
             return self.apply(lambda value: {k: value[k] for k in item})
         elif isinstance(item, str):
             # Create a StreamingSeries based on a column name
-            return StreamingSeries(name=item)
+            return StreamingSeries(name=item, sdf_id=id(self))
         else:
             raise TypeError(f'Unsupported key type "{type(item)}"')
 

--- a/quixstreams/dataframe/series.py
+++ b/quixstreams/dataframe/series.py
@@ -1,8 +1,9 @@
 import contextvars
+import functools
 import operator
-from typing import Optional, Union, Callable, Container, Any, Mapping
+from typing import Optional, Union, Callable, Container, Any, Mapping, TypeVar
 
-from typing_extensions import Self
+from typing_extensions import Self, ParamSpec
 
 from quixstreams.context import set_message_context
 from quixstreams.core.stream.functions import (
@@ -19,6 +20,9 @@ from .base import BaseStreaming
 from .exceptions import InvalidOperation, ColumnDoesNotExist, InvalidColumnReference
 
 __all__ = ("StreamingSeries",)
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
 
 
 def _getitem(d: Mapping, column_name: Union[str, int]) -> object:
@@ -42,6 +46,24 @@ def _getitem(d: Mapping, column_name: Union[str, int]) -> object:
             f"column referencing expects message value type 'dict', "
             f"not '{d.__class__.__name__}'"
         )
+
+
+def _validate_operation(func: Callable[_P, _T]) -> Callable[_P, _T]:
+    """
+    Ensure `StreamingSeries` involved in operations originate from the same SDF.
+    Can occur during `StreamingDataFrame` branching.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self: "StreamingSeries", other: Any, *args, **kwargs):
+        if isinstance(other, StreamingSeries):
+            if self.sdf_id != other.sdf_id:
+                raise InvalidOperation(
+                    "All column operations must originate from one `StreamingDataFrame`"
+                )
+        return func(self, other, *args, **kwargs)
+
+    return wrapper
 
 
 class StreamingSeries(BaseStreaming):
@@ -98,25 +120,35 @@ class StreamingSeries(BaseStreaming):
         self,
         name: Optional[str] = None,
         stream: Optional[Stream] = None,
+        sdf_id: Optional[int] = None,
     ):
         if not (name or stream):
             raise ValueError('Either "name" or "stream" must be passed')
         self._stream = stream or Stream(func=ApplyFunction(lambda v: _getitem(v, name)))
+        self._sdf_id = sdf_id
 
     @classmethod
-    def from_apply_callback(cls, func: ApplyWithMetadataCallback) -> Self:
+    def from_apply_callback(cls, func: ApplyWithMetadataCallback, sdf_id: int) -> Self:
         """
         Create a StreamingSeries from a function.
 
         The provided function will be wrapped into `Apply`
         :param func: a function to apply
+        :param sdf_id: the id of the calling `SDF`.
         :return: instance of `StreamingSeries`
         """
-        return cls(stream=Stream(ApplyWithMetadataFunction(func)))
+        return cls(stream=Stream(ApplyWithMetadataFunction(func)), sdf_id=sdf_id)
+
+    def _from_apply_callback(self, func: ApplyWithMetadataCallback):
+        return self.from_apply_callback(func, self._sdf_id)
 
     @property
     def stream(self) -> Stream:
         return self._stream
+
+    @property
+    def sdf_id(self) -> Optional[int]:
+        return self._sdf_id
 
     def apply(self, func: ApplyCallback) -> Self:
         """
@@ -150,7 +182,7 @@ class StreamingSeries(BaseStreaming):
         :return: a new `StreamingSeries` with the new callable added
         """
         child = self._stream.add_apply(func)
-        return self.__class__(stream=child)
+        return self.__class__(stream=child, sdf_id=self._sdf_id)
 
     def compose_returning(self) -> ReturningExecutor:
         """
@@ -241,6 +273,7 @@ class StreamingSeries(BaseStreaming):
         context.run(composed, value, key, timestamp, headers)
         return result
 
+    @_validate_operation
     def _operation(
         self,
         other: Union[Self, str, int, object],
@@ -253,14 +286,14 @@ class StreamingSeries(BaseStreaming):
         if isinstance(other, self.__class__):
             other_composed = other.compose_returning()
 
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers, op=operator_: op(
                     self_composed(value, key, timestamp, headers)[0],
                     other_composed(value, key, timestamp, headers)[0],
                 )
             )
         else:
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers, op=operator_: op(
                     self_composed(value, key, timestamp, headers)[0], other
                 )
@@ -475,6 +508,7 @@ class StreamingSeries(BaseStreaming):
     def __ge__(self, other: Union[Self, object]) -> Self:
         return self._operation(other, operator.ge)
 
+    @_validate_operation
     def __and__(self, other: Union[Self, object]) -> Self:
         """
         Do a logical "and" comparison.
@@ -493,20 +527,21 @@ class StreamingSeries(BaseStreaming):
 
         if isinstance(other, self.__class__):
             other_composed = other.compose_returning()
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers: self_composed(
                     value, key, timestamp, headers
                 )[0]
                 and other_composed(value, key, timestamp, headers)[0]
             )
         else:
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers: self_composed(
                     value, key, timestamp, headers
                 )[0]
                 and other
             )
 
+    @_validate_operation
     def __or__(self, other: Union[Self, object]) -> Self:
         """
         Do a logical "or" comparison.
@@ -524,14 +559,14 @@ class StreamingSeries(BaseStreaming):
         self_composed = self.compose_returning()
         if isinstance(other, self.__class__):
             other_composed = other.compose_returning()
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers: self_composed(
                     value, key, timestamp, headers
                 )[0]
                 or other_composed(value, key, timestamp, headers)[0]
             )
         else:
-            return self.from_apply_callback(
+            return self._from_apply_callback(
                 func=lambda value, key, timestamp, headers: self_composed(
                     value, key, timestamp, headers
                 )[0]

--- a/quixstreams/dataframe/series.py
+++ b/quixstreams/dataframe/series.py
@@ -140,6 +140,7 @@ class StreamingSeries(BaseStreaming):
         return cls(stream=Stream(ApplyWithMetadataFunction(func)), sdf_id=sdf_id)
 
     def _from_apply_callback(self, func: ApplyWithMetadataCallback):
+        # TODO - maybe there's a better patten for this? (_method calling classmethod)
         return self.from_apply_callback(func, self._sdf_id)
 
     @property

--- a/tests/test_quixstreams/test_dataframe/test_dataframe.py
+++ b/tests/test_quixstreams/test_dataframe/test_dataframe.py
@@ -1800,7 +1800,7 @@ class TestStreamingDataFrameBranching:
 
     def test_store_series_filter_as_var_and_use(self, dataframe_factory):
         """
-        NOTE: This is NOT dependent on splitting functionality, but splitting may
+        NOTE: This is NOT dependent on branching functionality, but branching may
         encourage these sorts of operations (it does NOT copy data).
 
         NOTE: this kind of operation is only guaranteed to be correct when the stored
@@ -1824,7 +1824,7 @@ class TestStreamingDataFrameBranching:
 
     def test_store_series_result_as_var_and_use(self, dataframe_factory):
         """
-        NOTE: This is NOT dependent on splitting functionality, but splitting may
+        NOTE: This is NOT dependent on branching functionality, but branching may
         encourage these sorts of operations (it does NOT copy data).
 
         NOTE: this kind of operation is only guaranteed to be correct when the stored
@@ -1848,7 +1848,7 @@ class TestStreamingDataFrameBranching:
 
     def test_store_sdf_filter_as_var_and_use(self, dataframe_factory):
         """
-        NOTE: This is NOT dependent on splitting functionality, but splitting may
+        NOTE: This is NOT dependent on branching functionality, but branching may
         encourage these sorts of operations.
 
         NOTE: This WILL copy data, so it is basically a more inefficient way of doing
@@ -2064,7 +2064,7 @@ class TestStreamingDataFrameBranching:
 
     def test_store_sdf_setter_as_var_and_use(self, dataframe_factory):
         """
-        NOTE: This is NOT dependent on splitting functionality, but splitting may
+        NOTE: This is NOT dependent on branching functionality, but branching may
         encourage these sorts of operations.
         """
         sdf = dataframe_factory().apply(add_n_df(10))
@@ -2078,3 +2078,32 @@ class TestStreamingDataFrameBranching:
         results = sdf.test(value={"v": 0}, **_extras)
 
         assert results == expected
+
+    def test_column_setting_from_another_sdf_series_fails(self, dataframe_factory):
+        """
+        Attempting to set a column based on another SDF series operation fails,
+        as series are only intended to be applied to the same SDF.
+        :param dataframe_factory:
+        :return:
+        """
+
+        sdf = dataframe_factory().apply(add_n_df(10))
+        sdf2 = sdf.apply(add_n_df(500))
+
+        with pytest.raises(InvalidOperation, match="Column-setting"):
+            sdf["new_col"] = sdf2["v"] + 3
+
+    def test_column_operations_different_sdfs_fails(self, dataframe_factory):
+        """
+        Attempting series operations involving multiple SDFs fails,
+        as series are only intended to be applied to the same SDF.
+        :param dataframe_factory:
+        :return:
+        """
+
+        sdf = dataframe_factory().apply(add_n_df(10))
+        sdf2 = sdf.apply(add_n_df(500))
+        sdf3 = sdf.apply(add_n_df(800))
+
+        with pytest.raises(InvalidOperation, match="All column operations"):
+            sdf["new_col"] = sdf2["v"] + sdf3["v"]

--- a/tests/test_quixstreams/test_dataframe/test_series.py
+++ b/tests/test_quixstreams/test_dataframe/test_series.py
@@ -504,3 +504,31 @@ class TestStreamingSeries:
         key, timestamp, headers = "key", 0, []
         with pytest.raises(InvalidColumnReference):
             StreamingSeries("x").test(2, key, timestamp, headers)
+
+    def test_series_origin_mismatch_fails(self):
+        """
+        Attempting to do operations that originate from two different SDF's fails (
+        arises from SDF branching).
+        """
+        series_1 = StreamingSeries(name="x", sdf_id=1)
+        series_2 = StreamingSeries(name="x", sdf_id=2)
+
+        # _operations calls
+        with pytest.raises(
+            InvalidOperation,
+            match="All column operations must originate from one `StreamingDataFrame`",
+        ):
+            series_1 + series_2
+
+        # others
+        with pytest.raises(
+            InvalidOperation,
+            match="All column operations must originate from one `StreamingDataFrame`",
+        ):
+            series_1 & series_2
+
+        with pytest.raises(
+            InvalidOperation,
+            match="All column operations must originate from one `StreamingDataFrame`",
+        ):
+            series_1 | series_2

--- a/tests/test_quixstreams/test_dataframe/test_series.py
+++ b/tests/test_quixstreams/test_dataframe/test_series.py
@@ -505,30 +505,23 @@ class TestStreamingSeries:
         with pytest.raises(InvalidColumnReference):
             StreamingSeries("x").test(2, key, timestamp, headers)
 
-    def test_series_origin_mismatch_fails(self):
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            lambda s1, s2: s1 + s2,
+            lambda s1, s2: s1 & s2,
+            lambda s1, s2: s1 | s2,
+        ],
+    )
+    def test_series_origin_mismatch_fails(self, operation):
         """
         Attempting to do operations that originate from two different SDF's fails (
         arises from SDF branching).
         """
-        series_1 = StreamingSeries(name="x", sdf_id=1)
-        series_2 = StreamingSeries(name="x", sdf_id=2)
-
-        # _operations calls
         with pytest.raises(
             InvalidOperation,
             match="All column operations must originate from one `StreamingDataFrame`",
         ):
-            series_1 + series_2
-
-        # others
-        with pytest.raises(
-            InvalidOperation,
-            match="All column operations must originate from one `StreamingDataFrame`",
-        ):
-            series_1 & series_2
-
-        with pytest.raises(
-            InvalidOperation,
-            match="All column operations must originate from one `StreamingDataFrame`",
-        ):
-            series_1 | series_2
+            operation(
+                StreamingSeries(name="x", sdf_id=1), StreamingSeries(name="x", sdf_id=2)
+            )


### PR DESCRIPTION
Exceptions are now thrown when Series operations with multiple SDFs are attempted.