### PR TITLE
fix(quix-ts-datalake-sink): stop silently dropping rows with NULL par…

### DIFF
--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -45,6 +45,12 @@ TIMESTAMP_COL_MAPPER = {
     "hour": lambda col: col.dt.hour.astype(str).str.zfill(2),
 }
 
+# Hive/Iceberg/Spark convention for partition values that are NULL. Readers
+# that respect the convention (DuckDB hive_partitioning, Spark, Trino…)
+# materialise the column as NULL when they encounter this sentinel in a
+# path segment.
+HIVE_NULL_PARTITION = "__HIVE_DEFAULT_PARTITION__"
+
 
 class QuixTSDataLakeSink(BatchingSink):
     """
@@ -199,10 +205,15 @@ class QuixTSDataLakeSink(BatchingSink):
         while attempts:
             start = time.perf_counter()
             try:
-                self._write_batch(batch)
+                rows_written = self._write_batch(batch)
                 elapsed_ms = (time.perf_counter() - start) * 1000
+                # Log the actually-written count, not batch.size. They are
+                # equal in normal operation, but reporting the real number
+                # makes any future silent-drop regression visible in the log.
                 logger.info(
-                    "Wrote %d rows to blob storage in %.1f ms", batch.size, elapsed_ms
+                    "Wrote %d rows to blob storage in %.1f ms",
+                    rows_written,
+                    elapsed_ms,
                 )
                 return
             except Exception as exc:
@@ -212,10 +223,16 @@ class QuixTSDataLakeSink(BatchingSink):
                 logger.warning("Write failed (%s) - retrying...", exc)
                 time.sleep(3)
 
-    def _write_batch(self, batch: SinkBatch):
-        """Convert batch to Parquet and write to blob storage with Hive partitioning."""
+    def _write_batch(self, batch: SinkBatch) -> int:
+        """Convert batch to Parquet and write to blob storage with Hive partitioning.
+
+        Returns the number of rows actually grouped and written to storage.
+        Equals batch.size in normal operation; reported by write() so any
+        future silent-drop regression is visible in the log instead of
+        being papered over with the input count.
+        """
         if not batch:
-            return
+            return 0
 
         # Convert batch to list of dictionaries
         rows = []
@@ -238,8 +255,19 @@ class QuixTSDataLakeSink(BatchingSink):
 
         # Use only the explicitly specified partition columns
         if partition_columns := self.hive_columns.copy():
+            # Rows where a partition column is NaN/None would be silently
+            # discarded by pandas.groupby's default dropna=True — the for-
+            # loop below would simply not iterate over them and they would
+            # never reach storage, even though write() would still report
+            # success using batch.size. Route them into a single Hive-NULL
+            # bucket instead so the data lands somewhere queryable.
+            for col in partition_columns:
+                if col in df.columns:
+                    df[col] = df[col].fillna(HIVE_NULL_PARTITION)
+
             # Group by partition columns and write each partition separately
             # This creates the Hive-style directory structure: col1=val1/col2=val2/file.parquet
+            rows_written = 0
             for group_values, group_df in df.groupby(partition_columns):
                 # Ensure group_values is always a tuple for consistent handling
                 if not isinstance(group_values, tuple):
@@ -262,15 +290,18 @@ class QuixTSDataLakeSink(BatchingSink):
                 self._write_parquet_to_storage(
                     data_df, storage_key, partition_columns, group_values
                 )
+                rows_written += len(group_df)
         else:
             # No partitioning - write as single file directly under table directory
             storage_key = (
                 f"{self.s3_prefix}/{self.table_name}/data_{uuid.uuid4().hex}.parquet"
             )
             self._write_parquet_to_storage(df, storage_key, [], ())
+            rows_written = len(df)
 
         # Wait for all uploads to complete and register files in catalog
         self._finalize_writes()
+        return rows_written
 
     def _write_parquet_to_storage(
         self,

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -46,14 +46,13 @@ TIMESTAMP_COL_MAPPER = {
 }
 
 # On-disk path segment used when a partition column value is NULL.
-# Earlier this was Hive/Iceberg/Spark's official ``__HIVE_DEFAULT_PARTITION__``
-# sentinel, but ``None`` is clearer in the UI and matches what users see
-# when they ``print(value)`` on a NULL row — so we use that instead. The
-# catalog conversion at the bottom of ``_write_batch`` still maps this
-# string back to actual SQL NULL when registering manifest entries, so
-# downstream ``partition_<col> IS NULL`` filters and partition-tree
-# NULL rendering keep working.
-HIVE_NULL_PARTITION = "None"
+# Unified with the reading side (quix-ts-datalake catalog + API + UI):
+# every writer in the stack emits this exact string, every reader maps
+# it back to SQL NULL. Double-underscore prefix/suffix keeps the
+# sentinel from colliding with real user values like the bare string
+# ``"None"`` or Spark's ``__HIVE_DEFAULT_PARTITION__``, both of which
+# the readers also accept for backward compatibility on existing data.
+HIVE_NULL_PARTITION = "__None__"
 
 # Loggers that emit one INFO record per HTTP round-trip — useful for low-
 # level SDK debugging, but pure noise for a sink that performs hundreds of
@@ -667,7 +666,7 @@ class QuixTSDataLakeSink(BatchingSink):
             # Build partition values dict.
             # _write_batch fillna()'s NaN partition values with HIVE_NULL_PARTITION
             # (the on-disk sentinel — see the constant near the top) so they
-            # survive groupby and land in a single ``col=None`` directory on
+            # survive groupby and land in a single ``col=__None__`` directory on
             # disk. The catalog, however, should record those values as actual
             # SQL NULL — not the literal sentinel string — so that downstream
             # `partition_<col> IS NULL` filters and partition-tree NULL rendering

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -45,11 +45,15 @@ TIMESTAMP_COL_MAPPER = {
     "hour": lambda col: col.dt.hour.astype(str).str.zfill(2),
 }
 
-# Hive/Iceberg/Spark convention for partition values that are NULL. Readers
-# that respect the convention (DuckDB hive_partitioning, Spark, Trino…)
-# materialise the column as NULL when they encounter this sentinel in a
-# path segment.
-HIVE_NULL_PARTITION = "__HIVE_DEFAULT_PARTITION__"
+# On-disk path segment used when a partition column value is NULL.
+# Earlier this was Hive/Iceberg/Spark's official ``__HIVE_DEFAULT_PARTITION__``
+# sentinel, but ``None`` is clearer in the UI and matches what users see
+# when they ``print(value)`` on a NULL row — so we use that instead. The
+# catalog conversion at the bottom of ``_write_batch`` still maps this
+# string back to actual SQL NULL when registering manifest entries, so
+# downstream ``partition_<col> IS NULL`` filters and partition-tree
+# NULL rendering keep working.
+HIVE_NULL_PARTITION = "None"
 
 # Loggers that emit one INFO record per HTTP round-trip — useful for low-
 # level SDK debugging, but pure noise for a sink that performs hundreds of
@@ -662,7 +666,8 @@ class QuixTSDataLakeSink(BatchingSink):
 
             # Build partition values dict.
             # _write_batch fillna()'s NaN partition values with HIVE_NULL_PARTITION
-            # so they survive groupby and land in a real Hive-NULL directory on
+            # (the on-disk sentinel — see the constant near the top) so they
+            # survive groupby and land in a single ``col=None`` directory on
             # disk. The catalog, however, should record those values as actual
             # SQL NULL — not the literal sentinel string — so that downstream
             # `partition_<col> IS NULL` filters and partition-tree NULL rendering

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -660,11 +660,19 @@ class QuixTSDataLakeSink(BatchingSink):
             else:
                 file_path = f"s3://{self.s3_bucket}/{storage_key}"
 
-            # Build partition values dict
-            partition_dict = {}
+            # Build partition values dict.
+            # _write_batch fillna()'s NaN partition values with HIVE_NULL_PARTITION
+            # so they survive groupby and land in a real Hive-NULL directory on
+            # disk. The catalog, however, should record those values as actual
+            # SQL NULL — not the literal sentinel string — so that downstream
+            # `partition_<col> IS NULL` filters and partition-tree NULL rendering
+            # work natively. Translate back here.
+            partition_dict: Dict[str, Optional[str]] = {}
             if partition_columns and partition_values:
                 for col, val in zip(partition_columns, partition_values):
-                    partition_dict[col] = str(val)
+                    partition_dict[col] = (
+                        None if val == HIVE_NULL_PARTITION else str(val)
+                    )
 
             # Create file entry
             file_entries.append(

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -51,6 +51,36 @@ TIMESTAMP_COL_MAPPER = {
 # path segment.
 HIVE_NULL_PARTITION = "__HIVE_DEFAULT_PARTITION__"
 
+# Loggers that emit one INFO record per HTTP round-trip — useful for low-
+# level SDK debugging, but pure noise for a sink that performs hundreds of
+# blob operations per minute (the Hive partition tree probe alone). The
+# sink mutes them by default; pass `silence_azure_http_logs=False` to
+# preserve them.
+_CHATTY_HTTP_LOGGERS = (
+    "azure",
+    "azure.core",
+    "azure.core.pipeline.policies.http_logging_policy",
+    "azure.storage",
+    "adlfs",
+    "botocore",
+    "boto3",
+    "s3transfer",
+)
+
+
+def silence_chatty_loggers() -> None:
+    """Mute per-request HTTP logging from the cloud-storage SDKs used by
+    this sink (Azure SDK + adlfs, botocore/boto3 + s3transfer).
+
+    Safe to call from application code at any point. Levels are raised to
+    WARNING, so anything actually noteworthy (auth failures, retries,
+    throttling, server errors) still propagates. Call after configuring
+    your own logging (e.g. after instantiating quixstreams.Application)
+    so the framework's logging setup does not reset these levels.
+    """
+    for name in _CHATTY_HTTP_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
+
 
 class QuixTSDataLakeSink(BatchingSink):
     """
