### PR TITLE
add convert_ints_to_floats to InfluxDB3Sink

### DIFF
--- a/docs/connectors/sinks/influxdb3-sink.md
+++ b/docs/connectors/sinks/influxdb3-sink.md
@@ -131,8 +131,8 @@ Default - `False`.
 
 ## Testing Locally
 
-Rather than connect to Azure, you can alternatively test your application using a local 
-emulated Azure host via Docker:
+Rather than connect to a hosted InfluxDB3 instance, you can alternatively test your 
+application using a local instance of InfluxDb3 using Docker:
 
 1. Execute in terminal:
 

--- a/docs/connectors/sinks/influxdb3-sink.md
+++ b/docs/connectors/sinks/influxdb3-sink.md
@@ -113,6 +113,9 @@ Default - `ms`.
 - `include_metadata_tags` - if True, includes the record's key, topic, and partition as tags.  
 Default - `False`.
 
+- `convert_ints_to_floats` - if True, converts all integer values to floats.  
+Default - `False`.
+
 - `batch_size` - the number of records to write to InfluxDB in one request.    
 Note that it only affects the size of one write request, and not the number of records flushed on each checkpoint.    
 Default - `1000`.
@@ -125,3 +128,29 @@ Default - `10000`.
 
 - `debug` - if True, print debug logs from InfluxDB client.  
 Default - `False`.
+
+## Testing Locally
+
+Rather than connect to Azure, you can alternatively test your application using a local 
+emulated Azure host via Docker:
+
+1. Execute in terminal:
+
+    ```bash
+    docker run --rm -d --name influxdb3 \
+    -p 8181:8181 \
+    quay.io/influxdb/influxdb3-core:latest \
+    serve --node-id=host0 --object-store=memory
+    ```
+
+2. Use the following settings for `InfluxDB3Sink` to connect:
+
+    ```python
+    InfluxDB3Sink(
+        host="http://localhost:8181",   # be sure to add http
+        organization_id="local",        # unused, but required
+        token="local",                  # unused, but required
+   )
+    ```
+
+The `database` you provide will be auto-created for you.

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -270,18 +270,20 @@ class InfluxDB3Sink(BatchingSink):
                     tags["__topic"] = batch.topic
                     tags["__partition"] = batch.partition
 
-                field_values = (
-                    (f, value[f])
-                    for f in _fields_keys
-                    if f in value or not self._allow_missing_fields
-                )
+                if _fields_keys:
+                    fields = {
+                        f: value[f]
+                        for f in _fields_keys
+                        if f in value or not self._allow_missing_fields
+                    }
+                else:
+                    fields = value
+
                 if self._convert_ints_to_floats:
                     fields = {
                         k: float(v) if isinstance(v, int) else v
-                        for k, v in (field_values if _fields_keys else value.items())
+                        for k, v in fields.items()
                     }
-                else:
-                    fields = {k: v for k, v in field_values} if _fields_keys else value
 
                 ts = value[time_key] if time_key is not None else item.timestamp
                 record = {

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -61,6 +61,7 @@ class InfluxDB3Sink(BatchingSink):
         time_precision: TimePrecision = "ms",
         allow_missing_fields: bool = False,
         include_metadata_tags: bool = False,
+        convert_ints_to_floats: bool = False,
         batch_size: int = 1000,
         enable_gzip: bool = True,
         request_timeout_ms: int = 10_000,
@@ -119,6 +120,8 @@ class InfluxDB3Sink(BatchingSink):
         :param include_metadata_tags: if True, includes record's key, topic,
             and partition as tags.
             Default - `False`.
+        :param convert_ints_to_floats: if True, converts all integer values to floats.
+            Default - `False`.
         :param batch_size: how many records to write to InfluxDB in one request.
             Note that it only affects the size of one write request, and not the number
             of records flushed on each checkpoint.
@@ -155,20 +158,20 @@ class InfluxDB3Sink(BatchingSink):
                     f'Keys {overlap_str} are present in both "fields_keys" and "tags_keys"'
                 )
 
