### PR TITLE
InfluxDb v3 sink tags improvements

### DIFF
--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -253,8 +253,9 @@ class InfluxDB3Sink(BatchingSink):
                     #  by doing str().
                     #  We may add some extra validation here in the future to prevent
                     #  unwanted conversion.
-                    tag = value.pop(tag_key)
-                    tags[tag_key] = tag
+                    if tag_key in value:
+                        tag = value.pop(tag_key)
+                        tags[tag_key] = tag
 
                 if self._include_metadata_tags:
                     tags["__key"] = item.key


### PR DESCRIPTION
The sink will not fail if some of the tags specified are not present in some rows.