### PR TITLE
Prevent buffered consumers from stalling after restart

### DIFF
--- a/quixstreams/internal_consumer/buffering.py
+++ b/quixstreams/internal_consumer/buffering.py
@@ -57,10 +57,7 @@ class PartitionBuffer:
         """
         Set the current consumer position for this topic partition.
 
-        The position is the next offset to be returned by the Kafka consumer. When a
-        process starts from a committed offset, the buffer has not observed the
-        previously consumed messages, so its max offset must be initialized from
-        the position to determine idleness correctly.
+        The position is the next offset to be returned by the Kafka consumer.
 
         :param offset: the current consumer position.
         """

--- a/quixstreams/internal_consumer/buffering.py
+++ b/quixstreams/internal_consumer/buffering.py
@@ -53,6 +53,20 @@ class PartitionBuffer:
         """
         self._high_watermark = offset
 
+    def set_position(self, offset: int):
+        """
+        Set the current consumer position for this topic partition.
+
+        The position is the next offset to be returned by the Kafka consumer. When a
+        process starts from a committed offset, the buffer has not observed the
+        previously consumed messages, so its max offset must be initialized from
+        the position to determine idleness correctly.
+
+        :param offset: the current consumer position.
+        """
+        if offset > 0:
+            self._max_offset = max(self._max_offset, offset - 1)
+
     def idleness(self) -> Idleness:
         """
         Check if the partition is idle or has more data to be consumed from the broker.
@@ -202,6 +216,17 @@ class PartitionBufferGroup:
         for topic, watermark in offsets.items():
             buffer = self._partition_buffers[topic]
             buffer.set_high_watermark(watermark)
+
+    def set_positions(self, offsets: dict[str, int]):
+        """
+        Set consumer positions for assigned partitions.
+
+        :param offsets: a mapping of {<topic>: <offset>} with the current consumer
+            positions for this group.
+        """
+        for topic, offset in offsets.items():
+            buffer = self._partition_buffers[topic]
+            buffer.set_position(offset)
 
     def append(self, message: SuccessfulConfluentKafkaMessageProto):
         """
@@ -357,17 +382,20 @@ class InternalConsumerBuffer:
         self,
         messages: Iterable[SuccessfulConfluentKafkaMessageProto],
         high_watermarks: dict[tuple[str, int], int],
+        positions: Optional[dict[tuple[str, int], int]] = None,
     ):
         """
         Feed new batch of messages to the buffer.
 
         :param messages: an iterable with successful `confluent_kafka.Message` objects (`.error()` is expected to be None).
         :param high_watermarks: a dictionary with high watermarks for all assigned topic partitions.
+        :param positions: a dictionary with current consumer positions for all assigned topic partitions.
         """
         for message in messages:
             partition_group = self._partition_groups[message.partition()]
             partition_group.append(message=message)
 
+        positions = positions or {}
         for partition_group in self._partition_groups.values():
             group_watermarks = {
                 topic: watermark
@@ -375,6 +403,12 @@ class InternalConsumerBuffer:
                 if partition == partition_group.partition
             }
             partition_group.set_high_watermarks(offsets=group_watermarks)
+            group_positions = {
+                topic: position
+                for (topic, partition), position in positions.items()
+                if partition == partition_group.partition
+            }
+            partition_group.set_positions(offsets=group_positions)
 
     def pop(self) -> Optional[SuccessfulConfluentKafkaMessageProto]:
         """

--- a/quixstreams/internal_consumer/consumer.py
+++ b/quixstreams/internal_consumer/consumer.py
@@ -135,6 +135,16 @@ class InternalConsumer(BaseConsumer):
                 tp for tp in partitions if not self._topics[tp.topic].is_changelog
             ]
             self._buffer.assign_partitions(buffer_partitions)
+            committed = consumer.committed(buffer_partitions, timeout=30)
+            self._buffer.feed(
+                messages=[],
+                high_watermarks={},
+                positions={
+                    (tp.topic, tp.partition): tp.offset
+                    for tp in committed
+                    if tp.offset >= 0
+                },
+            )
             if on_assign is not None:
                 on_assign(consumer, partitions)
 
@@ -340,17 +350,24 @@ class InternalConsumer(BaseConsumer):
 
         # Get the recent cached high watermarks
         high_watermarks: dict[tuple[str, int], int] = {}
+        positions: dict[tuple[str, int], int] = {}
         for tp in self.assignment():
             topic_obj = self._topics[tp.topic]
             if not topic_obj.is_changelog:
                 _, high = self.get_watermark_offsets(partition=tp, cached=True)
                 high_watermarks[(tp.topic, tp.partition)] = high
+                position, *_ = self.position([tp])
+                positions[(tp.topic, tp.partition)] = position.offset
 
         # Create a generator to validate messages
         valid_messages = _validate_message_batch(messages, on_error=self._on_error)
 
         # Feed the batch and the watermarks to the buffer