@@ -78,6 +108,13 @@ class QuixTSDataLakeSink(BatchingSink):
     :param namespace: Catalog namespace (default: "default")
     :param auto_create_bucket: If True, attempt to create bucket/path in storage if missing
     :param max_workers: Maximum number of parallel upload threads (default: 10)
+    :param silence_azure_http_logs: If True (default), raise the log levels of
+        the Azure SDK / adlfs / botocore HTTP-logging loggers to WARNING during
+        setup(). These libraries log one INFO record per HTTP round-trip with
+        the full URL and headers, which buries the sink's own logs under
+        hundreds of lines per minute of partition probing. Set to False to
+        keep the verbose request/response logs (useful for low-level SDK
+        debugging).
     :param on_client_connect_success: An optional callback made after successful
         client authentication, primarily for additional logging.
     :param on_client_connect_failure: An optional callback made after failed
@@ -99,6 +136,7 @@ class QuixTSDataLakeSink(BatchingSink):
         namespace: str = "default",
         auto_create_bucket: bool = True,
         max_workers: int = 10,
+        silence_azure_http_logs: bool = True,
         on_client_connect_success: Optional[ClientConnectSuccessCallback] = None,
         on_client_connect_failure: Optional[ClientConnectFailureCallback] = None,
     ):
@@ -129,6 +167,7 @@ class QuixTSDataLakeSink(BatchingSink):
         )
         self._auto_create_bucket = auto_create_bucket
         self._max_workers = max_workers
