### PR TITLE
version update to 3.24.0

### DIFF
--- a/quixstreams/__init__.py
+++ b/quixstreams/__init__.py
@@ -5,4 +5,4 @@ from .state import State
 
 __all__ = ["Application", "message_context", "MessageContext", "State"]
 
-__version__ = "3.23.7"
+__version__ = "3.24.0"


### PR DESCRIPTION
  1. State TTL (#1107) — state.set(key, value, ttl=timedelta(...)) auto-expires state entries;
  eviction rides the flush path with no extra threads. Existing stores stay compatible until TTL
  is first used on an empty partition. Solves unbounded state growth in dedup-style pipelines.
  2. Auto state recovery on expired source offsets (#1115) — if a stopped stateful app's committed
  offset falls off broker retention, restart now deletes the stale local state and recovers from
  the changelog instead of silently computing on mismatched state. Opt out via
  auto_recover_from_source_offset_out_of_range=False (fail-fast); resume point set by
  state_recovery_offset_reset.
  3. Buffered consumer restart fix (#1117) — time-aligned multi-topic consumers no longer stall
  after restart when one topic is idle at its high watermark; buffer positions are now seeded from
  live/assigned/committed offsets at assignment.