### PR TITLE
Feature: Early Window Expiration with Triggers

### DIFF
--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -596,19 +596,21 @@ if __name__ == '__main__':
 ### Early window expiration with triggers
 !!! info New in v3.24.0
 
-To expire windows before their natural expiration time based on custom conditions, you can pass the `on_update` callback to `.tumbling_window()` and `.hopping_window()` methods.
+To expire windows before their natural expiration time based on custom conditions, you can pass `before_update` or `after_update` callbacks to `.tumbling_window()` and `.hopping_window()` methods.
 
 This is useful when you want to emit results as soon as certain conditions are met, rather than waiting for the window to close naturally.
 
 **How it works**:
 
-- The `on_update` callback is invoked every time a window is updated with a new value.
-- It receives `old_value` and `new_value` - the raw aggregated values before and after the update.
-- For `collect()` operations, it receives lists of collected values.
-- If the callback returns `True`, the window is immediately expired and emitted downstream.
-- The expired window is removed from state, but may be "resurrected" if new data arrives within its time range before natural expiration.
+- The `before_update` callback is invoked before the window aggregation is updated with a new value.
+- The `after_update` callback is invoked after the window aggregation has been updated with a new value.
+- Both callbacks receive: `aggregated` (current or updated aggregated value), `value` (incoming value), `key`, `timestamp`, and `headers`.
+- For `collect()` operations without aggregation, `aggregated` contains the list of collected values.
+- If either callback returns `True`, the window is immediately expired and emitted downstream.
+- The window metadata is deleted from state, but collected values (if using `.collect()`) remain until natural expiration.
+- This means a triggered window can be "resurrected" if new data arrives within its time range - a new window will be created with the previously collected values still present.
 
-**Example**:
+**Example with after_update**:
 
 ```python
 from typing import Any
@@ -620,16 +622,18 @@ app = Application(...)
 sdf = app.dataframe(...)
 
 
-def trigger_on_threshold(old_value: int, new_value: int) -> bool:
+def trigger_on_threshold(
+    aggregated: int, value: Any, key: Any, timestamp: int, headers: Any
+) -> bool:
     """
     Expire the window early when the sum exceeds 1000.
     """
-    return new_value > 1000
+    return aggregated > 1000
 
 
 # Define a 1-hour tumbling window with early expiration trigger
 sdf = (
-    sdf.tumbling_window(timedelta(hours=1), on_update=trigger_on_threshold)
+    sdf.tumbling_window(timedelta(hours=1), after_update=trigger_on_threshold)
     .sum()
     .final()
 )
@@ -638,6 +642,25 @@ sdf = (
 if __name__ == '__main__':
     app.run()
 
+```
+
+**Example with before_update**:
+
+```python
+def trigger_before_large_value(
+    aggregated: int, value: Any, key: Any, timestamp: int, headers: Any
+) -> bool:
+    """
+    Expire the window before adding a value if it would make the sum too large.
+    """
+    return (aggregated + value) > 1000
+
+
+sdf = (
+    sdf.tumbling_window(timedelta(hours=1), before_update=trigger_before_large_value)
+    .sum()
+    .final()
+)
 ```
 
 

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -72,7 +72,7 @@ from .windows import (
     TumblingCountWindowDefinition,
     TumblingTimeWindowDefinition,
 )
-from .windows.base import WindowOnLateCallback
+from .windows.base import WindowOnLateCallback, WindowOnUpdateCallback
 
 if typing.TYPE_CHECKING:
     from quixstreams.processing import ProcessingContext
@@ -1085,6 +1085,7 @@ class StreamingDataFrame:
         grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