-        self._buffer.feed(messages=valid_messages, high_watermarks=high_watermarks)
+        self._buffer.feed(
+            messages=valid_messages,
+            high_watermarks=high_watermarks,
+            positions=positions,
+        )
 
         # Resume partitions with empty buffers
         for topic, partition in self._buffer.resume_empty():

--- a/quixstreams/internal_consumer/consumer.py
+++ b/quixstreams/internal_consumer/consumer.py
@@ -135,18 +135,34 @@ class InternalConsumer(BaseConsumer):
                 tp for tp in partitions if not self._topics[tp.topic].is_changelog
             ]
             self._buffer.assign_partitions(buffer_partitions)
+            if on_assign is not None:
+                on_assign(consumer, partitions)
+
             committed = consumer.committed(buffer_partitions, timeout=30)
+            positions = {
+                (tp.topic, tp.partition): tp.offset
+                for tp in consumer.position(buffer_partitions)
+                if tp.offset >= 0
+            }
+            positions.update(
+                {
+                    (tp.topic, tp.partition): tp.offset
+                    for tp in buffer_partitions
+                    if tp.offset >= 0 and (tp.topic, tp.partition) not in positions
+                }
+            )
+            positions.update(
+                {
+                    (tp.topic, tp.partition): tp.offset
+                    for tp in committed
+                    if tp.offset >= 0 and (tp.topic, tp.partition) not in positions
+                }
+            )
             self._buffer.feed(
                 messages=[],
                 high_watermarks={},
-                positions={
-                    (tp.topic, tp.partition): tp.offset
-                    for tp in committed
-                    if tp.offset >= 0
-                },
+                positions=positions,
             )
