### PR TITLE
sinks/InfluxDB3: adjust check to work with v2 and v3

### DIFF
--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -199,11 +199,10 @@ class InfluxDB3Sink(BatchingSink):
 
     def _get_influx_version(self):
         # This validates the token is valid regardless of version
-        headers = {"Authorization": f"Token {self._client_args['token']}"}
         try:
             r = requests.get(
                 urljoin(self._client_args["host"], "ping"),
-                headers=headers,
+                headers={"Authorization": f"Token {self._client_args['token']}"},
                 timeout=self._request_timeout_ms / 1000,
             )
             r.raise_for_status()


### PR DESCRIPTION
Previously, influxdb v3 sink also worked for v2, but a recent change (adding connection validation) broke it. 

This adjusts that connection check so v2 can work again with this sink, per the request of Tomas.