+        on_update: Optional[WindowOnUpdateCallback] = None,
     ) -> TumblingTimeWindowDefinition:
         """
         Create a time-based tumbling window transformation on this StreamingDataFrame.
@@ -1151,6 +1152,14 @@ class StreamingDataFrame:
             (default behavior).
             Otherwise, no message will be logged.
 
+        :param on_update: an optional callback to trigger early window expiration based
+            on custom conditions.
+            The callback receives `old_value` and `new_value` (the raw aggregated values
+            before and after the update). If it returns `True`, the window will be expired
+            immediately, even if it hasn't reached its natural expiration time.
+            For `collect()` operations, the callback receives lists of collected values.
+            Default - `None`.
+
         :return: `TumblingTimeWindowDefinition` instance representing the tumbling window
             configuration.
             This object can be further configured with aggregation functions
@@ -1166,6 +1175,7 @@ class StreamingDataFrame:
             dataframe=self,
             name=name,
             on_late=on_late,
+            on_update=on_update,
         )
 
     def tumbling_count_window(
@@ -1225,6 +1235,7 @@ class StreamingDataFrame:
         grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
+        on_update: Optional[WindowOnUpdateCallback] = None,
     ) -> HoppingTimeWindowDefinition:
         """
         Create a time-based hopping window transformation on this StreamingDataFrame.
@@ -1302,6 +1313,14 @@ class StreamingDataFrame:
             (default behavior).
             Otherwise, no message will be logged.
 
+        :param on_update: an optional callback to trigger early window expiration based
+            on custom conditions.
+            The callback receives `old_value` and `new_value` (the raw aggregated values
+            before and after the update). If it returns `True`, the window will be expired
+            immediately, even if it hasn't reached its natural expiration time.
+            For `collect()` operations, the callback receives lists of collected values.
+            Default - `None`.
+
         :return: `HoppingTimeWindowDefinition` instance representing the hopping
             window configuration.
             This object can be further configured with aggregation functions
@@ -1319,6 +1338,7 @@ class StreamingDataFrame:
             dataframe=self,
             name=name,
             on_late=on_late,
+            on_update=on_update,
         )
 
     def hopping_count_window(

--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -72,7 +72,11 @@ from .windows import (
     TumblingCountWindowDefinition,
     TumblingTimeWindowDefinition,
 )
-from .windows.base import WindowOnLateCallback, WindowOnUpdateCallback
+from .windows.base import (
+    WindowAfterUpdateCallback,
+    WindowBeforeUpdateCallback,
+    WindowOnLateCallback,
+)
 
 if typing.TYPE_CHECKING:
     from quixstreams.processing import ProcessingContext
@@ -1085,7 +1089,8 @@ class StreamingDataFrame:
         grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
-        on_update: Optional[WindowOnUpdateCallback] = None,
+        before_update: Optional[WindowBeforeUpdateCallback] = None,
+        after_update: Optional[WindowAfterUpdateCallback] = None,
     ) -> TumblingTimeWindowDefinition:
         """
         Create a time-based tumbling window transformation on this StreamingDataFrame.
@@ -1152,12 +1157,18 @@ class StreamingDataFrame:
             (default behavior).
             Otherwise, no message will be logged.
 
-        :param on_update: an optional callback to trigger early window expiration based
-            on custom conditions.
-            The callback receives `old_value` and `new_value` (the raw aggregated values
-            before and after the update). If it returns `True`, the window will be expired
-            immediately, even if it hasn't reached its natural expiration time.
-            For `collect()` operations, the callback receives lists of collected values.
+        :param before_update: an optional callback to trigger early window expiration
+            before the window is updated.
+            The callback receives `aggregated` (current aggregated value or default/None),
+            `value`, `key`, `timestamp`, and `headers`.
+            If it returns `True`, the window will be expired immediately.
+            Default - `None`.
+
+        :param after_update: an optional callback to trigger early window expiration
+            after the window is updated.
+            The callback receives `aggregated` (updated aggregated value), `value`, `key`,
+            `timestamp`, and `headers`.
+            If it returns `True`, the window will be expired immediately.
             Default - `None`.
 
         :return: `TumblingTimeWindowDefinition` instance representing the tumbling window
@@ -1175,7 +1186,8 @@ class StreamingDataFrame:
             dataframe=self,
             name=name,
             on_late=on_late,
-            on_update=on_update,
+            before_update=before_update,
+            after_update=after_update,
         )
 
     def tumbling_count_window(
@@ -1235,7 +1247,8 @@ class StreamingDataFrame:
         grace_ms: Union[int, timedelta] = 0,
         name: Optional[str] = None,
         on_late: Optional[WindowOnLateCallback] = None,
-        on_update: Optional[WindowOnUpdateCallback] = None,
+        before_update: Optional[WindowBeforeUpdateCallback] = None,
+        after_update: Optional[WindowAfterUpdateCallback] = None,
     ) -> HoppingTimeWindowDefinition:
         """
         Create a time-based hopping window transformation on this StreamingDataFrame.