+        self._silence_azure_http_logs = silence_azure_http_logs
 
         # Batch upload tracking
         self._pending_futures: List[Dict[str, Any]] = []
@@ -143,6 +182,13 @@ class QuixTSDataLakeSink(BatchingSink):
     def setup(self):
         """Initialize blob storage client and test connection."""
         logger.info("Starting Quix Lake Blob Storage Sink...")
+
+        # Done in setup() rather than __init__ so it runs after the host
+        # application (typically quixstreams.Application) has configured
+        # logging; otherwise the framework's setup would reset these levels
+        # back to whatever the global log level is.
+        if self._silence_azure_http_logs:
+            silence_chatty_loggers()
 
         # Extract bucket name from quixportal configuration
         self._s3_bucket = get_bucket_name()

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -311,9 +311,9 @@ class TestSilenceChattyLoggers:
         silence_chatty_loggers()
 
         for name in self._SILENCED:
-            assert _logging.getLogger(name).level == _logging.WARNING, (
-                f"{name} not raised to WARNING"
-            )
+            assert (
+                _logging.getLogger(name).level == _logging.WARNING
+            ), f"{name} not raised to WARNING"
 
     def test_setup_silences_when_flag_is_true(self, sink_factory, mock_blob_client):
         import logging as _logging

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -246,6 +246,111 @@ class TestQuixTSDataLakeSinkInit:
         with pytest.raises(RuntimeError, match="s3_bucket not initialized"):
             _ = sink.s3_bucket
 
