### PR TITLE
bugfix for topic creation with quix-based external broker

### DIFF
--- a/quixstreams/platforms/quix/topic_manager.py
+++ b/quixstreams/platforms/quix/topic_manager.py
@@ -63,8 +63,10 @@ class QuixTopicManager(TopicManager):
         :param timeout: creation acknowledge timeout (seconds)
         :param create_timeout: topic finalization timeout (seconds)
         """
+        # note: prepending was already performed as needed, so we skip doing it
+        # within `create_topics`
         self._quix_config_builder.create_topics(
-            topics, timeout=timeout, finalize_timeout=create_timeout
+            topics, timeout=timeout, finalize_timeout=create_timeout, prepend=False
         )
 
     def _resolve_topic_name(self, name: str) -> str:

--- a/tests/test_quixstreams/test_platforms/test_quix/test_config.py
+++ b/tests/test_quixstreams/test_platforms/test_quix/test_config.py
@@ -596,6 +596,7 @@ class TestQuixKafkaConfigsBuilder:
 
         mock_response = create_autospec(Response)
         mock_response.text = "already exists"
+        mock_response.status_code = 400
 
         timeout = 4.5
         finalize_timeout = 9.5
@@ -605,7 +606,11 @@ class TestQuixKafkaConfigsBuilder:
         )
         stack = ExitStack()
         create_topic = stack.enter_context(patch.object(cfg_builder, "_create_topic"))
-        create_topic.side_effect = HTTPError(response=mock_response)
+        create_topic.side_effect = QuixApiRequestFailure(
+            url="url",
+            status_code=mock_response.status_code,
+            error_text=mock_response.text,
+        )
         get_topics = stack.enter_context(patch.object(cfg_builder, "get_topics"))
         get_topics.return_value = get_topics_return
         finalize = stack.enter_context(patch.object(cfg_builder, "_finalize_create"))


### PR DESCRIPTION
Fix two bugs: 

1. the wrong topic name is used during topic creation attempt for Quix external broker topic that already exists: 
  - the external topic name (ex:` "my_ext_topic"`), which already exists, would be correctly identified and NOT prepend the workspace-id (so it stays `"my_ext_topic"`), as desired
  - PROBLEM: Then, during topic creation step per `QuixConfigBuilder`, the workspace_id would be prepended and used to check whether the topic already exists (ex: `"my_ws-my_ext_topic"`), but the actual topic name is `"my_ext_topic"`
  - It looks like the topic needs created, so it tries to create it, sans prefix (`"my_ext_topic"`), as desired.
  - The creation correctly raises an exception that the topic already exists. This should be caught and ignored gracefully, BUT....
  
  2. When attempting to create a Quix topic that already exists, it was looking for an `HTTPError` to catch, but the error is bundled as `QuixApiRequestFailure` instead. So, it raises said exception instead of gracefully ignoring it.


The fixes:
1. whenever topic creation requests are made by the `QuixTopicManager`, it passes a flag to `QuixConfigBuilder.create_topics` to NOT prepend the workspace_id during creation since it's already handled all the naming resolutions.

2. Handle the correct exception.