-        self._client_args = dict(
-            token=token,
-            host=host,
-            org=organization_id,
-            database=database,
-            debug=debug,
-            enable_gzip=enable_gzip,
-            timeout=request_timeout_ms,
-            write_client_options={
+        self._client_args = {
+            "token": token,
+            "host": host,
+            "org": organization_id,
+            "database": database,
+            "debug": debug,
+            "enable_gzip": enable_gzip,
+            "timeout": request_timeout_ms,
+            "write_client_options": {
                 "write_options": WriteOptions(
                     write_type=WriteType.synchronous,
                 )
             },
-        )
+        }
         self._client: Optional[InfluxDBClient3] = None
         self._measurement = self._measurement_callable(measurement)
         self._fields_keys = self._fields_callable(fields_keys)
@@ -178,6 +181,7 @@ class InfluxDB3Sink(BatchingSink):
         self._write_precision = self._TIME_PRECISIONS[time_precision]
         self._batch_size = batch_size
         self._allow_missing_fields = allow_missing_fields
+        self._convert_ints_to_floats = convert_ints_to_floats
 
     def _measurement_callable(self, setter: MeasurementSetter) -> MeasurementCallable:
         if callable(setter):
@@ -201,7 +205,11 @@ class InfluxDB3Sink(BatchingSink):
             # the best we can do is confirm authentication was successful
             self._client.query("")
         except Exception as e:
-            if "No SQL statements were provided in the query string" not in str(e):
+            e_str = str(e)
+            if not (
+                "No SQL statements were provided in the query string" in e_str
+                or "database not found" in e_str  # attempts making db when writing
+            ):
                 raise
 
     def add(
@@ -262,16 +270,19 @@ class InfluxDB3Sink(BatchingSink):
                     tags["__topic"] = batch.topic
                     tags["__partition"] = batch.partition
 
-                fields = (
-                    {
-                        field_key: value[field_key]
-                        for field_key in _fields_keys
-                        if (field_key in value or not self._allow_missing_fields)
-                        and field_key not in _tags_keys
-                    }
-                    if _fields_keys
-                    else value
+                field_values = (
+                    (f, value[f])
+                    for f in _fields_keys
+                    if f in value or not self._allow_missing_fields
                 )
+                if self._convert_ints_to_floats:
+                    fields = {
+                        k: float(v) if isinstance(v, int) else v
+                        for k, v in (field_values if _fields_keys else value.items())
+                    }
+                else:
+                    fields = {k: v for k, v in field_values} if _fields_keys else value
+
                 ts = value[time_key] if time_key is not None else item.timestamp
                 record = {
                     "measurement": _measurement,

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -98,10 +98,8 @@ class TestInfluxDB3Sink:
         )
         sink.flush()
 
-        assert client_mock.write.call_count == 1
-        first_call = client_mock.write.call_args_list[0]
-        assert first_call.kwargs == {
-            "record": [
+        client_mock.write.assert_called_once_with(
+            record=[
                 {
                     "measurement": measurement,
                     "tags": {},
@@ -109,8 +107,8 @@ class TestInfluxDB3Sink:
                     "time": timestamp,
                 }
             ],
-            "write_precision": "ms",
-        }
+            write_precision="ms",
+        )
 
     def test_write_tags_keys(self, influxdb3_sink_factory):
         client_mock = MagicMock(spec_set=InfluxDBClient3)
@@ -134,10 +132,8 @@ class TestInfluxDB3Sink:
         )
         sink.flush()
 
-        assert client_mock.write.call_count == 1
-        first_call = client_mock.write.call_args_list[0]
-        assert first_call.kwargs == {
-            "record": [
+        client_mock.write.assert_called_once_with(
+            record=[
                 {
                     "measurement": measurement,
                     "tags": {"tag1": 1},
@@ -145,8 +141,8 @@ class TestInfluxDB3Sink:
                     "time": timestamp,
                 }
             ],
-            "write_precision": "ms",
-        }
+            write_precision="ms",
+        )
 
     def test_write_values_not_dicts_fail(self, influxdb3_sink_factory):
         client_mock = MagicMock(spec_set=InfluxDBClient3)
@@ -188,10 +184,8 @@ class TestInfluxDB3Sink:
         )
         sink.flush()
 
-        assert client_mock.write.call_count == 1
-        first_call = client_mock.write.call_args_list[0]
-        assert first_call.kwargs == {
-            "record": [
+        client_mock.write.assert_called_once_with(
+            record=[
                 {
                     "measurement": measurement,
                     "tags": {"b": 2},
@@ -199,8 +193,8 @@ class TestInfluxDB3Sink:
                     "time": timestamp,
                 }
             ],
-            "write_precision": "ms",
-        }
+            write_precision="ms",
+        )
 
     def test_init_fields_keys_and_tags_keys_overlap_fails(self, influxdb3_sink_factory):
         client_mock = MagicMock(spec_set=InfluxDBClient3)
@@ -237,10 +231,8 @@ class TestInfluxDB3Sink:
         )
         sink.flush()
 
-        assert client_mock.write.call_count == 1
-        first_call = client_mock.write.call_args_list[0]
-        assert first_call.kwargs == {
-            "record": [
+        client_mock.write.assert_called_once_with(
+            record=[
                 {
                     "measurement": measurement,
                     "tags": {"__topic": topic, "__partition": 0, "__key": key},
@@ -248,8 +240,8 @@ class TestInfluxDB3Sink:
                     "time": timestamp,
                 }
             ],
-            "write_precision": "ms",
-        }
+            write_precision="ms",
+        )
 
     def test_write_batch_size(self, influxdb3_sink_factory):
         client_mock = MagicMock(spec_set=InfluxDBClient3)
@@ -396,10 +388,8 @@ class TestInfluxDB3Sink:
         )
         sink.flush()
 
-        assert client_mock.write.call_count == 1
-        first_call = client_mock.write.call_args_list[0]
-        assert first_call.kwargs == {
-            "record": [
+        client_mock.write.assert_called_once_with(
+            record=[
                 {
                     "measurement": measurement,
                     "tags": {},
@@ -407,5 +397,5 @@ class TestInfluxDB3Sink:
                     "time": timestamp,
                 }
             ],
-            "write_precision": "ms",
-        }
+            write_precision="ms",
+        )

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -366,12 +366,20 @@ class TestInfluxDB3Sink:
         with pytest.raises(influxdb_client_3.InfluxDBError):
             sink.flush()
 
-    def test_convert_ints_to_floats(self, influxdb3_sink_factory):
+    @pytest.mark.parametrize(
+        "fields_keys, result",
+        [
+            ((), {"str_key": "value", "int_key": 0.0, "float_key": 1.1}),
+            (("str_key", "int_key"), {"str_key": "value", "int_key": 0.0}),
+        ],
+    )
+    def test_convert_ints_to_floats(self, influxdb3_sink_factory, fields_keys, result):
         client_mock = MagicMock(spec_set=InfluxDBClient3)
         measurement = "measurement"
         sink = influxdb3_sink_factory(
             client_mock=client_mock,
             measurement=measurement,
+            fields_keys=fields_keys,
             convert_ints_to_floats=True,
         )
         topic = "test-topic"
@@ -395,7 +403,7 @@ class TestInfluxDB3Sink:
                 {
                     "measurement": measurement,
                     "tags": {},
-                    "fields": {"str_key": "value", "int_key": 0.0, "float_key": 1.1},
+                    "fields": result,
                     "time": timestamp,
                 }
             ],


### PR DESCRIPTION
Note the main challenge here is the set of fields is dynamic except when a static list of fields is passed, so for the most part we need to inspect each message value. 

We could add a separate check for when users pass a static list of fields (that is, `field_keys` is a non-empty, non-callable), but I figured if users are doing so, they probably are handling a small enough subset that it wouldn't make a huge difference to do something other than loop through them anyway.

I also considered making a dict with a hash of input fields and the list of fields that were ints or floats for that input set so we wouldn't have to loop through each field every time, but it was only beneficial with 50+ fields (of course better as field count went up) and when float fields were not the majority. Figured there were too many caveats with that approach to warrant overcomplicating the code.