-            if on_assign is not None:
-                on_assign(consumer, partitions)
 
         def _on_revoke(consumer: Consumer, partitions: list[TopicPartition]):
             buffer_partitions = [

--- a/quixstreams/internal_consumer/consumer.py
+++ b/quixstreams/internal_consumer/consumer.py
@@ -138,6 +138,9 @@ class InternalConsumer(BaseConsumer):
             if on_assign is not None:
                 on_assign(consumer, partitions)
 
+            # Seed the buffer from effective positions so partitions already at
+            # their start offset can be recognized as idle before any messages
+            # are observed in this process.
             committed = consumer.committed(buffer_partitions, timeout=30)
             positions = {
                 (tp.topic, tp.partition): tp.offset

--- a/tests/test_quixstreams/test_internal_consumer/test_buffering.py
+++ b/tests/test_quixstreams/test_internal_consumer/test_buffering.py
@@ -198,6 +198,44 @@ class TestInternalConsumerBuffer:
         # is empty but its watermark is -1001 (unknown)
         assert buffer.pop() is None
 
+    def test_pop_item_multiple_topics_single_partition_empty_but_position_at_high_watermark(
+        self,
+    ):
+        """
+        Test that InternalConsumerBuffer returns a message if another assigned topic
+        is empty but the consumer position shows it is already at the high watermark.
+        """
+
+        buffer = InternalConsumerBuffer()
+        buffer.assign_partitions(
+            [
+                TopicPartition(topic="test", partition=0),
+                TopicPartition(topic="test1", partition=0),
+            ]
+        )
+
+        messages = [
+            ConfluentKafkaMessageStub(
+                topic="test", partition=0, value=b"1", timestamp=(1, 10), offset=462
+            ),
+        ]
+        high_watermarks = {
+            ("test", 0): 909,
+            ("test1", 0): 3,
+        }
+        positions = {
+            ("test", 0): 463,
+            ("test1", 0): 3,
+        }
+
+        buffer.feed(
+            messages=messages,
+            high_watermarks=high_watermarks,
+            positions=positions,
+        )
+
+        assert buffer.pop() is messages[0]
+
     def test_feed_invalid_offset(self):
         buffer = InternalConsumerBuffer()
         buffer.assign_partitions([TopicPartition(topic="test", partition=0)])

--- a/tests/test_quixstreams/test_internal_consumer/test_consumer.py
+++ b/tests/test_quixstreams/test_internal_consumer/test_consumer.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from confluent_kafka import KafkaError, TopicPartition
+from confluent_kafka import OFFSET_INVALID, KafkaError, TopicPartition
 
 from quixstreams.exceptions import PartitionAssignmentError
 from quixstreams.internal_consumer import InternalConsumer
@@ -374,3 +374,78 @@ class TestInternalConsumer:
         assert rows[1].timestamp == messages[2].timestamp
         assert rows[2].timestamp == messages[3].timestamp
         assert rows[3].timestamp == messages[1].timestamp
+
+    def test_poll_row_buffered_releases_message_when_other_topic_committed_at_end(
+        self,
+        consumer_factory,
+        internal_consumer_factory,
+        topic_json_serdes_factory,
+        producer,
+    ):
+        """
+        Test buffered consumption after restart when one topic has lag and another
+        co-partitioned topic is already committed at its high watermark.
+        """
+        topic1 = topic_json_serdes_factory()
+        topic2 = topic_json_serdes_factory()
+        consumer_group = str(uuid4())
+
+        with producer:
+            for i in range(3):
+                producer.produce(
+                    topic=topic2.name,
+                    key=b"key",
+                    value=f'{{"field": "idle-{i}"}}'.encode(),
+                    timestamp=i,
+                )
+            producer.produce(
+                topic=topic1.name,
+                key=b"key",
+                value=b'{"field": "active"}',
+                timestamp=10,
+            )
+
+        with consumer_factory(
+            consumer_group=consumer_group,
+            auto_offset_reset="earliest",
+            auto_commit_enable=False,
+        ) as consumer:
+            consumer.subscribe(topics=[topic1.name, topic2.name])
+            while not consumer.assignment():
+                consumer.poll(0.1)
+            consumer.commit(
+                offsets=[
+                    TopicPartition(topic=topic1.name, partition=0, offset=0),
+                    TopicPartition(topic=topic2.name, partition=0, offset=3),
+                ],
+                asynchronous=False,
+            )
+
+        with internal_consumer_factory(
+            consumer_group=consumer_group,
+            auto_offset_reset="earliest",
+            auto_commit_enable=False,
+        ) as consumer:
+            consumer.subscribe([topic1, topic2])
+
+            real_position = consumer.position
+
+            def position_with_unknown_idle_topic(partitions):
+                positions = real_position(partitions)
+                for position in positions:
+                    if position.topic == topic2.name:
+                        position.offset = OFFSET_INVALID
+                return positions
+
+            row = None
+            with patch.object(
+                consumer, "position", side_effect=position_with_unknown_idle_topic
+            ):
+                while Timeout():
+                    row = consumer.poll_row(0.1, buffered=True)
+                    if row is not None:
+                        break
+
+        assert row is not None
+        assert row.topic == topic1.name
+        assert row.value == {"field": "active"}

--- a/tests/test_quixstreams/test_internal_consumer/test_consumer.py
+++ b/tests/test_quixstreams/test_internal_consumer/test_consumer.py
@@ -449,3 +449,75 @@ class TestInternalConsumer:
         assert row is not None
         assert row.topic == topic1.name
         assert row.value == {"field": "active"}
+
+    def test_poll_row_buffered_respects_on_assign_seek_before_position_seed(
+        self,
+        consumer_factory,
+        internal_consumer_factory,
+        topic_json_serdes_factory,
+        producer,
+    ):
+        """
+        Test that buffer position seeding respects customized offsets set in
+        the assignment callback.
+        """
+        topic1 = topic_json_serdes_factory()
+        topic2 = topic_json_serdes_factory()
+        consumer_group = str(uuid4())
+
+        with producer:
+            for i in range(3):
+                producer.produce(
+                    topic=topic1.name,
+                    key=b"key",
+                    value=f'{{"field": "replay-{i}"}}'.encode(),
+                    timestamp=10 + i,
+                )
+            producer.produce(
+                topic=topic2.name,
+                key=b"key",
+                value=b'{"field": "idle"}',
+                timestamp=1,
+            )
+
+        with consumer_factory(
+            consumer_group=consumer_group,
+            auto_offset_reset="earliest",
+            auto_commit_enable=False,
+        ) as consumer:
+            consumer.subscribe(topics=[topic1.name, topic2.name])
+            while not consumer.assignment():
+                consumer.poll(0.1)
+            consumer.commit(
+                offsets=[
+                    TopicPartition(topic=topic1.name, partition=0, offset=3),
+                    TopicPartition(topic=topic2.name, partition=0, offset=1),
+                ],
+                asynchronous=False,
+            )
+
+        def on_assign(consumer, partitions):
+            for partition in partitions:
+                if partition.topic == topic1.name:
+                    partition.offset = 0
+                elif partition.topic == topic2.name:
+                    partition.offset = 1
+            consumer.assign(partitions)
+
+        with internal_consumer_factory(
+            consumer_group=consumer_group,
+            auto_offset_reset="earliest",
+            auto_commit_enable=False,
+        ) as consumer:
+            consumer.subscribe([topic1, topic2], on_assign=on_assign)
+
+            row = None
+            while Timeout():
+                row = consumer.poll_row(0.1, buffered=True)
+                if row is not None:
+                    break
+
+        assert row is not None
+        assert row.topic == topic1.name
+        assert row.offset == 0
+        assert row.value == {"field": "replay-0"}


### PR DESCRIPTION
Fixes
- Seed the time-alignment buffer from effective consumer positions, explicit assignment offsets, or committed offsets so empty co-partitioned topics can be recognised as idle after restart
- Preserve custom assignment offsets while still falling back to committed offsets when live positions are unknown

Tests
- Cover buffered restart recovery when one topic has lag and another topic is already committed at its high watermark
- Cover buffered replay from a custom assignment offset below the committed group offset