+    def test_silence_azure_http_logs_defaults_to_true(self):
+        """The chatty-log mute should be on by default — Azure SDK + adlfs
+        log one INFO record per HTTP round-trip, which is pure noise for a
+        sink that probes a deep partition tree."""
+        sink = QuixTSDataLakeSink(s3_prefix="p", table_name="t")
+        assert sink._silence_azure_http_logs is True
+
+    def test_silence_azure_http_logs_can_be_disabled(self):
+        sink = QuixTSDataLakeSink(
+            s3_prefix="p", table_name="t", silence_azure_http_logs=False
+        )
+        assert sink._silence_azure_http_logs is False
+
+
+# =============================================================================
+# 1b. Chatty Logger Silencing
+# =============================================================================
+
+
+class TestSilenceChattyLoggers:
+    """Tests for the silence_chatty_loggers() helper and its integration
+    with sink.setup()."""
+
+    # Names that the helper is responsible for muting. Kept in sync with
+    # _CHATTY_HTTP_LOGGERS in quix_ts_datalake_sink.py.
+    _SILENCED = (
+        "azure",
+        "azure.core",
+        "azure.core.pipeline.policies.http_logging_policy",
+        "azure.storage",
+        "adlfs",
+        "botocore",
+        "boto3",
+        "s3transfer",
+    )
+
+    @pytest.fixture(autouse=True)
+    def _reset_logger_levels(self):
+        """Reset levels on the silenced loggers before and after each test
+        so we don't leak state into the rest of the suite."""
+        import logging as _logging
+
+        previous = {
+            name: _logging.getLogger(name).level for name in self._SILENCED
+        }
+        for name in self._SILENCED:
+            _logging.getLogger(name).setLevel(_logging.NOTSET)
+        try:
+            yield
+        finally:
+            for name, level in previous.items():
+                _logging.getLogger(name).setLevel(level)
+
+    def test_helper_raises_levels_to_warning(self):
+        import logging as _logging
+
+        from quixstreams.sinks.core.quix_ts_datalake_sink import (
+            silence_chatty_loggers,
+        )
+
+        # Start permissive — everything would otherwise emit INFO.
+        for name in self._SILENCED:
+            _logging.getLogger(name).setLevel(_logging.INFO)
+
+        silence_chatty_loggers()
+
+        for name in self._SILENCED:
+            assert (
+                _logging.getLogger(name).level == _logging.WARNING
+            ), f"{name} not raised to WARNING"
+
+    def test_setup_silences_when_flag_is_true(self, sink_factory, mock_blob_client):
+        import logging as _logging
+
+        sink = sink_factory(silence_azure_http_logs=True)
+        for name in self._SILENCED:
+            _logging.getLogger(name).setLevel(_logging.INFO)
+
+        with patch(
+            "quixstreams.sinks.core.quix_ts_datalake_sink.get_bucket_name",
+            return_value="test-bucket",
+        ):
+            sink.setup()
+
+        for name in self._SILENCED:
+            assert _logging.getLogger(name).level == _logging.WARNING
+
+    def test_setup_leaves_logger_levels_alone_when_flag_is_false(
+        self, sink_factory, mock_blob_client
+    ):
+        import logging as _logging
+
+        sink = sink_factory(silence_azure_http_logs=False)
+        for name in self._SILENCED:
+            _logging.getLogger(name).setLevel(_logging.INFO)
+
+        with patch(
+            "quixstreams.sinks.core.quix_ts_datalake_sink.get_bucket_name",
+            return_value="test-bucket",
+        ):
+            sink.setup()
+
+        for name in self._SILENCED:
+            assert _logging.getLogger(name).level == _logging.INFO
+
 
 # =============================================================================
 # 2. Timestamp Column Mapping Tests

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -697,10 +697,10 @@ class TestWriteOperations:
             call.args[0] for call in mock_blob_client.put_object_async.call_args_list
         ]
         assert any("machine=M1" in k for k in storage_keys)
