### PR TITLE
Feature: InfluxDB3 sink verify_ssl param

### DIFF
--- a/docs/connectors/sinks/influxdb3-sink.md
+++ b/docs/connectors/sinks/influxdb3-sink.md
@@ -165,6 +165,10 @@ Default - `False`.
   rejects points due to retention policy violations...
   Default - `False`.
 
+- `verify_ssl` - if True, verifies SSL certificates when connecting to InfluxDB.
+  Set this to false to skip verifying SSL certificate when calling APIs, useful for environments using self-signed certificates.
+  Default = `True`.
+
 ## Testing Locally
 
 Rather than connect to a hosted InfluxDB3 instance, you can alternatively test your 

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -79,6 +79,7 @@ class InfluxDB3Sink(BatchingSink):
         on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
         on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         raise_on_retention_violation: bool = False,
+        verify_ssl: bool = True,
     ):
         """
         A connector to sink processed data to InfluxDB v3.
@@ -157,6 +158,9 @@ class InfluxDB3Sink(BatchingSink):
             Keeping this False (default) is recommended for production to handle old
             data gracefully without blocking the pipeline.
             Default - `False`.
+        :param verify_ssl: if True, verifies SSL certificates when connecting to InfluxDB.
+            Set this to false to skip verifying SSL certificate when calling APIs, useful for environments using self-signed certificates.
+            Default - `True`.
         """
 
         super().__init__(
@@ -185,6 +189,7 @@ class InfluxDB3Sink(BatchingSink):
             "database": database,
             "debug": debug,
             "enable_gzip": enable_gzip,
+            "verify_ssl": verify_ssl,
             "write_client_options": {
                 "write_options": WriteOptions(
                     write_type=WriteType.synchronous,

--- a/quixstreams/sinks/core/influxdb3.py
+++ b/quixstreams/sinks/core/influxdb3.py
@@ -216,6 +216,7 @@ class InfluxDB3Sink(BatchingSink):
                 httpx.URL(url=self._client_args["host"], path="/ping"),
                 headers={"Authorization": f"Token {self._client_args['token']}"},
                 timeout=self._request_timeout_ms / 1000,
+                verify=self._client_args["verify_ssl"],
             )
             r.raise_for_status()
         except Exception:


### PR DESCRIPTION
When connecting to an instance of InfluxDB3 that is using self signed certificates an error is received as the certificate cannot be verified. This feature adds a wrapper for the InfluxDB3 client to be able to pass the verify_ssl parameter. Default value is set to True.  