### PR TITLE
fix(quix-ts-datalake-sink): literal NULL partition + invariant ts_ms dtype    

### DIFF
--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -497,14 +497,20 @@ class QuixTSDataLakeSink(BatchingSink):
         Add timestamp-based columns (year/month/day/hour) for time-based partitioning.
 
         This method extracts time components from the timestamp column and adds them
-        as separate columns that can be used for Hive partitioning.
+        as separate columns that can be used for Hive partitioning. The source
+        ``timestamp_column`` is **not** mutated — derivation happens on a local
+        datetime64 series. Preserving its dtype is part of the sink's contract
+        with readers (in particular, ``ts_ms`` is the system-injected Kafka
+        timestamp and must always land in parquet as int64 ms, regardless of
+        whether time-based hive partitioning is configured).
         """
-        # Convert to datetime if needed (handles numeric timestamps)
-        if not pd.api.types.is_datetime64_any_dtype(df[self.timestamp_column]):
+        # Build a datetime64 view of the timestamp column to extract from.
+        # Never write this back into ``df`` — that would change the dtype of
+        # the source column in the parquet output.
+        timestamp_col = df[self.timestamp_column]
+        if not pd.api.types.is_datetime64_any_dtype(timestamp_col):
             sample_value = float(
-                df[self.timestamp_column].iloc[0]
-                if not df[self.timestamp_column].empty
-                else 0
+                timestamp_col.iloc[0] if not timestamp_col.empty else 0
             )
 
             # Auto-detect timestamp unit by inspecting the magnitude of the value
@@ -514,28 +520,14 @@ class QuixTSDataLakeSink(BatchingSink):
             # - Microseconds: ~1.7e15
             # - Nanoseconds: ~1.7e18
             if sample_value > 1e17:
-                # Nanoseconds (Java/Kafka timestamps)
-                df[self.timestamp_column] = pd.to_datetime(
-                    df[self.timestamp_column], unit="ns"
-                )
+                unit = "ns"  # Nanoseconds (Java/Kafka timestamps)
             elif sample_value > 1e14:
-                # Microseconds
-                df[self.timestamp_column] = pd.to_datetime(
-                    df[self.timestamp_column], unit="us"
-                )
+                unit = "us"  # Microseconds
             elif sample_value > 1e11:
-                # Milliseconds (common in JavaScript/Kafka)
-                df[self.timestamp_column] = pd.to_datetime(
-                    df[self.timestamp_column], unit="ms"
-                )
+                unit = "ms"  # Milliseconds (common in JavaScript/Kafka)
             else:
-                # Seconds (Unix timestamp)
-                df[self.timestamp_column] = pd.to_datetime(
-                    df[self.timestamp_column], unit="s"
-                )
-
-        # Extract time-based columns (year, month, day, hour) from the timestamp
-        timestamp_col = df[self.timestamp_column]
+                unit = "s"  # Seconds (Unix timestamp)
+            timestamp_col = pd.to_datetime(timestamp_col, unit=unit)
 
         # Only add columns that are specified in _ts_hive_columns
         # TIMESTAMP_COL_MAPPER handles proper formatting (e.g., zero-padding for months/days)

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -667,16 +667,16 @@ class QuixTSDataLakeSink(BatchingSink):
             # _write_batch fillna()'s NaN partition values with HIVE_NULL_PARTITION
             # (the on-disk sentinel — see the constant near the top) so they
             # survive groupby and land in a single ``col=__None__`` directory on
-            # disk. The catalog, however, should record those values as actual
-            # SQL NULL — not the literal sentinel string — so that downstream
-            # `partition_<col> IS NULL` filters and partition-tree NULL rendering
-            # work natively. Translate back here.
-            partition_dict: Dict[str, Optional[str]] = {}
+            # disk. The catalog receives the same literal string — including
+            # the ``__None__`` sentinel for NULL buckets — so the manifest
+            # row, the on-disk path, and what DuckDB's
+            # ``hive_partitioning=true`` exposes at query time all agree.
+            # Equality filters then resolve end-to-end without any sentinel
+            # translation in the lake.
+            partition_dict: Dict[str, str] = {}
             if partition_columns and partition_values:
                 for col, val in zip(partition_columns, partition_values):
-                    partition_dict[col] = (
-                        None if val == HIVE_NULL_PARTITION else str(val)
-                    )
+                    partition_dict[col] = str(val)
 
             # Create file entry
             file_entries.append(

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -446,6 +446,42 @@ class TestTimestampColumnMapping:
         assert "month" not in result_df.columns
         assert "hour" not in result_df.columns
 
+    def test_add_timestamp_columns_does_not_mutate_timestamp_column_dtype(
+        self, sink_factory
+    ):
+        """
+        Regression: extracting year/month/day/hour for time-based hive
+        partitioning must not change the dtype of the source timestamp
+        column. ``ts_ms`` is a system column the sink injects from the
+        Kafka ``item.timestamp`` (always int64 ms); its dtype is part of
+        the contract with readers — files written under different
+        ``HIVE_COLUMNS`` configurations must store ``ts_ms`` with the same
+        type, otherwise downstream readers see the same column as BIGINT
+        in some files and TIMESTAMP in others.
+        """
+        sink = sink_factory(hive_columns=["year", "month", "day", "hour"])
+
+        df = pd.DataFrame(
+            {"ts_ms": [1704067200000, 1704067260000], "value": [1, 2]}
+        )
+        original_dtype = df["ts_ms"].dtype
+
+        result_df = sink._add_timestamp_columns(df)
+
+        # Derived columns still correct.
+        assert result_df["year"].iloc[0] == "2024"
+        assert result_df["month"].iloc[0] == "01"
+        assert result_df["day"].iloc[0] == "01"
+        assert result_df["hour"].iloc[0] == "00"
+
+        # Source ts_ms column is untouched — same dtype, same values.
+        assert result_df["ts_ms"].dtype == original_dtype, (
+            f"ts_ms dtype changed from {original_dtype} to "
+            f"{result_df['ts_ms'].dtype}; partitioning logic must not "
+            f"mutate the data column"
+        )
+        assert list(result_df["ts_ms"]) == [1704067200000, 1704067260000]
+
 
 # =============================================================================
 # 3. Empty Dict Handling Tests

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -461,9 +461,7 @@ class TestTimestampColumnMapping:
         """
         sink = sink_factory(hive_columns=["year", "month", "day", "hour"])
 