-        # Null partition values land under the Hive convention sentinel so
-        # downstream readers (Iceberg/Spark/DuckDB hive_partitioning) treat
-        # the column as NULL rather than the literal string "None".
-        assert any("machine=__HIVE_DEFAULT_PARTITION__" in k for k in storage_keys)
+        # Null partition values land in a single ``machine=None`` bucket. The
+        # catalog still gets SQL NULL for these rows (see ``_write_batch``)
+        # — the on-disk segment is the human-readable string ``None``.
+        assert any("machine=None" in k for k in storage_keys)
 
     def test_write_all_null_partition_values_still_writes(
         self, sink_factory, mock_blob_client
@@ -740,7 +740,7 @@ class TestWriteOperations:
 
         assert mock_blob_client.put_object_async.call_count == 1
         storage_key = mock_blob_client.put_object_async.call_args.args[0]
-        assert "machine=__HIVE_DEFAULT_PARTITION__" in storage_key
+        assert "machine=None" in storage_key
 
     def test_write_adds_timestamp_from_item_if_missing(
         self, sink_factory, sample_batch, mock_blob_client
@@ -990,11 +990,11 @@ class TestCatalogIntegration:
         self, sink_factory, mock_blob_client, mock_catalog_client
     ):
         """
-        A row whose partition column is None / missing lands in the Hive-NULL
-        bucket on disk (path segment = `col=__HIVE_DEFAULT_PARTITION__`), but
-        the catalog payload must record the partition value as SQL NULL — not
-        as the literal sentinel string. This is what lets downstream readers
-        emit `partition_<col> IS NULL` filters and render the bucket as NULL
+        A row whose partition column is None / missing lands in a
+        ``col=None`` bucket on disk, but the catalog payload must record
+        the partition value as SQL NULL — not as the literal string
+        "None". This is what lets downstream readers emit
+        ``partition_<col> IS NULL`` filters and render the bucket as NULL
         in their partition trees, instead of leaking the storage-layer
         sentinel into user-facing SQL.
         """
@@ -1043,10 +1043,11 @@ class TestCatalogIntegration:
         by_partition = {f["partition_values"]["machine"]: f for f in files}
         assert by_partition["M1"]["partition_values"]["machine"] == "M1"
         assert by_partition[None]["partition_values"]["machine"] is None
-        # Storage key on disk still uses the Hive convention sentinel so
-        # the on-disk layout is portable to Spark / Iceberg readers.
+        # Storage key on disk uses the literal "None" string — easier to
+        # eyeball than the Hive sentinel and matches what ``str(None)`` would
+        # produce naturally for a Python user inspecting the path.
         null_bucket_path = by_partition[None]["file_path"]
-        assert "machine=__HIVE_DEFAULT_PARTITION__" in null_bucket_path
+        assert "machine=None" in null_bucket_path
 
 
 # =============================================================================

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -538,6 +538,110 @@ class TestWriteOperations:
         # Should have 2 uploads - one for each partition
         assert mock_blob_client.put_object_async.call_count == 2
 
+    def test_write_does_not_drop_rows_with_none_partition_value(
+        self, sink_factory, mock_blob_client
+    ):
+        """
+        Regression: rows whose partition column is None / missing must NOT
+        be silently dropped.
+
+        pandas' DataFrame.groupby defaults to dropna=True, so any row whose
+        partition key contains NaN is silently excluded from the iteration.
+        The sink's for-loop never produced a group for those rows, no PUT
+        was issued — yet write() still logged "Wrote N rows" (using
+        batch.size, not the actually-written count), hiding the data loss.
+        """
+        sink = sink_factory(hive_columns=["machine"])
+
+        records = [
+            {
+                "value": {"machine": "M1", "ts_ms": 1704067200000},
+                "key": "k1",
+                "timestamp": 1704067200000,
+                "offset": 0,
+            },
+            {
+                "value": {"machine": None, "ts_ms": 1704067260000},
+                "key": "k2",
+                "timestamp": 1704067260000,
+                "offset": 1,
+            },
+            {
+                # Missing 'machine' entirely → NaN in the DataFrame, same path.
+                "value": {"ts_ms": 1704067320000},
+                "key": "k3",
+                "timestamp": 1704067320000,
+                "offset": 2,
+            },
+        ]
+        batch = SinkBatch(topic="test", partition=0)
+        for r in records:
+            batch.append(
+                value=r["value"],
+                key=r["key"],
+                timestamp=r["timestamp"],
+                headers=[],
+                offset=r["offset"],
+            )
+
+        sink.write(batch)
+
+        # Two distinct partition groups → two PUTs: one for M1, one for the
+        # null bucket containing both the explicit-None and missing-key rows.
+        assert mock_blob_client.put_object_async.call_count == 2
+
+        storage_keys = [
+            call.args[0]
+            for call in mock_blob_client.put_object_async.call_args_list
+        ]
+        assert any("machine=M1" in k for k in storage_keys)
+        # Null partition values land under the Hive convention sentinel so
+        # downstream readers (Iceberg/Spark/DuckDB hive_partitioning) treat
+        # the column as NULL rather than the literal string "None".
+        assert any(
+            "machine=__HIVE_DEFAULT_PARTITION__" in k for k in storage_keys
+        )
+
+    def test_write_all_null_partition_values_still_writes(
+        self, sink_factory, mock_blob_client
+    ):
+        """
+        Regression: a batch in which every row has a NaN partition value
+        must still write a file. Previously this case produced zero PUTs
+        while the sink reported success.
+        """
+        sink = sink_factory(hive_columns=["machine"])
+
+        records = [
+            {
+                "value": {"ts_ms": 1704067200000},  # no 'machine'
+                "key": "k1",
+                "timestamp": 1704067200000,
+                "offset": 0,
+            },
+            {
+                "value": {"machine": None, "ts_ms": 1704067260000},
+                "key": "k2",
+                "timestamp": 1704067260000,
+                "offset": 1,
+            },
+        ]
+        batch = SinkBatch(topic="test", partition=0)
+        for r in records:
+            batch.append(
+                value=r["value"],
+                key=r["key"],
+                timestamp=r["timestamp"],
+                headers=[],
+                offset=r["offset"],
+            )
+
+        sink.write(batch)
+
+        assert mock_blob_client.put_object_async.call_count == 1
+        storage_key = mock_blob_client.put_object_async.call_args.args[0]
+        assert "machine=__HIVE_DEFAULT_PARTITION__" in storage_key
+
     def test_write_adds_timestamp_from_item_if_missing(
         self, sink_factory, sample_batch, mock_blob_client
     ):

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -697,10 +697,11 @@ class TestWriteOperations:
             call.args[0] for call in mock_blob_client.put_object_async.call_args_list
         ]
         assert any("machine=M1" in k for k in storage_keys)