@@ -1313,12 +1326,18 @@ class StreamingDataFrame:
             (default behavior).
             Otherwise, no message will be logged.
 
-        :param on_update: an optional callback to trigger early window expiration based
-            on custom conditions.
-            The callback receives `old_value` and `new_value` (the raw aggregated values
-            before and after the update). If it returns `True`, the window will be expired
-            immediately, even if it hasn't reached its natural expiration time.
-            For `collect()` operations, the callback receives lists of collected values.
+        :param before_update: an optional callback to trigger early window expiration
+            before the window is updated.
+            The callback receives `aggregated` (current aggregated value or default/None),
+            `value`, `key`, `timestamp`, and `headers`.
+            If it returns `True`, the window will be expired immediately.
+            Default - `None`.
+
+        :param after_update: an optional callback to trigger early window expiration
+            after the window is updated.
+            The callback receives `aggregated` (updated aggregated value), `value`, `key`,
+            `timestamp`, and `headers`.
+            If it returns `True`, the window will be expired immediately.
             Default - `None`.
 
         :return: `HoppingTimeWindowDefinition` instance representing the hopping
@@ -1338,7 +1357,8 @@ class StreamingDataFrame:
             dataframe=self,
             name=name,
             on_late=on_late,
-            on_update=on_update,
+            before_update=before_update,
+            after_update=after_update,
         )
 
     def hopping_count_window(

--- a/quixstreams/dataframe/windows/base.py
+++ b/quixstreams/dataframe/windows/base.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 WindowResult: TypeAlias = dict[str, Any]
 WindowKeyResult: TypeAlias = tuple[Any, WindowResult]
 Message: TypeAlias = tuple[WindowResult, Any, int, Any]
+WindowOnUpdateCallback: TypeAlias = Callable[[Any, Any], bool]
 
 WindowAggregateFunc = Callable[[Any, Any], Any]
 

--- a/quixstreams/dataframe/windows/count_based.py
+++ b/quixstreams/dataframe/windows/count_based.py
@@ -58,6 +58,7 @@ class CountWindow(Window):
         value: Any,
         key: Any,
         timestamp_ms: int,
+        headers: Any,
         transaction: WindowedPartitionTransaction[str, CountWindowsData],
     ) -> tuple[Iterable[WindowKeyResult], Iterable[WindowKeyResult]]:
         """

--- a/quixstreams/dataframe/windows/sliding.py
+++ b/quixstreams/dataframe/windows/sliding.py
@@ -35,6 +35,7 @@ class SlidingWindow(TimeWindow):
         value: Any,
         key: Any,
         timestamp_ms: int,
+        headers: Any,
         transaction: WindowedPartitionTransaction,
     ) -> tuple[Iterable[WindowKeyResult], Iterable[WindowKeyResult]]:
         """

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional
@@ -269,9 +270,9 @@ class TimeWindow(Window):
             )
 
         # Combine triggered windows with time-expired windows
-        all_expired_windows = triggered_windows + list(expired_windows)
+        all_expired_windows = itertools.chain(expired_windows, triggered_windows)
 
-        return updated_windows, iter(all_expired_windows)
+        return updated_windows, all_expired_windows
 
     def expire_by_partition(
         self,

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -190,11 +190,9 @@ class TimeWindow(Window):
                     current_value, value, key, timestamp_ms, headers
                 ):
                     # Get collected values for the result
