### PR TITLE
InfluxDB3Sink: improve timestamp type handling

### DIFF
--- a/docs/connectors/sinks/influxdb3-sink.md
+++ b/docs/connectors/sinks/influxdb3-sink.md
@@ -96,16 +96,27 @@ InfluxDB3Sink accepts the following configuration parameters:
 
 - `measurement` - a measurement name, required.
   
-- `fields_keys` - a list of keys to be used as "fields" when writing to InfluxDB.  
+- `fields_keys` - an iterable (list) of strings used as InfluxDB "fields".  
+  Also accepts a single-argument callable that receives the current message data as a dict and returns an iterable of strings.
+  - If present, it must not overlap with "tags_keys".
+  - If empty, the whole record value will be used.  
 See the [What data can be sent to InfluxDB](#what-data-can-be-sent-to-influxdb) for more info.
 
-- `tags_keys` - a list of keys to be used as "tags" when writing to InfluxDB.  
+- `tags_keys` - an iterable (list) of strings used as InfluxDB "tags".  
+  Also accepts a single-argument callable that receives the current message data as a 
+  dict and returns an iterable of strings.
+  - If present, it must not overlap with "fields_keys".
+  - Given keys are popped from the value dictionary since the same key
+    cannot be both a tag and field.
+  - If empty, no tags will be sent.  
 See the [What data can be sent to InfluxDB](#what-data-can-be-sent-to-influxdb) for more info.
 
-            
-- `time_key` - a key to be used as "time" when writing to InfluxDB.  
-By default, the record timestamp will be used with millisecond time precision.
-When using a custom key, you may need to adjust the `time_precision` setting to match.
+- `time_setter` - an optional column name to use as "time" for InfluxDB.  
+  Also accepts a callable which receives the current message data and
+  returns either the desired time or `None` (use default).  
+  - The time can be an `int`, `string` (RFC3339 format), or `datetime`.
+  - The time must match the `time_precision` argument if not a `datetime` object, else raises.
+  - By default, a record's kafka timestamp with `"ms"` time precision is used.
 
 - `time_precision` - a time precision to use when writing to InfluxDB.  
 Default - `ms`.

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -297,7 +297,6 @@ class InfluxDB3Sink(BatchingSink):
                 else:
                     ts = value[time_key]
                     # Note: currently NOT validating the timestamp itself is valid
-                    # Also, int length must correspond to the passed `time_precision`
                     if not isinstance(ts, valid := (str, int, datetime)):
                         raise TypeError(
                             f'InfluxDB3 "time" field expects: {valid}, got {type(ts)}'

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -308,7 +308,8 @@ class InfluxDB3Sink(BatchingSink):
                     if time_len != expected:
                         raise ValueError(
                             f'`time_precision` of "{self._write_precision}" '
-                            f"expects a {expected}-digit integer epoch, got {time_len}"
+                            f"expects a {expected}-digit integer epoch, "
+                            f"got {time_len} (timestamp: {ts})."
                         )
 
                 record = {

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -116,10 +116,12 @@ class InfluxDB3Sink(BatchingSink):
             - If empty, no tags will be sent.
             >***NOTE***: InfluxDB client always converts tag values to strings.
             Default - `()`.
-        :param time_setter: a key to be used as "time" when writing to InfluxDB.
-            By default, the record timestamp will be used with "ms" time precision.
-            When using a custom key, you may need to adjust the `time_precision` setting
-            to match.
+        :param time_setter: an optional column name to use as "time" for InfluxDB.
+            Also accepts a callable which receives the current message data and
+            returns either the desired time or `None` (use default).
+            The time can be an `int`, `string` (RFC3339 format), or `datetime`.
+            The time must match the `time_precision` argument if not a `datetime` object, else raises.
+            By default, a record's kafka timestamp with "ms" time precision is used.
         :param time_precision: a time precision to use when writing to InfluxDB.
             Possible values: "ms", "ns", "us", "s".
             Default - `"ms"`.

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -263,12 +263,11 @@ class InfluxDB3Sink(BatchingSink):
 
                 if ts is None:
                     ts = item.timestamp
-                else:
-                    # Note: currently NOT validating the timestamp itself is valid
-                    if not isinstance(ts, valid := (str, int, datetime)):
-                        raise TypeError(
-                            f'InfluxDB3 "time" field expects: {valid}, got {type(ts)}'
-                        )
+                # Note: currently NOT validating the timestamp itself is valid
+                elif not isinstance(ts, valid := (str, int, datetime)):
+                    raise TypeError(
+                        f'InfluxDB3 "time" field expects: {valid}, got {type(ts)}'
+                    )
 
                 if isinstance(ts, int):
                     time_len = len(str(ts))

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -294,7 +294,7 @@ class InfluxDB3Sink(BatchingSink):
 
                 if self._convert_ints_to_floats:
                     fields = {
-                        k: float(v) if isinstance(v, int) else v
+                        k: float(v) if type(v) is int else v  # avoids bool matching
                         for k, v in fields.items()
                     }
 

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Callable, Iterable, Literal, Mapping, Optional, Union, get_args
 
 from quixstreams.models import HeadersTuples
@@ -350,7 +350,7 @@ def _ts_min_default(timestamp: Union[int, str, datetime]):
     elif isinstance(timestamp, str):
         return "~"  # lexicographically largest ASCII char
     elif isinstance(timestamp, datetime):
-        return datetime.max
+        return datetime.max.replace(tzinfo=timezone.utc)
 
 
 def _ts_max_default(timestamp: Union[int, str, datetime]):
@@ -359,4 +359,4 @@ def _ts_max_default(timestamp: Union[int, str, datetime]):
     elif isinstance(timestamp, str):
         return ""
     elif isinstance(timestamp, datetime):
-        return datetime.min
+        return datetime.min.replace(tzinfo=timezone.utc)

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -31,7 +31,7 @@ def influxdb3_sink_factory():
             measurement=measurement,
             fields_keys=fields_keys,
             tags_keys=tags_keys,
-            time_key=time_key,
+            time_setter=time_key,
             time_precision=time_precision,
             include_metadata_tags=include_metadata_tags,
             convert_ints_to_floats=convert_ints_to_floats,
@@ -50,7 +50,7 @@ class TestInfluxDB3Sink:
         sink = influxdb3_sink_factory(client_mock=client_mock, measurement=measurement)
         topic = "test-topic"
 
-        value, timestamp = {"key": "value"}, 1
+        value, timestamp = {"key": "value"}, 1234567890123
         for partition in (0, 1):
             sink.add(
                 value=value,
@@ -87,7 +87,7 @@ class TestInfluxDB3Sink:
         )
         topic = "test-topic"
 
-        value, timestamp = {"key1": 1, "key2": 2}, 1
+        value, timestamp = {"key1": 1, "key2": 2}, 1234567890123
         sink.add(
             value=value,
             key="key",
@@ -121,7 +121,7 @@ class TestInfluxDB3Sink:
         )
         topic = "test-topic"
 
-        value, timestamp = {"key1": 1, "tag1": 1}, 1
+        value, timestamp = {"key1": 1, "tag1": 1}, 1234567890123
         sink.add(
             value=value,
             key="key",
@@ -173,7 +173,7 @@ class TestInfluxDB3Sink:
         )
         topic = "test-topic"
 
-        value, timestamp = {"a": 1, "b": 2}, 1
+        value, timestamp = {"a": 1, "b": 2}, 1234567890123
         sink.add(
             value=value,
             key="key",
@@ -220,7 +220,7 @@ class TestInfluxDB3Sink:
         )
         topic = "test-topic"
 
-        key, value, timestamp = "key", {"key1": 1, "tag1": 1}, 1
+        key, value, timestamp = "key", {"key1": 1, "tag1": 1}, 1234567890123
         sink.add(
             value=value,
             key=key,
@@ -254,7 +254,7 @@ class TestInfluxDB3Sink:
         topic = "test-topic"
 
         value1, value2 = {"key": "value1"}, {"key": "value2"}
-        timestamp = 1
+        timestamp = 1234567890123
         sink.add(
             value=value1,
             key="key",
@@ -318,7 +318,7 @@ class TestInfluxDB3Sink:
         topic = "test-topic"
 
         value1 = {"key": "value1"}
-        timestamp = 1
+        timestamp = 1234567890123
         sink.add(
             value=value1,
             key="key",
@@ -346,7 +346,7 @@ class TestInfluxDB3Sink:
         topic = "test-topic"
 
         value1 = {"key": "value1"}
-        timestamp = 1
+        timestamp = 1234567890123
         sink.add(
             value=value1,
             key="key",
@@ -377,7 +377,8 @@ class TestInfluxDB3Sink:
         )
         topic = "test-topic"
 
-        value, timestamp = {"str_key": "value", "int_key": 0, "float_key": 1.1}, 1
+        value = {"str_key": "value", "int_key": 0, "float_key": 1.1}
+        timestamp = 1234567890123
         sink.add(
             value=value,
             key="key",
@@ -429,7 +430,7 @@ class TestInfluxDB3Sink:
         sink.add(
             value=value,
             key="key",
-            timestamp=1,
+            timestamp=1234567890123,
             headers=[],
             topic=topic,
             partition=0,
@@ -472,7 +473,7 @@ class TestInfluxDB3Sink:
         sink.add(
             value=value,
             key="key",
-            timestamp=1,
+            timestamp=1234567890123,
             headers=[],
             topic=topic,
             partition=0,
@@ -484,3 +485,6 @@ class TestInfluxDB3Sink:
         error_str = str(e)
         assert precision in error_str
         assert "got 16" in error_str
+
+
+# TODO: add tests for all the different passable callables.

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -406,7 +406,9 @@ class TestInfluxDB3Sink:
         (
             1625140800123,
             "2021-07-01T00:00:00Z",
-            datetime.datetime(2021, 7, 1, 0, 0, 0, 123456),
+            datetime.datetime(
+                2021, 7, 1, 0, 0, 0, 123456, tzinfo=datetime.timezone.utc
+            ),
         ),
     )
     def test_valid_timestamps(self, influxdb3_sink_factory, time, caplog):

--- a/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_influxdb_v3.py
@@ -452,7 +452,7 @@ class TestInfluxDB3Sink:
 
     def test_invalid_int_timestamp(self, influxdb3_sink_factory):
         """
-        Valid timestamps are accepted and correctly recognize as mins/maxes.
+        Integer timestamps must match the precision length else raise an error.
         """
         precision = "ms"
         client_mock = MagicMock(spec_set=InfluxDBClient3)


### PR DESCRIPTION
Changed some behavior around timestamp handling so when non-int timestamps are used, they could properly evaluate the min and max.

Also added further validation that helps with errors that are not super obvious to end user.