-        # Null partition values land in a single ``machine=None`` bucket. The
-        # catalog still gets SQL NULL for these rows (see ``_write_batch``)
-        # — the on-disk segment is the human-readable string ``None``.
-        assert any("machine=None" in k for k in storage_keys)
+        # Null partition values land in a single ``machine=__None__`` bucket.
+        # The catalog still gets SQL NULL for these rows (see ``_write_batch``)
+        # — the on-disk segment is the unified ``__None__`` sentinel used
+        # across the sink, catalog, API, and UI.
+        assert any("machine=__None__" in k for k in storage_keys)
 
     def test_write_all_null_partition_values_still_writes(
         self, sink_factory, mock_blob_client
@@ -991,9 +992,9 @@ class TestCatalogIntegration:
     ):
         """
         A row whose partition column is None / missing lands in a
-        ``col=None`` bucket on disk, but the catalog payload must record
-        the partition value as SQL NULL — not as the literal string
-        "None". This is what lets downstream readers emit
+        ``col=__None__`` bucket on disk, but the catalog payload must
+        record the partition value as SQL NULL — not as the literal
+        sentinel string. This is what lets downstream readers emit
         ``partition_<col> IS NULL`` filters and render the bucket as NULL
         in their partition trees, instead of leaking the storage-layer
         sentinel into user-facing SQL.
@@ -1043,11 +1044,11 @@ class TestCatalogIntegration:
         by_partition = {f["partition_values"]["machine"]: f for f in files}
         assert by_partition["M1"]["partition_values"]["machine"] == "M1"
         assert by_partition[None]["partition_values"]["machine"] is None
-        # Storage key on disk uses the literal "None" string — easier to
-        # eyeball than the Hive sentinel and matches what ``str(None)`` would
-        # produce naturally for a Python user inspecting the path.
+        # Storage key on disk uses the unified ``__None__`` sentinel — the
+        # same string the catalog, API, and UI all expect for NULL partition
+        # values.
         null_bucket_path = by_partition[None]["file_path"]
-        assert "machine=None" in null_bucket_path
+        assert "machine=__None__" in null_bucket_path
 
 
 # =============================================================================

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -991,6 +991,68 @@ class TestCatalogIntegration:
         with pytest.raises(Exception, match="Manifest error"):
             sink.write(batch)
 
+    def test_manifest_registers_null_partition_as_sql_null(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        """
+        A row whose partition column is None / missing lands in the Hive-NULL
+        bucket on disk (path segment = `col=__HIVE_DEFAULT_PARTITION__`), but
+        the catalog payload must record the partition value as SQL NULL — not
+        as the literal sentinel string. This is what lets downstream readers
+        emit `partition_<col> IS NULL` filters and render the bucket as NULL
+        in their partition trees, instead of leaking the storage-layer
+        sentinel into user-facing SQL.
+        """
+        sink = sink_factory(
+            hive_columns=["machine"],
+            catalog_url="http://catalog:8080",
+            auto_discover=True,
+        )
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+
+        records = [
+            {
+                "value": {"machine": "M1", "ts_ms": 1704067200000},
+                "key": "k1",
+                "timestamp": 1704067200000,
+                "offset": 0,
+            },
+            {
+                "value": {"machine": None, "ts_ms": 1704067260000},
+                "key": "k2",
+                "timestamp": 1704067260000,
+                "offset": 1,
+            },
+        ]
+        batch = SinkBatch(topic="test", partition=0)
+        for r in records:
+            batch.append(
+                value=r["value"],
+                key=r["key"],
+                timestamp=r["timestamp"],
+                headers=[],
+                offset=r["offset"],
+            )
+
+        sink.write(batch)
+
+        manifest_calls = [
+            call
+            for call in mock_catalog_client.post.call_args_list
+            if "manifest" in str(call)
+        ]
+        assert len(manifest_calls) == 1
+        files = manifest_calls[0].kwargs["json"]["files"]
+        # One file per partition group — M1 and the null bucket.
+        by_partition = {f["partition_values"]["machine"]: f for f in files}
+        assert by_partition["M1"]["partition_values"]["machine"] == "M1"
+        assert by_partition[None]["partition_values"]["machine"] is None
+        # Storage key on disk still uses the Hive convention sentinel so
+        # the on-disk layout is portable to Spark / Iceberg readers.
+        null_bucket_path = by_partition[None]["file_path"]
+        assert "machine=__HIVE_DEFAULT_PARTITION__" in null_bucket_path
+
 
 # =============================================================================
 # 7. Error Handling Tests

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -288,9 +288,7 @@ class TestSilenceChattyLoggers:
         so we don't leak state into the rest of the suite."""
         import logging as _logging
 
