### PR TITLE
ci: add workflow_dispatch trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: 'CI'
 
 on:
   pull_request:
+  workflow_dispatch:
 
 
 # Run only one workflow per PR or commit


### PR DESCRIPTION
  Enables the "Run workflow" button on the Actions tab so CI can be
  triggered manually. Needed because automatic PR-triggered runs are
  not firing. Must be cherry-picked onto release/* branches to dispatch
  against them — GitHub uses the target branch's workflow definition.