-                    collected = []
-                    if collect:
-                        collected = state.get_from_collection(start, end)
-                        # Add the current value that's being collected
-                        collected.append(self._collect_value(value))
+                    # Do NOT include the current value - before_update means
+                    # we expire BEFORE adding the current value
+                    collected = state.get_from_collection(start, end) if collect else []
 
                     result = self._results(current_value, collected, start, end)
                     triggered_windows.append((key, result))

--- a/quixstreams/state/types.py
+++ b/quixstreams/state/types.py
@@ -391,6 +391,16 @@ class WindowedPartitionTransaction(Protocol[K, V]):
         """
         ...
 
+    def delete_window(self, start_ms: int, end_ms: int, prefix: bytes) -> None:
+        """
+        Delete a single window defined by start and end timestamps.
+
+        :param start_ms: start of the window in milliseconds
+        :param end_ms: end of the window in milliseconds
+        :param prefix: a key prefix
+        """
+        ...
+
     def delete_windows(
         self, max_start_time: int, delete_values: bool, prefix: bytes
     ) -> None:

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_sliding.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_sliding.py
@@ -21,9 +21,13 @@ AGGREGATE_PARAMS = {
 }
 
 
-def process(window, value, key, transaction, timestamp_ms):
+def process(window, value, key, transaction, timestamp_ms, headers=None):
     updated, expired = window.process_window(
-        value=value, key=key, transaction=transaction, timestamp_ms=timestamp_ms
+        value=value,
+        key=key,
+        transaction=transaction,
+        timestamp_ms=timestamp_ms,
+        headers=headers,
     )
     return list(updated), list(expired)
 


### PR DESCRIPTION
## Early Window Expiration with Triggers

This PR adds support for early window expiration via callback triggers for tumbling and hopping windows.

### Feature Overview

Windows can now be expired early based on custom logic by providing `before_update` or `after_update` callbacks when defining a window. When these callbacks return `True`, the window is immediately expired rather than waiting for its natural expiration time.

### API

Two new optional parameters added to `tumbling_window()` and `hopping_window()`:

- **`before_update`**: Callback invoked before updating the window state
  - Receives the current aggregated value (or collection) before the new value is applied
  - Useful for preventing a value from being included if a threshold would be exceeded

- **`after_update`**: Callback invoked after updating the window state  
  - Receives the updated aggregated value (or collection) after the new value is applied
  - Useful for expiring a window once a threshold is reached

Both callbacks receive: `(aggregated, value, key, timestamp, headers) -> bool`

### Examples

**After Update - Expire when sum exceeds threshold:**
```python
def trigger_on_sum(aggregated, value, key, timestamp, headers):
    return aggregated > 100  # Expire when sum exceeds 100

sdf = app.dataframe(topic)
sdf = sdf.tumbling_window(duration_ms=60000, after_update=trigger_on_sum).sum().final()
```

**Before Update - Prevent value from exceeding threshold:**
```python
def trigger_before_exceeding(aggregated, value, key, timestamp, headers):
    return (aggregated + value) > 100  # Expire before sum would exceed 100

sdf = app.dataframe(topic)
sdf = sdf.tumbling_window(duration_ms=60000, before_update=trigger_before_exceeding).sum().final()
```

**With collect operations:**
```python
def trigger_on_count(aggregated, value, key, timestamp, headers):
    return len(aggregated) >= 10  # Expire when 10 items collected

sdf = app.dataframe(topic)
sdf = sdf.tumbling_window(duration_ms=60000, after_update=trigger_on_count).collect().final()
```

### Implementation Details

- Triggered windows are moved to the expired windows list and deleted from state
- Collection values are not immediately deleted; normal expiration handles cleanup
- This means triggered windows can be "resurrected" if new data arrives before natural expiration
- Works with both aggregation operations (`.sum()`, `.mean()`, etc.) and `.collect()`
- Fully compatible with overlapping hopping windows