-        previous = {
-            name: _logging.getLogger(name).level for name in self._SILENCED
-        }
+        previous = {name: _logging.getLogger(name).level for name in self._SILENCED}
         for name in self._SILENCED:
             _logging.getLogger(name).setLevel(_logging.NOTSET)
         try:
@@ -313,9 +311,9 @@ class TestSilenceChattyLoggers:
         silence_chatty_loggers()
 
         for name in self._SILENCED:
-            assert (
-                _logging.getLogger(name).level == _logging.WARNING
-            ), f"{name} not raised to WARNING"
+            assert _logging.getLogger(name).level == _logging.WARNING, (
+                f"{name} not raised to WARNING"
+            )
 
     def test_setup_silences_when_flag_is_true(self, sink_factory, mock_blob_client):
         import logging as _logging
@@ -696,16 +694,13 @@ class TestWriteOperations:
         assert mock_blob_client.put_object_async.call_count == 2
 
         storage_keys = [
-            call.args[0]
-            for call in mock_blob_client.put_object_async.call_args_list
+            call.args[0] for call in mock_blob_client.put_object_async.call_args_list
         ]
         assert any("machine=M1" in k for k in storage_keys)
         # Null partition values land under the Hive convention sentinel so
         # downstream readers (Iceberg/Spark/DuckDB hive_partitioning) treat
         # the column as NULL rather than the literal string "None".
