### PR TITLE
Fix a bug with disappearing tables without new data

### DIFF
--- a/quixstreams/utils/printing.py
+++ b/quixstreams/utils/printing.py
@@ -127,16 +127,15 @@ class Printer:
         # the table in-place. When a new row arrives, immediately
         # print the new row at the bottom, removing the oldest row
         # from the top if table is full.
-        console_cleared = False
-        for table in self._tables:
-            if table.has_new_data():
-                # Clear console only once per print call
-                # and only if there is new data to print.
-                if not console_cleared:
-                    self._console.clear()
-                    console_cleared = True
 
-                table.print(self._console)
+        if not any(table.has_new_data() for table in self._tables):
+            # If no table has new data, do not print anything.
+            return
+
+        self._console.clear()
+        for table in self._tables:
+            table.print(self._console)
+
         time.sleep(self._live_slowdown)
 
     def _print_non_interactive(self) -> None:

--- a/tests/test_quixstreams/test_utils/test_printing.py
+++ b/tests/test_quixstreams/test_utils/test_printing.py
@@ -91,6 +91,79 @@ def test_empty_table(
     assert get_output() == ""
 
 
+def test_print_interactive_no_new_data(
+    printer: Printer, get_output: Callable[[], str]
+) -> None:
+    printer._print = printer._print_interactive
+    table1 = printer.add_table(title="Table 1", size=2)
+    table2 = printer.add_table(title="Table 2", size=2)
+    table1.add_row({"foo": 1})
+    table2.add_row({"bar": 2})
+
+    printer.print()
+    assert get_output() == (
+        "Table 1\n"
+        "┏━━━━━┓\n"
+        "┃ foo ┃\n"
+        "┡━━━━━┩\n"
+        "│ 1   │\n"
+        "└─────┘\n"
+        "Table 2\n"
+        "┏━━━━━┓\n"
+        "┃ bar ┃\n"
+        "┡━━━━━┩\n"
+        "│ 2   │\n"
+        "└─────┘\n"
+    )
+
+    printer.print()
+    assert get_output() == ""
+
+
+def test_print_interactive_any_table_has_new_data(
+    printer: Printer, get_output: Callable[[], str]
+) -> None:
+    printer._print = printer._print_interactive
+    table1 = printer.add_table(title="Table 1", size=2)
+    table2 = printer.add_table(title="Table 2", size=2)
+    table1.add_row({"foo": 1})
+    table2.add_row({"bar": 2})
+
+    printer.print()
+    assert get_output() == (
+        "Table 1\n"
+        "┏━━━━━┓\n"
+        "┃ foo ┃\n"
+        "┡━━━━━┩\n"
+        "│ 1   │\n"
+        "└─────┘\n"
+        "Table 2\n"
+        "┏━━━━━┓\n"
+        "┃ bar ┃\n"
+        "┡━━━━━┩\n"
+        "│ 2   │\n"
+        "└─────┘\n"
+    )
+
+    table1.add_row({"foo": 11})
+    printer.print()
+    assert get_output() == (
+        "Table 1\n"
+        "┏━━━━━┓\n"
+        "┃ foo ┃\n"
+        "┡━━━━━┩\n"
+        "│ 1   │\n"
+        "│ 11  │\n"
+        "└─────┘\n"
+        "Table 2\n"
+        "┏━━━━━┓\n"
+        "┃ bar ┃\n"
+        "┡━━━━━┩\n"
+        "│ 2   │\n"
+        "└─────┘\n"
+    )
+
+
 def test_print_interactive(printer: Printer, get_output: Callable[[], str]) -> None:
     printer._print = printer._print_interactive
     table = printer.add_table(title="Test Table", size=2)


### PR DESCRIPTION
In interactive mode print all tables even if only one has new data.