-        df = pd.DataFrame(
-            {"ts_ms": [1704067200000, 1704067260000], "value": [1, 2]}
-        )
+        df = pd.DataFrame({"ts_ms": [1704067200000, 1704067260000], "value": [1, 2]})
         original_dtype = df["ts_ms"].dtype
 
         result_df = sink._add_timestamp_columns(df)

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -741,7 +741,7 @@ class TestWriteOperations:
 
         assert mock_blob_client.put_object_async.call_count == 1
         storage_key = mock_blob_client.put_object_async.call_args.args[0]
-        assert "machine=None" in storage_key
+        assert "machine=__None__" in storage_key
 
     def test_write_adds_timestamp_from_item_if_missing(
         self, sink_factory, sample_batch, mock_blob_client
@@ -987,17 +987,18 @@ class TestCatalogIntegration:
         with pytest.raises(Exception, match="Manifest error"):
             sink.write(batch)
 
-    def test_manifest_registers_null_partition_as_sql_null(
+    def test_manifest_registers_null_partition_as_literal_sentinel(
         self, sink_factory, mock_blob_client, mock_catalog_client
     ):
         """
         A row whose partition column is None / missing lands in a
-        ``col=__None__`` bucket on disk, but the catalog payload must
-        record the partition value as SQL NULL — not as the literal
-        sentinel string. This is what lets downstream readers emit
-        ``partition_<col> IS NULL`` filters and render the bucket as NULL
-        in their partition trees, instead of leaking the storage-layer
-        sentinel into user-facing SQL.
+        ``col=__None__`` bucket on disk, and the catalog payload must
+        record the same literal ``__None__`` string — not SQL NULL —
+        so the manifest, the on-disk path, and what readers see at query
+        time (DuckDB's ``hive_partitioning=true`` exposes the literal
+        path segment as the column value) all agree. The lake treats
+        partition values as opaque strings end-to-end; equality filters
+        on ``__None__`` then resolve without any sentinel translation.
         """
         sink = sink_factory(
             hive_columns=["machine"],
@@ -1043,11 +1044,10 @@ class TestCatalogIntegration:
         # One file per partition group — M1 and the null bucket.
         by_partition = {f["partition_values"]["machine"]: f for f in files}
         assert by_partition["M1"]["partition_values"]["machine"] == "M1"
-        assert by_partition[None]["partition_values"]["machine"] is None
-        # Storage key on disk uses the unified ``__None__`` sentinel — the
-        # same string the catalog, API, and UI all expect for NULL partition
-        # values.
-        null_bucket_path = by_partition[None]["file_path"]
+        # Literal passthrough: catalog row carries ``__None__`` exactly,
+        # matching the on-disk path segment.
+        assert by_partition["__None__"]["partition_values"]["machine"] == "__None__"
+        null_bucket_path = by_partition["__None__"]["file_path"]
         assert "machine=__None__" in null_bucket_path
 
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                 
                                                                                                                                                                                                                             
  Two related correctness fixes in `QuixTSDataLakeSink`:                                                                                                                                                                     
                                                                                                                                                                                                                             
  1. **NULL partitions are now registered in the catalog as the literal `__None__` string** instead of being silently translated to SQL `NULL` (`quix_ts_datalake_sink.py:_register_files_in_manifest`).                     
  2. **`ts_ms` (and any user-configured `timestamp_column`) keeps its input dtype** when `HIVE_COLUMNS` includes `year` / `month` / `day` / `hour` (`quix_ts_datalake_sink.py:_add_timestamp_columns`).                      
                                              
  ## Why                                                                                                                                                                                                                     
                                                            
  ### NULL-partition leak (commit 1)                                                                                                                                                                                         
                                                            
  The sink wrote NULL-partition rows to disk under `col=__None__/` but POSTed the catalog manifest with `partition_<col>=NULL`. The on-disk sentinel and the catalog row disagreed for every file the sink registered. The   
  reading side of the lake now treats partition values as opaque strings end-to-end — the catalog, the on-disk path, and what DuckDB's `hive_partitioning=true` exposes at query time must all agree on the same literal. 
  With the old translation in place, the partition tree split one logical NULL bucket into two (files lived under `__None__/` but their catalog rows showed up under an empty bucket).

  Fix: send `str(val)` for every partition value, no NULL magic.                                                                                                                                                             
                                              
  ### Timestamp dtype mutation (commit 2)                                                                                                                                                                                    
                                                            
  `_add_timestamp_columns` overwrote `df[timestamp_column]` in place when converting numeric timestamps to `datetime64` for year/month/day/hour extraction. As a result:                                                     
                                              
  - `HIVE_COLUMNS` with no time columns → parquet stored `ts_ms` as **BIGINT**.                                                                                                                                              
  - `HIVE_COLUMNS` with any time column → parquet stored `ts_ms` as **TIMESTAMP**.
                                                                                                                                                                                                                             
  The same logical column landed in parquet as two incompatible types depending on partitioning config, so reconfiguring `HIVE_COLUMNS` (or running two sinks with different configs against one table) silently fractured 
  the table.                                                                                                                                                                                                                 
                                                                                                                                                                                                                             
  This violates the contract on `ts_ms` in particular: `ts_ms` is sink-injected from `item.timestamp` (Kafka message timestamp, always int64 ms). Its dtype is not a partitioning concern.                                   
                                                                                                                                                                                                                             
  Fix: derive year/month/day/hour from a local `datetime64` series; never write back into `df[timestamp_column]`.
                                                                                                                                                                                                                             
  ## Test plan                                                                                                                                                                                                               
   
  - [x] `tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py` — 58/58 pass.                                                                                                                            
  - [x] New `test_manifest_registers_null_partition_as_literal_sentinel` asserts the catalog payload carries `'__None__'` literal and the on-disk path matches.
  - [x] New `test_add_timestamp_columns_does_not_mutate_timestamp_column_dtype` asserts `ts_ms` keeps `int64` after extraction with `HIVE_COLUMNS=[year, month, day, hour]`.                                                 
  - [x] Adjacent stale assertion in `test_write_all_null_partition_values_still_writes` updated from `machine=None` to `machine=__None__` (was already expected on-disk, just an out-of-date string check).
                                                                                                                                                                                                                             
  ## Coordination with the lake                                                                                                                                                                                              
                                                                                                                                                                                                                             
  The lake side (`Quix.DataLake.Timeseries`) has been refactored to literal-passthrough handling of partition values and to expect `ts_ms` as int64. With both changes in place, the sink→catalog→tree→query path agrees     
  end-to-end and `WHERE test_run = '__None__'` returns the rows of the NULL bucket without any sentinel translation in between.                                                                                              
                                                                                                                                                                                                                             
  ## Migration note for users                               
                                                                                                                                                                                                                             
  - Files already on disk written by the old sink (catalog rows say `NULL`, on-disk path says `__None__`) appear as two distinct buckets in the partition tree until the table is refreshed against the new lake. A single 
  `/refresh` re-scans S3, finds the literal `__None__`, and collapses them into one bucket.                                                                                                                                  
  - Files written before the timestamp fix may have `ts_ms` as `TIMESTAMP` (if `HIVE_COLUMNS` included a time column at write time) and `BIGINT` otherwise. The lake's compaction already groups by type and unifies on read;
   running compaction after this lands will produce a uniformly-typed `ts_ms` column.