### PR TITLE
feat(lookup.quix_configuration_service): add support for binary and JSON fields

### DIFF
--- a/quixstreams/dataframe/joins/lookups/__init__.py
+++ b/quixstreams/dataframe/joins/lookups/__init__.py
@@ -1,7 +1,8 @@
 from .base import BaseField, BaseLookup
 from .quix_configuration_service import (
     QuixConfigurationService,
-    QuixConfigurationServiceField,
+    QuixConfigurationServiceBytesField,
+    QuixConfigurationServiceJSONField,
 )
 from .sqlite import SQLiteLookup, SQLiteLookupField, SQLiteLookupQueryField
 
@@ -13,4 +14,6 @@ __all__ = [
     "SQLiteLookup",
     "SQLiteLookupField",
     "SQLiteLookupQueryField",
+    "QuixConfigurationServiceJSONField",
+    "QuixConfigurationServiceBytesField",
 ]

--- a/quixstreams/dataframe/joins/lookups/quix_configuration_service/__init__.py
+++ b/quixstreams/dataframe/joins/lookups/quix_configuration_service/__init__.py
@@ -1,7 +1,9 @@
 from .lookup import Lookup as QuixConfigurationService
-from .models import Field as QuixConfigurationServiceField
+from .models import BytesField as QuixConfigurationServiceBytesField
+from .models import JSONField as QuixConfigurationServiceJSONField
 
 __all__ = [
     "QuixConfigurationService",
-    "QuixConfigurationServiceField",
+    "QuixConfigurationServiceJSONField",
+    "QuixConfigurationServiceBytesField",
 ]

--- a/quixstreams/dataframe/joins/lookups/quix_configuration_service/cache.py
+++ b/quixstreams/dataframe/joins/lookups/quix_configuration_service/cache.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Optional, Tuple
 from quixstreams.utils.pickle import pickle_copier
 
 from ..utils import CacheInfo
-from .models import ConfigurationVersion, Field
+from .models import BaseField, ConfigurationVersion
 
 
 class VersionDataLRU:
