### PR TITLE
feature: add include_metadata param to PostgreSQLSink to make __key a…

### DIFF
--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -80,6 +80,7 @@ class PostgreSQLSink(BatchingSink):
         statement_timeout_seconds: int = 30,
         primary_key_columns: PrimaryKeyColumns = (),
         upsert_on_primary_key: bool = False,
+        include_metadata: bool = True,
         on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
         on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
         **kwargs,
@@ -111,6 +112,9 @@ class PostgreSQLSink(BatchingSink):
         :param upsert_on_primary_key: Upsert based on the given `primary_key_columns`.
             If False, every message is treated as an independent entry, and any
             primary key collisions will consequently raise an exception.
+        :param include_metadata: If True (default), includes ``__key`` and ``timestamp``
+            columns for every row written to PostgreSQL. Set to False to omit them.
+            Defaults to True for backward compatibility.            
         :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
         :param on_client_connect_failure: An optional callback made after failed
@@ -140,6 +144,7 @@ class PostgreSQLSink(BatchingSink):
             )
         self._primary_key_setter = _primary_key_setter(primary_key_columns)
         self._do_upsert = upsert_on_primary_key
+        self._include_metadata = include_metadata
 
         self._client_settings = {
             "host": host,
@@ -168,7 +173,7 @@ class PostgreSQLSink(BatchingSink):
                 primary_key_columns = [primary_key_columns]
 
             row = {}
-            if item.key is not None:
+            if item.key is not None and self._include_metadata:
                 key_type = type(item.key)
                 table["cols_types"].setdefault(KEY_COLUMN_NAME, key_type)
                 row[KEY_COLUMN_NAME] = item.key
@@ -184,7 +189,8 @@ class PostgreSQLSink(BatchingSink):
                     table["cols_types"].setdefault(key, type(value))
                     row[key] = value
 
-            row[TIMESTAMP_COLUMN_NAME] = datetime.fromtimestamp(item.timestamp / 1000)
+            if self._include_metadata:
+                row[TIMESTAMP_COLUMN_NAME] = datetime.fromtimestamp(item.timestamp / 1000)
             table["rows"].append(row)
 
         table_counts = {}
@@ -253,18 +259,29 @@ class PostgreSQLSink(BatchingSink):
     def _create_table(self, table_name: str):
         if table_name in self._tables:
             return
-        query = sql.SQL(
-            """
-            CREATE TABLE IF NOT EXISTS {table} (
-                {timestamp_col} TIMESTAMP NOT NULL,
-                {key_col} TEXT
+        if self._include_metadata:
+            query = sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {table} (
+                    {timestamp_col} TIMESTAMP NOT NULL,
+                    {key_col} TEXT
+                )
+                """
+            ).format(
+                table=sql.Identifier(self._schema_name, table_name),
+                timestamp_col=sql.Identifier(TIMESTAMP_COLUMN_NAME),
+                key_col=sql.Identifier(KEY_COLUMN_NAME),
             )
-            """
-        ).format(
-            table=sql.Identifier(self._schema_name, table_name),
-            timestamp_col=sql.Identifier(TIMESTAMP_COLUMN_NAME),
-            key_col=sql.Identifier(KEY_COLUMN_NAME),
-        )
+        else:
+            query = sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {table} (
+                    _row_id SERIAL
+                )
+                """
+            ).format(
+                table=sql.Identifier(self._schema_name, table_name),
+            )
 
         with self._client.cursor() as cursor:
             cursor.execute(query)

--- a/quixstreams/sinks/community/postgresql.py
+++ b/quixstreams/sinks/community/postgresql.py
@@ -114,7 +114,7 @@ class PostgreSQLSink(BatchingSink):
             primary key collisions will consequently raise an exception.
         :param include_metadata: If True (default), includes ``__key`` and ``timestamp``
             columns for every row written to PostgreSQL. Set to False to omit them.
-            Defaults to True for backward compatibility.            
+            Defaults to True for backward compatibility.
         :param on_client_connect_success: An optional callback made after successful
             client authentication, primarily for additional logging.
         :param on_client_connect_failure: An optional callback made after failed
@@ -190,7 +190,9 @@ class PostgreSQLSink(BatchingSink):
                     row[key] = value
 
             if self._include_metadata:
-                row[TIMESTAMP_COLUMN_NAME] = datetime.fromtimestamp(item.timestamp / 1000)
+                row[TIMESTAMP_COLUMN_NAME] = datetime.fromtimestamp(
+                    item.timestamp / 1000
+                )
             table["rows"].append(row)
 
         table_counts = {}

--- a/tests/test_quixstreams/test_sinks/test_community/test_postgres_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_community/test_postgres_sink.py
@@ -119,6 +119,7 @@ def postgres_sink_factory(postgres_connection) -> callable:
         table_name: TableName = DEFAULT_TABLE_NAME,
         primary_key_columns: PrimaryKeyColumns = (),
         upsert_on_primary_key: bool = False,
+        include_metadata: bool = True,
     ) -> PostgreSQLSink:
         info = postgres_connection.info
         return PostgreSQLSink(
@@ -130,6 +131,7 @@ def postgres_sink_factory(postgres_connection) -> callable:
             table_name=table_name,
             primary_key_columns=primary_key_columns,
             upsert_on_primary_key=upsert_on_primary_key,
+            include_metadata=include_metadata,
         )
 
     return inner
@@ -613,3 +615,211 @@ def test_sink_composite_primary_key_upsert(
             r["_timestamp"] / 1000
         )
     assert data == get_all_table_rows()