-        assert any(
-            "machine=__HIVE_DEFAULT_PARTITION__" in k for k in storage_keys
-        )
+        assert any("machine=__HIVE_DEFAULT_PARTITION__" in k for k in storage_keys)
 
     def test_write_all_null_partition_values_still_writes(
         self, sink_factory, mock_blob_client


### PR DESCRIPTION
…tition values

`_write_batch` builds a DataFrame from the batch and groups by the configured `hive_columns` before writing one parquet per partition. `pandas.DataFrame.groupby` defaults to `dropna=True`, so any row whose partition key contains NaN (the partition field was `None` in the payload, or absent entirely) was silently excluded from iteration. The for-loop never produced a group for those rows, `_write_parquet_to_storage` was never called, and `_finalize_writes` returned early without logging. Yet `write()` still reported success using `batch.size` — so the sink logged "Wrote N rows to blob storage" while nothing reached storage.

In the worst case where every row of every batch was missing one partition column, the sink ran for hours producing only successful- looking logs and zero PUTs to Azure/S3.

Fix:
- Fill NaN partition values with `__HIVE_DEFAULT_PARTITION__` before grouping. This is the Hive/Iceberg/Spark convention; DuckDB's `hive_partitioning=true` reader, Spark, and Trino all materialise the column as SQL NULL when they encounter this sentinel.
- `_write_batch` now returns the rows actually grouped and written.
- `write()` logs that count instead of `batch.size`, so any future silent-drop regression is visible in the log instead of being papered over with the input count.

Adds two regression tests covering mixed-null and all-null batches.