@@ -23,7 +23,7 @@ class VersionDataLRU:
 
     def __init__(
         self,
-        func: Callable[[Optional[ConfigurationVersion], dict[str, Field]], Any],
+        func: Callable[[Optional[ConfigurationVersion], dict[str, BaseField]], Any],
         maxsize: int = 128,
     ):
         self.cache: OrderedDict[
@@ -35,7 +35,7 @@ class VersionDataLRU:
         self.misses = 0
 
     def __call__(
-        self, version: Optional[ConfigurationVersion], fields: dict[str, Field]
+        self, version: Optional[ConfigurationVersion], fields: dict[str, BaseField]
     ) -> Any:
         """
         Get cached data for the given version and fields, or compute and cache it.
@@ -60,7 +60,7 @@ class VersionDataLRU:
         return result
 
     def remove(
-        self, version: Optional[ConfigurationVersion], fields: dict[str, Field]
+        self, version: Optional[ConfigurationVersion], fields: dict[str, BaseField]
     ) -> None:
         """
         Remove the cached data for the given version and fields, if present.

--- a/quixstreams/dataframe/joins/lookups/quix_configuration_service/lookup.py
+++ b/quixstreams/dataframe/joins/lookups/quix_configuration_service/lookup.py
@@ -15,7 +15,15 @@ from ..base import BaseLookup
 from ..utils import CacheInfo
 from .cache import VersionDataLRU
 from .environment import QUIX_REPLICA_NAME
-from .models import Configuration, ConfigurationVersion, Event, Field
+from .models import (
+    RAISE_ON_MISSING,
+    BaseField,
+    BytesField,
+    Configuration,
+    ConfigurationVersion,
+    Event,
+    JSONField,
+)
 
 if TYPE_CHECKING:
     from quixstreams.app import ApplicationConfig
@@ -23,12 +31,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-FALLBACK_DEFAULT = object()
 DEFAULT_REQUEST_TIMEOUT = 5
 DEFAULT_CONSUMER_GROUP = "enrich"
 
 
-class Lookup(BaseLookup[Field]):
+class Lookup(BaseLookup[BaseField]):
     """
     Lookup join implementation for enriching streaming data with configuration data from a Kafka topic.
 
@@ -109,15 +116,59 @@ class Lookup(BaseLookup[Field]):
 
         self._start()
 
-        self._fields_by_type: dict[int, dict[str, dict[str, Field]]] = defaultdict(dict)
+        self._fields_by_type: dict[int, dict[str, dict[str, BaseField]]] = defaultdict(
+            dict
+        )
 
-    def _fetch_version_content(self, version: ConfigurationVersion) -> Optional[Any]:
+    def json_field(
+        self,
+        jsonpath: str,
+        type: str,
+        first_match_only: bool = True,
+        default: Any = RAISE_ON_MISSING,
+    ) -> JSONField:
         """
-        Fetch and parse JSON content from the URL specified in the version's contentUrl attribute.
+        Create a JSON field for extracting values from configuration content using JSONPath.
 
-        :param version: The configuration version containing the contentUrl to fetch JSON content from.
+        :param jsonpath: The JSONPath expression to extract the value.
+        :param type: The configuration type.
+        :param first_match_only: If True, only the first match is returned, otherwise all matches are returned.
+        :param default: The default value if the field is missing.
 
-        :returns: The parsed JSON content, or FALLBACK_DEFAULT if fetching fails and fallback is enabled.
+        :returns: A JSONField instance.
+        """
+        return JSONField(
+            jsonpath=jsonpath,
+            type=type,
+            first_match_only=first_match_only,
+            default=default,
+        )
+
+    def bytes_field(
+        self,
+        type: str,
+        default: Any = RAISE_ON_MISSING,
+    ) -> BytesField:
+        """
+        Create a bytes field for extracting binary content from configuration.
+
+        :param type: The configuration type.
+        :param default: The default value if the field is missing.
+
+        :returns: A BytesField instance.
+        """
+        return BytesField(
+            type=type,
+            default=default,
+        )
+
+    def _fetch_version_content(self, version: ConfigurationVersion) -> Optional[bytes]:
+        """
+        Fetch raw content from the URL specified in the version's contentUrl attribute.
+
+        :param version: The configuration version containing the contentUrl to fetch raw content from.
+
+        :returns: The raw content, or None if fetching fails and fallback is enabled.
 
         :raises: Exception: If fetching fails and fallback is set to "error".
         """
@@ -128,7 +179,7 @@ class Lookup(BaseLookup[Field]):
             )
             response.raise_for_status()
             version.success()
-            return orjson.loads(response.content)
+            return response.content
         except Exception as e:
             logger.error(
                 f"Failed to fetch configuration content from {version.contentUrl}: {e}"
@@ -137,7 +188,7 @@ class Lookup(BaseLookup[Field]):
                 raise
 
             version.failed()
-            return FALLBACK_DEFAULT
+            return None
 
     def _start(self) -> None:
         """
@@ -291,7 +342,7 @@ class Lookup(BaseLookup[Field]):
         return version
 
     def _version_data(
-        self, version: Optional[ConfigurationVersion], fields: dict[str, Field]
+        self, version: Optional[ConfigurationVersion], fields: dict[str, BaseField]
     ) -> dict[str, Any]:
         """
         Retrieve the configuration data for a given version and fields.
@@ -305,7 +356,7 @@ class Lookup(BaseLookup[Field]):
             return {key: field.missing() for key, field in fields.items()}
 
         content = self._fetch_version_content(version)
-        if content is FALLBACK_DEFAULT:
+        if content is None:
             return {key: field.missing() for key, field in fields.items()}
 
         return {
@@ -327,7 +378,7 @@ class Lookup(BaseLookup[Field]):
 
     def join(
         self,
-        fields: Mapping[str, Field],
+        fields: Mapping[str, BaseField],
         on: str,
         value: dict[str, Any],
         key: Any,

--- a/quixstreams/dataframe/joins/lookups/quix_configuration_service/models.py
+++ b/quixstreams/dataframe/joins/lookups/quix_configuration_service/models.py
@@ -140,7 +140,7 @@ class ConfigurationVersion:
     version: int
     contentUrl: str
     sha256sum: str
-    valid_from: float  # timestamp ms
+    valid_from: Optional[float]  # timestamp ms
     retry_count: int = dataclasses.field(default=0, hash=False, init=False)
     retry_at: int = dataclasses.field(default=sys.maxsize, hash=False, init=False)
 

--- a/tests/test_quixstreams/test_dataframe/test_joins/test_lookup_quix_config.py
+++ b/tests/test_quixstreams/test_dataframe/test_joins/test_lookup_quix_config.py
@@ -147,7 +147,7 @@ class TestConfiguration:
 
     def test_find_valid_version_single_version_no_timestamp(self):
         """Test finding valid version with a single version that has no valid_from timestamp."""
-        version = create_configuration_version(version=1, valid_from=0)
+        version = create_configuration_version(version=1, valid_from=None)
         config = Configuration(versions={1: version})
 
         result = config.find_valid_version(1500)
@@ -258,7 +258,9 @@ class TestConfiguration:
     def test_find_valid_version_mixed_timestamp_and_no_timestamp(self):
         """Test finding valid version with mix of timestamped and non-timestamped versions."""
         version1 = create_configuration_version(version=1, valid_from=1000.0)
-        version2 = create_configuration_version(version=2, valid_from=0.0)
+        version2 = create_configuration_version(
+            version=2, valid_from=None
+        )  # No timestamp
         version3 = create_configuration_version(version=3, valid_from=3000.0)
 
         config = Configuration(versions={1: version1, 2: version2, 3: version3})
@@ -314,8 +316,8 @@ class TestConfiguration:
 
     def test_find_versions_with_no_timestamp_versions(self):
         """Test _find_versions with versions that have no valid_from timestamp."""
-        version1 = create_configuration_version(version=1, valid_from=0.0)
-        version2 = create_configuration_version(version=2, valid_from=0.0)
+        version1 = create_configuration_version(version=1, valid_from=None)
+        version2 = create_configuration_version(version=2, valid_from=None)
 
         config = Configuration(versions={1: version1, 2: version2})
 
@@ -405,7 +407,7 @@ class TestConfigurationVersion:
 
         assert version.id == "test-config"
         assert version.version == 1
-        assert version.valid_from == 0
+        assert version.valid_from is None
 
     def test_success_method(self):
         """Test the success method resets retry parameters."""
@@ -610,7 +612,10 @@ class TestLookupFindVersion:
         wildcard_id = lookup._config_id("user-config", "*")
 
         # All should be different
-        assert len({config_id1, config_id2, config_id3, wildcard_id}) == 4
+        assert config_id1 != config_id2
+        assert config_id1 != config_id3
+        assert config_id1 != wildcard_id
+        assert config_id2 != config_id3
 
         # Same inputs should produce same ID
         assert config_id1 == lookup._config_id("user-config", "user123")


### PR DESCRIPTION
…SON fields

- Introduce BytesField and JSONField for the Quix Configuration Lookup
- Update Quix Configuration Lookup to provide json_field and bytes_field helpers
- Refactor tests to use new field types and helpers

This enables extraction of both JSON and binary content from configuration services, improving flexibility for downstream consumers.