+
+
+def test_sink_without_metadata(
+    sink_app_factory,
+    postgres_sink_factory,
+    resource_source_factory,
+    postgres_connection,
+):
+    """Validates PR #1098: include_metadata=False omits __key and timestamp columns.
+
+    When include_metadata=False, the written table must contain ONLY data columns
+    (event_time, hostname, resource, used_percent) and must NOT contain the
+    metadata columns (__key, timestamp).
+    """
+    data = [
+        {
+            "event_time": 1752158109872,
+            "hostname": "host_0",
+            "resource": "CPU",
+            "used_percent": 91.61,
+        },
+        {
+            "event_time": 1752158109873,
+            "hostname": "host_0",
+            "resource": "RAM",
+            "used_percent": 37.03,
+        },
+        {
+            "event_time": 1752158109876,
+            "hostname": "host_1",
+            "resource": "CPU",
+            "used_percent": 56.22,
+        },
+        {
+            "event_time": 1752158109877,
+            "hostname": "host_1",
+            "resource": "RAM",
+            "used_percent": 80.01,
+        },
+    ]
+    app = sink_app_factory(
+        resource_source_factory(data),
+        postgres_sink_factory(include_metadata=False),
+    )
+    app.run(count=len(data))
+
+    # -- Assert metadata columns are ABSENT from the table schema --
+    data_columns = {"event_time", "hostname", "resource", "used_percent"}
+    with postgres_connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
+            (DEFAULT_TABLE_NAME,),
+        )
+        actual_columns = {row[0] for row in cursor.fetchall()}
+    postgres_connection.commit()
+
+    assert KEY_COLUMN_NAME not in actual_columns, (
+        f"Metadata column {KEY_COLUMN_NAME!r} should be absent when "
+        f"include_metadata=False, but found columns: {actual_columns}"
+    )
+    assert TIMESTAMP_COLUMN_NAME not in actual_columns, (
+        f"Metadata column {TIMESTAMP_COLUMN_NAME!r} should be absent when "
+        f"include_metadata=False, but found columns: {actual_columns}"
+    )
+    for col in data_columns:
+        assert col in actual_columns, (
+            f"Data column {col!r} should be present, "
+            f"but found columns: {actual_columns}"
+        )
+
+    # -- Assert the written row data matches the input data --
+    data_col_list = sorted(data_columns)
+    select_query = sql.SQL("SELECT {columns} FROM {table} ORDER BY {order}").format(
+        columns=sql.SQL(", ").join(map(sql.Identifier, data_col_list)),
+        table=sql.Identifier(DEFAULT_TABLE_NAME),
+        order=sql.Identifier("event_time"),
+    )
+    with postgres_connection.cursor() as cursor:
+        cursor.execute(select_query)
+        rows = [dict(zip(data_col_list, row)) for row in cursor.fetchall()]
+    postgres_connection.commit()
+
+    expected = sorted(data, key=lambda r: r["event_time"])
+    assert rows == expected
+
+
+def test_sink_with_metadata_default(
+    sink_app_factory,
+    postgres_sink_factory,
+    resource_source_factory,
+    postgres_connection,
+):
+    """Validates PR #1098: default include_metadata=True still includes __key and
+    timestamp columns, ensuring backward compatibility.
+    """
+    data = [
+        {
+            "event_time": 1752158109872,
+            "hostname": "host_0",
+            "resource": "CPU",
+            "used_percent": 91.61,
+        },
+    ]
+    app = sink_app_factory(
+        resource_source_factory(data),
+        postgres_sink_factory(),  # default include_metadata=True
+    )
+    app.run(count=len(data))
+
+    with postgres_connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
+            (DEFAULT_TABLE_NAME,),
+        )
+        actual_columns = {row[0] for row in cursor.fetchall()}
+    postgres_connection.commit()
+
+    assert KEY_COLUMN_NAME in actual_columns, (
+        f"Metadata column {KEY_COLUMN_NAME!r} should be present by default, "
+        f"but found columns: {actual_columns}"
+    )
+    assert TIMESTAMP_COLUMN_NAME in actual_columns, (
+        f"Metadata column {TIMESTAMP_COLUMN_NAME!r} should be present by default, "
+        f"but found columns: {actual_columns}"
+    )
+
+
+def test_sink_without_metadata_upsert_primary_key(
+    sink_app_factory,
+    postgres_sink_factory,
+    resource_source_factory,
+    postgres_connection,
+):
+    """Validates PR #1098: include_metadata=False combined with primary-key upsert.
+
+    When include_metadata=False and upsert_on_primary_key=True, the dedup/upsert
+    logic must still work correctly and the written table must contain only data
+    columns (no __key, no timestamp). After dedup on hostname, only the last
+    value per hostname should survive (data[2:]).
+    """
+    data = [
+        {
+            "event_time": 1752158109872,
+            "hostname": "host_0",
+            "resource": "CPU",
+            "used_percent": 91.61,
+        },
+        {
+            "event_time": 1752158109876,
+            "hostname": "host_1",
+            "resource": "CPU",
+            "used_percent": 56.22,
+        },
+        {
+            "event_time": 1752158109881,
+            "hostname": "host_0",
+            "resource": "CPU",
+            "used_percent": 11.29,
+        },
+        {
+            "event_time": 1752158109883,
+            "hostname": "host_1",
+            "resource": "CPU",
+            "used_percent": 96.12,
+        },
+    ]
+    app = sink_app_factory(
+        resource_source_factory(data),
+        postgres_sink_factory(
+            primary_key_columns=["hostname"],
+            upsert_on_primary_key=True,
+            include_metadata=False,
+        ),
+    )
+    app.run(count=len(data))
+
+    # -- Assert metadata columns are ABSENT from the table schema --
+    with postgres_connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT column_name FROM information_schema.columns WHERE table_name = %s",
+            (DEFAULT_TABLE_NAME,),
+        )
+        actual_columns = {row[0] for row in cursor.fetchall()}
+    postgres_connection.commit()
+
+    assert KEY_COLUMN_NAME not in actual_columns, (
+        f"Metadata column {KEY_COLUMN_NAME!r} should be absent when "
+        f"include_metadata=False, but found columns: {actual_columns}"
+    )
+    assert TIMESTAMP_COLUMN_NAME not in actual_columns, (
+        f"Metadata column {TIMESTAMP_COLUMN_NAME!r} should be absent when "
+        f"include_metadata=False, but found columns: {actual_columns}"
+    )
+
+    # -- Assert the surviving rows are the deduped last-per-hostname values --
+    data_columns = sorted(["event_time", "hostname", "resource", "used_percent"])
+    select_query = sql.SQL("SELECT {columns} FROM {table} ORDER BY {order}").format(
+        columns=sql.SQL(", ").join(map(sql.Identifier, data_columns)),
+        table=sql.Identifier(DEFAULT_TABLE_NAME),
+        order=sql.Identifier("hostname"),
+    )
+    with postgres_connection.cursor() as cursor:
+        cursor.execute(select_query)
+        rows = [dict(zip(data_columns, row)) for row in cursor.fetchall()]
+    postgres_connection.commit()
+
+    expected = sorted(data[2:], key=lambda r: r["hostname"])
+    assert rows == expected


### PR DESCRIPTION
…nd timestamp optional

Closes #1009

Added `include_metadata: bool = True` parameter to PostgreSQLSink.

Changes:
- When True (default): __key and timestamp columns are written as before (backward compatible)
- When False: __key and timestamp columns are skipped entirely

Users can now do:
  sink = PostgreSQLSink(..., include_metadata=False)