### PR TITLE
 Correct stale documentation across streaming APIs and connectors

### DIFF
--- a/docs/advanced/checkpointing.md
+++ b/docs/advanced/checkpointing.md
@@ -21,10 +21,11 @@ See the [Configuration](../configuration.md#processing-guarantees) page to learn
 - The `Checkpoint` object is responsible for keeping track of processed Kafka offsets and pending state transactions.
 - After the message is successfully processed, its offset is marked as processed in the current checkpoint.
 - When checkpoint commits, it will:
-    1. *Produce changelog messages for every pending state update to the changelog topics (if they are enabled).*
-    2. *Flush the Kafka Producer and verify the delivery of every outgoing message both to output and changelog topics.*
-    3. *Synchronously commit the topic offsets to Kafka.*
-    4. *Flush the pending state transactions to the durable state stores.*
+    1. *Flush registered sinks. If a sink raises `SinkBackpressureError`, processing pauses assigned partitions and the checkpoint exits early without committing offsets.*
+    2. *Produce changelog messages for every pending state update to the changelog topics (if they are enabled).*
+    3. *Flush the Kafka Producer and verify the delivery of every outgoing message both to output and changelog topics.*
+    4. *Synchronously commit the topic offsets to Kafka.*
+    5. *Flush the pending state transactions to the durable state stores.*
         
 - After the checkpoint is fully committed, a new one is created and the processing continues.
 - Besides the regular intervals, the checkpoint is also committed when Kafka partitions are rebalanced.
@@ -106,4 +107,3 @@ In the At-Least-Once setting, it is still possible that unwanted changelog chang
 - Since the changelogs are already produced, during recovery from scratch they will be applied to the state even though the messages are now filtered.
 
 Though this case is rare, the best way to avoid it is to stop the application clean and ensure the latest checkpoint successfully commits before updating the processing code.
-

--- a/docs/advanced/producer-consumer-lowlevel.md
+++ b/docs/advanced/producer-consumer-lowlevel.md
@@ -49,11 +49,10 @@ from quixstreams import Application
 app = Application(
     broker_address='localhost:9092', 
     auto_offset_reset='earliest', 
-    auto_commit_enable=True,
 )
 
 # Create a consumer and start a polling loop
-with app.get_consumer() as consumer:
+with app.get_consumer(auto_commit_enable=True) as consumer:
     consumer.subscribe(topics=['my-topic'])
 
     while True:

--- a/docs/advanced/schema-registry.md
+++ b/docs/advanced/schema-registry.md
@@ -2,7 +2,7 @@
 
 Serializers and deserializers for JSON Schema, Avro, and Protobuf support integration with a Schema Registry.
 
-The current implementation wraps Confluent's serializers and deserializers, which are tightly coupled with the Schema Registry.
+The current implementation wraps Confluent's serializers and deserializers. JSON Schema and Avro deserializers use Schema Registry lookups; Protobuf deserialization uses the provided `msg_type` and Confluent wire-format handling, while accepting Schema Registry config for API consistency.
 
 To integrate your existing Schema Registry, pass `SchemaRegistryClientConfig` to your serializers and deserializers. Additional optional configuration can be provided via `SchemaRegistrySerializationConfig`. 
 
@@ -110,5 +110,7 @@ serializer = ProtobufSerializer(
     schema_registry_serialization_config=schema_registry_serialization_config,
 )
 ```
+
+`ProtobufDeserializer` requires the local `msg_type`; it does not fetch the Protobuf message type from Schema Registry.
 
 See the [Serialization and Deserialization](./serialization.md) page to learn more about how to integrate the serializer and deserializer with your application.

--- a/docs/advanced/serialization.md
+++ b/docs/advanced/serialization.md
@@ -79,7 +79,7 @@ output_topic = app.topic('output', value_serializer=JSONSerializer(schema=MY_SCH
 Apache Avro is a row-based binary serialization format. Avro stores the schema in JSON format alongside the data, enabling efficient processing and schema evolution.
 
 You can learn more about the Apache Avro format [here](https://avro.apache.org/docs/).
-The Avro serializer and deserializer need to be passed explicitly and must include the schema.
+The Avro serializer and deserializer need to be passed explicitly. Local schemaless Avro deserialization must include the schema; Schema Registry-backed deserialization can fetch the writer schema when `schema_registry_client_config` is provided.
 
 > **WARNING**: The Avro serializer and deserializer require the `fastavro` library.  
 > You can install Quix Streams with the necessary dependencies using:  

--- a/docs/advanced/stateful-processing.md
+++ b/docs/advanced/stateful-processing.md
@@ -85,7 +85,7 @@ They are also compacted to prevent them from growing indefinitely.
 ### How Changelog Topics Work
 - When the application starts, it automatically checks which state stores need to be created.  
 It will ensure the changelog topics exist for these stores.
-- When the key is updated in the state store during processing, the update will be sent both to the changelog topic and the local state store.
+- When the key is updated in the state store during processing, the update is staged in the current state transaction. During checkpoint commit, staged updates are produced to the changelog topic and then flushed to the local state store.
 - When the application restarts or a new consumer joins the group, it will check whether the state stores are up-to-date with their changelog topics.    
 If they are not, the application will first update the local stores, and only then will it continue processing the messages. 
 

--- a/docs/advanced/topics.md
+++ b/docs/advanced/topics.md
@@ -19,7 +19,7 @@ Default - `True`.
 2. Define a topic using `Application.topic()` method.    
 This will let the app track this topic on the Kafka broker
 
-When you have this code in place, the topics will be created on `Application.run()`.
+When you call `Application.topic()`, regular topics are inspected on the broker and created immediately if they do not exist.
 
 >***NOTE:*** Quix Streams automatically creates topics only if they don't exist in Kafka.   
 > It never updates the topic configuration after the topics are already created.
@@ -41,8 +41,8 @@ output_topic = app.topic('output')
 # Create a bypass transformation sending messages from the input topic to the output one
 sdf = app.dataframe(input_topic).to_topic(output_topic)
 
-# Run the Application. 
-# The topics will be validated and created during this function call.
+# Run the Application.
+# The topics were validated and created when Application.topic() was called.
 app.run()
 ```
 
@@ -80,8 +80,8 @@ output_topic = app.topic(
 # Create a bypass transformation sending messages from the input topic to the output one
 sdf = app.dataframe(input_topic).to_topic(output_topic)
 
-# Run the Application. 
-# The topics will be validated and created during this function call.
+# Run the Application.
+# The topics were validated and created when Application.topic() was called.
 # Note: if the topics already exist, the configs will remain intact.
 app.run()
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,8 @@ the `commit_every` parameter.
 - **`auto_offset_reset`** - Consumer `auto.offset.reset` setting.  
 It determines where the consumer should start reading messages from.  
 See more `auto.offset.reset` in this [article](https://www.quix.io/blog/kafka-auto-offset-reset-use-cases-and-pitfalls#the-auto-offset-reset-configuration).  
-**Options**: `"latest"`, `"earliest"`.  
+**Options**: `"latest"`, `"earliest"`, `"error"`.  
+Using `"error"` makes the consumer raise an error if no committed offset is found for a partition.  
 **Default** - `"latest"`.
 
 - **`processing_guarantee`** - Use "at-least-once" or "exactly-once" processing guarantees.  

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,7 +168,8 @@ For more information about tuning the `commit_interval`, see the ["Configuring t
 ## State
 - **`state_dir`** - path to the application state directory.  
 This directory contains data for each state store separated by consumer group.  
-Default - `"state"`.
+When not set, Quix Streams uses the first available value from this order: `Quix__Deployment__State__Path`, deprecated `Quix__State__Dir`, `/app/state` for Quix deployments, then `state` for local runs.  
+Default - auto-detected as described above.
 
 - **`rocksdb_options`** - options to be used for RocksDB instances.   
 The default configuration is described in the class `quixstreams.state.rocksdb.options.RocksDBOptions`.  

--- a/docs/connectors/sinks/amazon-s3-sink.md
+++ b/docs/connectors/sinks/amazon-s3-sink.md
@@ -107,8 +107,8 @@ Each object is named using the batch's starting offset (padded to 19 digits) and
 
 ## Supported Formats
 
-- **JSON**: Supports appending to existing files
-- **Parquet**: Does not support appending (new file created for each batch)
+- **JSON**: Writes a new object for each batch
+- **Parquet**: Writes a new object for each batch
 
 ## Delivery Guarantees
 

--- a/docs/connectors/sinks/custom-sinks.md
+++ b/docs/connectors/sinks/custom-sinks.md
@@ -22,7 +22,7 @@ Other sinks may write the data straight away.
 
 2. When the current checkpoint is committed, the app calls `BaseSink.flush()`.  
 For example, `BatchingSink` will write the accumulated data during `flush()`.
-   1. If the destination cannot accept new data, sinks can raise a special exception `SinkBackpressureError(topic, partition, retry_after)` and specify the timeout for the writes to be retried later.  
+   1. If the destination cannot accept new data, sinks can raise a special exception `SinkBackpressureError(retry_after)` and specify the timeout for the writes to be retried later.  
    2. The application will react to `SinkBackpressureError` by pausing the corresponding topic-partition for the given time and seeking the partition offset back to the beginning of the checkpoint.  
    3. When the timeout elapses, the app will resume consuming from this partition, re-process the data, and try to sink it again.
 
@@ -37,7 +37,7 @@ For example, some databases may rate limit the number of bytes written in a give
 
 To handle these scenarios, Sinks provide the **backpressure mechanism**.
 
-The Sink can tell the application to pause consuming from the given topic-partition and reprocess the data later by raising a [SinkBackpressureError(topic, partition, retry_after)](../../api-reference/sinks.md#sinkbackpressureerror).
+The Sink can tell the application to pause consuming and reprocess the data later by raising a [SinkBackpressureError(retry_after)](../../api-reference/sinks.md#sinkbackpressureerror).
 
 The app will catch the `SinkBackpressureError`, pause the topic-partition for the `retry_after` timeout, seek the partition offset back to the beginning of the checkpoint, and remove this partition from the current checkpoint commit.
 
@@ -75,8 +75,6 @@ class MyDatabaseSink(BatchingSink):
             # In case of timeout, tell the app to wait for 30s 
             # and retry the writing later
             raise SinkBackpressureError(
-               retry_after=30.0, 
-               topic=batch.topic, 
-               partition=batch.partition,
+               retry_after=30.0,
             )
 ```

--- a/docs/connectors/sinks/custom-sinks.md
+++ b/docs/connectors/sinks/custom-sinks.md
@@ -74,7 +74,5 @@ class MyDatabaseSink(BatchingSink):
         except TimeoutError:
             # In case of timeout, tell the app to wait for 30s 
             # and retry the writing later
-            raise SinkBackpressureError(
-               retry_after=30.0,
-            )
+            raise SinkBackpressureError(retry_after=30.0)
 ```

--- a/docs/connectors/sinks/custom-sinks.md
+++ b/docs/connectors/sinks/custom-sinks.md
@@ -23,8 +23,8 @@ Other sinks may write the data straight away.
 2. When the current checkpoint is committed, the app calls `BaseSink.flush()`.  
 For example, `BatchingSink` will write the accumulated data during `flush()`.
    1. If the destination cannot accept new data, sinks can raise a special exception `SinkBackpressureError(retry_after)` and specify the timeout for the writes to be retried later.  
-   2. The application will react to `SinkBackpressureError` by pausing the corresponding topic-partition for the given time and seeking the partition offset back to the beginning of the checkpoint.  
-   3. When the timeout elapses, the app will resume consuming from this partition, re-process the data, and try to sink it again.
+   2. The application will react to `SinkBackpressureError` by pausing all assigned topic partitions for the given time and seeking their offsets back to the beginning of the checkpoint.  
+   3. When the timeout elapses, the app will resume consuming from these partitions, re-process the data, and try to sink it again.
 
 3. If any of the sinks fail during `flush()`, the application will abort the checkpoint, and the data will be re-processed again. 
 
@@ -39,7 +39,7 @@ To handle these scenarios, Sinks provide the **backpressure mechanism**.
 
 The Sink can tell the application to pause consuming and reprocess the data later by raising a [SinkBackpressureError(retry_after)](../../api-reference/sinks.md#sinkbackpressureerror).
 
-The app will catch the `SinkBackpressureError`, pause the topic-partition for the `retry_after` timeout, seek the partition offset back to the beginning of the checkpoint, and remove this partition from the current checkpoint commit.
+The app will catch the `SinkBackpressureError`, pause all assigned topic partitions for the `retry_after` timeout, seek their offsets back to the beginning of the checkpoint, and exit the current checkpoint without committing offsets.
 
 This way, the processing will continue, and the backpressured data will be re-processed and sinked again after the timeout.
 

--- a/docs/connectors/sinks/elasticsearch-sink.md
+++ b/docs/connectors/sinks/elasticsearch-sink.md
@@ -121,7 +121,7 @@ They will be included as
 {
     "field_x": "value_a",
     "field_y": "value_b",
-    "__key": b"my_key",
+    "__key": "my_key",
     "__headers": {},
     "__timestamp": 1234567890,
 }

--- a/docs/connectors/sinks/microsoft-azure-file-sink.md
+++ b/docs/connectors/sinks/microsoft-azure-file-sink.md
@@ -36,7 +36,7 @@ Create an instance of `AzureFileSink` and pass it to the `StreamingDataFrame.sin
 ```python
 from quixstreams import Application
 from quixstreams.sinks.community.file.azure import AzureFileSink
-from quixstreams.sinks.community.file.destinations import AzureFileDestination
+from quixstreams.sinks.community.file.formats import JSONFormat
 
 
 # Configure the sink to write JSON files to Azure

--- a/docs/connectors/sinks/microsoft-azure-file-sink.md
+++ b/docs/connectors/sinks/microsoft-azure-file-sink.md
@@ -83,8 +83,8 @@ Each object is named using the batch's starting offset (padded to 19 digits) and
 
 ## Supported Formats
 
-- **JSON**: Supports appending to existing files
-- **Parquet**: Does not support appending (new file created for each batch)
+- **JSON**: Writes a new blob for each batch
+- **Parquet**: Writes a new blob for each batch
 
 ## Delivery Guarantees
 

--- a/docs/connectors/sinks/mqtt-sink.md
+++ b/docs/connectors/sinks/mqtt-sink.md
@@ -97,9 +97,10 @@ The sink provides delivery guarantees based on the configured QoS level:
 During checkpointing, the sink waits for all pending publish acknowledgments to complete:
 
 - The wait time is controlled by `mqtt_flush_timeout_seconds` parameter
-- If any messages fail to publish within the flush timeout, an error is raised
+- If any messages fail to publish within the flush timeout, `MqttPublishAckTimeout` is raised and the MQTT client is cleaned up
 - When errors occur:
-  - The application will retry the entire batch from the last successful offset
+  - The checkpoint is aborted rather than paused with sink backpressure
+  - The data will be reprocessed from the last committed offset when processing resumes
   - Some messages that were successfully published in the failed batch may be published again
   - This ensures no messages are lost, but some might be delivered more than once
 

--- a/docs/connectors/sinks/quix-ts-datalake-sink.md
+++ b/docs/connectors/sinks/quix-ts-datalake-sink.md
@@ -100,7 +100,7 @@ Tracking state is in-memory only. On process restart or Kafka partition rebalanc
 
 ### Callback must not block
 
-The callback runs on the sink's flush thread, which is the same thread that drives the Kafka consumer heartbeat. A blocking call inside the callback (for example, a synchronous producer `flush()`) will stop the consumer from polling, causing a heartbeat timeout and triggering a rebalance cascade. The callback must do bounded work and return promptly. If you need to produce a Kafka message from the callback, use a fire-and-forget `produce()` call — do not follow it with a synchronous `flush()`.
+The callback can run either during sink `flush()` on the thread that drives the Kafka consumer heartbeat, or on the timeout tracker's background daemon thread. A blocking call inside the callback (for example, a synchronous producer `flush()`) can stop the consumer from polling when invoked during `flush()`, causing a heartbeat timeout and triggering a rebalance cascade. The callback must do bounded work and return promptly. If you need to produce a Kafka message from the callback, use a fire-and-forget `produce()` call — do not follow it with a synchronous `flush()`.
 
 ### Example: wiring a timeout-event producer
 

--- a/docs/connectors/sinks/quix-ts-datalake-sink.md
+++ b/docs/connectors/sinks/quix-ts-datalake-sink.md
@@ -80,11 +80,11 @@ Both parameters must be set to a usable value (`stream_timeout_ms` a positive in
 
 When a key has been silent for at least `stream_timeout_ms`:
 
-1. The key's tracking entry is evicted from the in-memory dict.
+1. An INFO line is logged: `Stream 'sensor-a' timed out (silence N ms >= threshold M ms)`.
 2. `on_stream_timeout(key)` is called synchronously.
-3. An INFO line is logged: `Stream 'sensor-a' timed out (silence N ms >= threshold M ms)`.
+3. If the callback returns successfully, the key's tracking entry is evicted from the in-memory dict.
 
-The eviction happens before the callback, so a callback that raises still counts as fired — the same key will not fire again for the current silence period. If the key starts producing again after eviction, it is treated as a fresh stream with a new baseline and will fire again on its next silence.
+If the callback raises, the exception is logged and the key remains tracked so the callback can be retried on the next check cycle. If the key starts producing again after successful eviction, it is treated as a fresh stream with a new baseline and will fire again on its next silence.
 
 A TTL safety sweep also evicts any tracking entry older than `3 × stream_timeout_ms` without firing (WARNING logged). This bounds the dict size in degenerate cases without any additional configuration.
 

--- a/docs/connectors/sinks/quix-ts-datalake-sink.md
+++ b/docs/connectors/sinks/quix-ts-datalake-sink.md
@@ -71,10 +71,10 @@ All silence-detection logic is provided by the standalone [`StreamTimeoutTracker
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `stream_timeout_ms` | `Optional[int]` | `None` | Per-key silence threshold in milliseconds. Must be a positive integer. The feature is disabled when this is `None`, `0`, or negative. |
+| `stream_timeout_ms` | `Optional[int]` | `None` | Per-key silence threshold in milliseconds. Must be a positive integer when `on_stream_timeout` is set. |
 | `on_stream_timeout` | `Optional[Callable[[Any], None]]` | `None` | Callback invoked once per silent key. Receives the raw Kafka message key as-is (`bytes`, `str`, `int`, … — whatever was passed to the sink). Exceptions are logged and swallowed. |
 
-Both parameters must be set to a usable value (`stream_timeout_ms` a positive int, `on_stream_timeout` callable) for the feature to activate. Any other combination disables the feature with zero overhead: no per-key dict is allocated, no background thread is started.
+Both parameters must be set to a usable value (`stream_timeout_ms` a positive int, `on_stream_timeout` callable) for the feature to activate. Passing both as `None` disables the feature with zero overhead: no per-key dict is allocated, no background thread is started. Any other invalid combination raises `ValueError`.
 
 ### Fire-and-evict semantics
 

--- a/docs/connectors/sinks/stream-timeout-tracker.md
+++ b/docs/connectors/sinks/stream-timeout-tracker.md
@@ -69,7 +69,7 @@ tracker.enabled       # True iff both params are valid
 tracker.touch(key)    # record a key (call from the host sink's `add()`)
 tracker.check_now()   # synchronous check (call from the host sink's `flush()`)
 tracker.start()       # start the background daemon thread (call from `setup()`)
-tracker.stop()        # signal the thread to exit (call from `cleanup()`)
+tracker.stop()        # signal the thread to exit from your host's shutdown path
 ```
 
 Both `stream_timeout_ms` and `on_stream_timeout` must be provided together. Mismatched pairs raise `ValueError`. Passing `None` for both silently disables the tracker — every public method becomes a no-op and the per-key dict is never allocated.
@@ -104,10 +104,11 @@ class MyCustomSink(BatchingSink):
         super().setup()
         self._timeout.start()
 
-    def cleanup(self):
+    def stop_timeout_tracker(self):
         self._timeout.stop()
-        super().cleanup()
 ```
+
+`BaseSink` and `BatchingSink` do not define an application-invoked cleanup hook. If your host owns the sink lifecycle, call `tracker.stop()` from that host's shutdown path; otherwise the daemon thread will also self-terminate after sustained idle.
 
 The tracker treats `topic`/`partition`/`offset` as opaque kwargs; pass any per-record context you want — the tracker currently ignores them (reserved for future log enrichment).
 

--- a/docs/connectors/sources/README.md
+++ b/docs/connectors/sources/README.md
@@ -10,7 +10,7 @@ from quixstreams.sources import CSVSource
 
 def main():
     app = Application()
-    source = CSVSource(path="input.csv")
+    source = CSVSource(path="input.csv", name="csv")
     
     sdf = app.dataframe(source=source)
     sdf.print(metadata=True)
@@ -61,7 +61,7 @@ from quixstreams.models.topics import TopicConfig
 def main():
     app = Application()
     # Create a CSVSource
-    source = CSVSource(path="input.csv")
+    source = CSVSource(path="input.csv", name="csv")
     
     # Define a topic for the CSVSource with a custom config
     topic = app.topic("my_csv_source", config=TopicConfig(num_partitions=4, replication_factor=1))

--- a/docs/connectors/sources/amazon-kinesis-source.md
+++ b/docs/connectors/sources/amazon-kinesis-source.md
@@ -107,7 +107,7 @@ processed (produced) more than once.
     
 ## Topic
 
-The default topic name the Application dumps to is `source-kinesis_<stream name>`.
+The source default topic name is `kinesis_<stream name>`. When passed to `Application.dataframe(source=...)` without a custom topic, the Kafka topic name is prefixed as `source__kinesis_<stream name>`.
 
 
 ## Testing Locally
@@ -130,4 +130,3 @@ Rather than connect to AWS, you can alternatively test your application using a 
 
 3. Set all other `aws_` parameters for `KinesisSource` to _any_ string. 
 They will not be used, but they must still be populated!
-

--- a/docs/connectors/sources/amazon-s3-source.md
+++ b/docs/connectors/sources/amazon-s3-source.md
@@ -105,7 +105,7 @@ Here are some important configurations to be aware of (see [File Source API](../
 
 ### Optional:
 
-- `format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
+- `file_format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
     **Advanced**: can optionally provide a `Format` instance (`compression` will then be ignored).    
     **Default**: `"json"`
 - `compression`: what compression is used on the given files, if any (ex: `"gzip"`)    
@@ -245,7 +245,7 @@ This will result in the following Kafka message format for `Application`:
 ### Custom Schemas (Advanced)
 
 If the original files are not formatted as expected, custom loaders can be configured 
-on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(format=<Format>)`.
+on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(file_format=<Format>)`.
 
 Formats can be imported from `quixstreams.sources.community.file.formats`.
 

--- a/docs/connectors/sources/amazon-s3-source.md
+++ b/docs/connectors/sources/amazon-s3-source.md
@@ -263,8 +263,7 @@ beginning (reproducing all previously processed messages).
 The default topic will have a partition count that reflects the partition count found 
 within the provided topic's folder structure.
 
-The default topic name the Application dumps to is based on the last folder name of 
-the `FileSource` `directory` as: `source__<last folder name>`.
+The default source topic name is based on the bucket and last path name as `s3_<bucket>_<last path name>`. When passed to `Application.dataframe(source=...)` without a custom topic, the Kafka topic name is prefixed as `source__s3_<bucket>_<last path name>`.
 
 Rather than connect to AWS, you can alternatively test your application using a local 
 emulated S3 host via Docker (using minio):

--- a/docs/connectors/sources/google-cloud-pubsub-source.md
+++ b/docs/connectors/sources/google-cloud-pubsub-source.md
@@ -132,7 +132,7 @@ regardless of ordering settings).
     
 ## Topic
 
-The default topic name the Application dumps to is `gcp-pubsub_{subscription_name}_{topic_name}`.
+The source default topic name is `pubsub_{subscription_name}_{topic_name}`. When passed to `Application.dataframe(source=...)` without a custom topic, the Kafka topic name is prefixed as `source__pubsub_{subscription_name}_{topic_name}`.
 
 
 ## Testing Locally

--- a/docs/connectors/sources/kafka-source.md
+++ b/docs/connectors/sources/kafka-source.md
@@ -2,7 +2,7 @@
 
 A source that reads data from a Kafka topic and produce it to another Kafka topic. The two topics can be located on different Kafka clusters.
 
-This source supports exactly-once guarantees.
+This source supports exactly-once guarantees when the `Application` is configured with `processing_guarantee="exactly-once"`; otherwise it uses the application's default at-least-once guarantee.
 
 ## How To Use
 

--- a/docs/connectors/sources/local-file-source.md
+++ b/docs/connectors/sources/local-file-source.md
@@ -253,5 +253,4 @@ beginning (reproducing all previously processed messages).
 The default topic will have a partition count that reflects the partition count found 
 within the provided topic's folder structure.
 
-The default topic name the Application dumps to is based on the last folder name of 
-the `FileSource` `directory` as: `source__<last folder name>`.
+The default source topic name is based on the last path name as `file_<last path name>`. When passed to `Application.dataframe(source=...)` without a custom topic, the Kafka topic name is prefixed as `source__file_<last path name>`.

--- a/docs/connectors/sources/local-file-source.md
+++ b/docs/connectors/sources/local-file-source.md
@@ -95,7 +95,7 @@ Here are some important configurations to be aware of (see [File Source API](../
 
 ### Optional:
 
-- `format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
+- `file_format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
     **Advanced**: can optionally provide a `Format` instance (`compression` will then be ignored).    
     **Default**: `"json"`
 - `compression`: what compression is used on the given files, if any (ex: `"gzip"`)    
@@ -235,7 +235,7 @@ This will result in the following Kafka message format for `Application`:
 ### Custom Schemas (Advanced)
 
 If the original files are not formatted as expected, custom loaders can be configured 
-on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(format=<Format>)`.
+on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(file_format=<Format>)`.
 
 Formats can be imported from `quixstreams.sources.community.file.formats`.
 

--- a/docs/connectors/sources/microsoft-azure-file-source.md
+++ b/docs/connectors/sources/microsoft-azure-file-source.md
@@ -272,7 +272,7 @@ emulated Azure host via Docker:
     mcr.microsoft.com/azure-storage/azurite:latest
     ```
 
-2. Set `connection_string` for `AzureOrigin` to: 
+2. Set `connection_string` for `AzureFileSource` to: 
 
 ```python
 "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"

--- a/docs/connectors/sources/microsoft-azure-file-source.md
+++ b/docs/connectors/sources/microsoft-azure-file-source.md
@@ -98,7 +98,7 @@ Here are some important configurations to be aware of (see [File Source API](../
 
 ### Optional:
 
-- `format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
+- `file_format`: what format the message files are in (ex: `"json"`, `"parquet"`).    
     **Advanced**: can optionally provide a `Format` instance (`compression` will then be ignored).    
     **Default**: `"json"`
 - `compression`: what compression is used on the given files, if any (ex: `"gzip"`)    
@@ -237,7 +237,7 @@ This will result in the following Kafka message format for `Application`:
 ### Custom Schemas (Advanced)
 
 If the original files are not formatted as expected, custom loaders can be configured 
-on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(format=<Format>)`.
+on some `Format` classes (ex: `JsonFormat`) which can be handed to `FileSource(file_format=<Format>)`.
 
 Formats can be imported from `quixstreams.sources.community.file.formats`.
 

--- a/docs/connectors/sources/mqtt-source.md
+++ b/docs/connectors/sources/mqtt-source.md
@@ -90,7 +90,6 @@ Here are some important configurations to be aware of (see [MQTT Source API](../
     **Default**: Raw message payload
 - `timestamp_setter`: Function to extract timestamp from MQTT message.
     **Default**: Uses "_timestamp" from payload or message timestamp
-- `properties`: MQTT properties (MQTT v5 only).
 - `on_client_connect_success`: Optional callback for successful client authentication.
 - `on_client_connect_failure`: Optional callback for failed client authentication.
 

--- a/docs/connectors/sources/quix-source.md
+++ b/docs/connectors/sources/quix-source.md
@@ -18,7 +18,7 @@ def main():
       topic="source-topic",
       quix_sdk_token="quix-sdk-token",
       quix_workspace_id="quix-workspace-id",
-      quix_portal_api="https://portal-api.platform.quix.io",
+      quix_portal_api="https://portal-api.cloud.quix.io",
     )
     
     sdf = app.dataframe(source=source)

--- a/docs/connectors/sources/quix-source.md
+++ b/docs/connectors/sources/quix-source.md
@@ -18,6 +18,7 @@ def main():
       topic="source-topic",
       quix_sdk_token="quix-sdk-token",
       quix_workspace_id="quix-workspace-id",
+      quix_portal_api="https://portal-api.platform.quix.io",
     )
     
     sdf = app.dataframe(source=source)

--- a/docs/groupby.md
+++ b/docs/groupby.md
@@ -247,14 +247,14 @@ what `store_id` it came from) ***over the past hour***.
 In this case, we need to get a windowed sum based on a single column identifier: `item`.
 
 This can be done by simply passing the `item` column name to `.group_by()`, followed by 
-a [`tumbling_window()`](windowing.md#time-based-tumbling-windows) [`.sum()`](aggregations.md#built-in-aggregators-and-collectors) over the past `3600` seconds:
+a [`tumbling_window()`](windowing.md#time-based-tumbling-windows) [`.sum()`](aggregations.md#built-in-aggregators-and-collectors) over the past hour:
 
 ```python
 from quixstreams.dataframe.windows import Sum
 
 sdf = app.dataframe(input_topic)
 sdf = sdf.group_by("item")
-sdf = sdf.tumbling_window(duration_ms=3600).agg(total_quantity=Sum()).final()
+sdf = sdf.tumbling_window(duration_ms=3_600_000).agg(total_quantity=Sum()).final()
 ```
 which generates data like:
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,6 +1,6 @@
 # Quix Streams client library
 
-Quix Streams v2 is a cloud native library for processing data in Kafka using pure Python. It’s designed to give you the power of a distributed system in a lightweight library by combining the low-level scalability and resiliency features of Kafka with an easy to use Python interface.
+Quix Streams is a cloud native library for processing data in Kafka using pure Python. It’s designed to give you the power of a distributed system in a lightweight library by combining the low-level scalability and resiliency features of Kafka with an easy to use Python interface.
 
 Quix Streams has the following benefits:
 

--- a/docs/producer.md
+++ b/docs/producer.md
@@ -90,7 +90,7 @@ The `Producer` is implemented on top of the [`confluent_kafka`](https://github.c
 
 - `broker_address` - the Kafka broker address.
 - `partitioner` - the partitioner to be used. Default - `murmur2`. Available values: `"random"`, `"consistent_random"`, `"murmur2"`, `"murmur2_random"`, `"fnv1a"`, `"fnv1a_random"`.
-- `producer_poll_timeout` - the timeout to be used when polling Kafka for the producer callbacks. Default - `0.0`. `Producer` polls for callbacks automatically on each `.produce()` call.
+- `producer_poll_timeout` - the timeout used by the `Application` processing loop when polling Kafka for producer callbacks. Default - `0.0`. Low-level `Producer.produce()` calls poll callbacks with `poll(0)` after a successful produce; the method's `poll_timeout` parameter is only used when polling before retrying after a full local producer buffer.
 - `producer_extra_config` - a dictionary with additional configuration parameters for Producer in the format of `librdkafka`.
 
 The full list of configuration parameters can be found in [the librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)  

--- a/docs/producer.md
+++ b/docs/producer.md
@@ -94,4 +94,4 @@ The `Producer` is implemented on top of the [`confluent_kafka`](https://github.c
 - `producer_extra_config` - a dictionary with additional configuration parameters for Producer in the format of `librdkafka`.
 
 The full list of configuration parameters can be found in [the librdkafka documentation](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)  
-Passing `bootstrap.servers` and `partitioner` within `producer_extra_config` will have no effect because they are already supplied to the `Application` object.
+Passing `partitioner` within `producer_extra_config` overrides the default `murmur2` partitioner. Passing `bootstrap.servers` within `producer_extra_config` has no effect because broker configuration is supplied by the `Application` object.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -80,6 +80,9 @@ app = Application(
 # Define a topic with chat messages in JSON format
 messages_topic = app.topic(name="messages", value_deserializer="json")
 
+# Define a topic to write the split words back to Kafka
+words_topic = app.topic(name="words", value_serializer="json")
+
 # Create a StreamingDataFrame - the stream processing pipeline
 # with a Pandas-like interface on streaming data
 sdf = app.dataframe(topic=messages_topic)
@@ -100,6 +103,9 @@ sdf["length"] = sdf["text"].apply(lambda word: len(word))
 
 # Print the output result
 sdf = sdf.update(lambda row: print(f"Output: {row}"))
+
+# Write the results back to Kafka
+sdf = sdf.to_topic(words_topic)
 
 # Run the streaming application
 if __name__ == "__main__":

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -141,7 +141,7 @@ python consumer.py
 [2024-02-21 19:57:38,669] [INFO] : Topics required for this application: "messages", "words"
 [2024-02-21 19:57:38,699] [INFO] : Validating Kafka topics exist and are configured correctly...
 [2024-02-21 19:57:38,718] [INFO] : Kafka topics validation complete
-[2024-02-21 19:57:38,718] [INFO] : Initializing state directory at "/app/state/text-splitter-v1"
+[2024-02-21 19:57:38,718] [INFO] : Initializing state directory at "<current-directory>/state/text-splitter-v1"
 [2024-02-21 19:57:38,718] [INFO] : The application started and is now processing incoming messages
 Input:  {'chat_id': 'id1', 'text': 'Lorem ipsum dolor sit amet'}
 Output: {'text': 'Lorem', 'length': 5}

--- a/docs/tutorials/anomaly-detection/tutorial.md
+++ b/docs/tutorials/anomaly-detection/tutorial.md
@@ -196,7 +196,7 @@ Now we do a (5 second) windowing operation on our temperature value. A few very 
     - Since we care about temperature readings PER MACHINE, our example producer used MACHINE_ID as the Kafka message key. 
     - If we had instead used a static key, say "my_machines", our Anomaly Detector would have evaluated the machines together as one.
 
-- The event's windowing timestamp comes from the "Timestamp" (case-sensitive!!!) field, which SDF looks for in the message value when first receiving it. If it doesn't exist, the kafka message timestamp is used. [A custom function can also be used](../../windowing.md#extracting-timestamps-from-messages).
+- The event's windowing timestamp comes from the Kafka/source message timestamp in this tutorial. To derive event time from a value field such as `"Timestamp"`, configure a [`timestamp_extractor`](../../windowing.md#extracting-timestamps-from-messages) on the topic or source.
 
 
 

--- a/docs/upgrading-legacy.md
+++ b/docs/upgrading-legacy.md
@@ -127,9 +127,9 @@ The Quix Streams <2.0 client supported and actively managed multiple message typ
 on one topic under the hood, which significantly complicates the client messaging model.
 
 As such, `quixstreams>=2.0` intends to _encourage_ producing only one message type
-per topic by enforcing one serializer per-topic, per-application. Additionally, 
-`quixstreams>=2.0` ignores all but `TimeseriesData` and `EventData` message types 
-when using a `QuixDeserializer`. 
+per topic by enforcing one serializer per-topic, per-application. When using a `QuixDeserializer`,
+`quixstreams>=2.0` parses `TimeseriesData`, `ParameterData`, `EventData`, and `EventData[]`
+messages, and ignores metadata/control message types such as stream properties and definitions.
 
 It is still possible to handle multiple types in one application, 
 but it must be done manually with a custom serialization and handling logic.

--- a/docs/upgrading-legacy.md
+++ b/docs/upgrading-legacy.md
@@ -91,21 +91,21 @@ stream.timeseries.buffer.time_span_in_milliseconds = 100
 
 These metadata were passed to Kafka topics as messages.
 
-Quix Streams >=2.0 has deprecated the metadata messages, and they are silently omitted 
+Quix Streams 2.0 and later have deprecated the metadata messages, and they are silently omitted 
 during processing.
 
 
 ### "Split" Messages Unsupported
 
-Quix Streams >= 2.0 has deprecated the "split" messaging format (it will remain 
+Quix Streams 2.0 and later have deprecated the "split" messaging format (it will remain 
 supported in legacy C# library).
 
-***`quixstreams>=2.0` will fail deserialization for split messages unless your application handles or suppresses the resulting serialization error.***
+***Quix Streams 2.0 and later fail deserialization for split messages unless your application handles or suppresses the resulting serialization error.***
 
 
 ### Batched/"Buffered" Message Handling
 
-`quixstreams>=2.0` has deprecated producer-based batching/buffering of messages, 
+Quix Streams 2.0 and later have deprecated producer-based batching/buffering of messages, 
 which essentially consolidates multiple messages into one.
 
 However, it will still be able to consume these messages without issue.
@@ -126,9 +126,9 @@ For example, a message like the one below would equate to three independently pr
 The Quix Streams <2.0 client supported and actively managed multiple message types like `ParameterData` and `EventData`
 on one topic under the hood, which significantly complicates the client messaging model.
 
-As such, `quixstreams>=2.0` intends to _encourage_ producing only one message type
+As such, Quix Streams 2.0 and later _encourage_ producing only one message type
 per topic by enforcing one serializer per-topic, per-application. When using a `QuixDeserializer`,
-`quixstreams>=2.0` parses `TimeseriesData`, `ParameterData`, `EventData`, and `EventData[]`
+Quix Streams 2.0 and later parse `TimeseriesData`, `ParameterData`, `EventData`, and `EventData[]`
 messages, and ignores metadata/control message types such as stream properties and definitions.
 
 It is still possible to handle multiple types in one application, 

--- a/docs/upgrading-legacy.md
+++ b/docs/upgrading-legacy.md
@@ -100,7 +100,7 @@ during processing.
 Quix Streams >= 2.0 has deprecated the "split" messaging format (it will remain 
 supported in legacy C# library).
 
-***`quixstreams>=2.0` will (gracefully) skip any split messages it encounters.***
+***`quixstreams>=2.0` will fail deserialization for split messages unless your application handles or suppresses the resulting serialization error.***
 
 
 ### Batched/"Buffered" Message Handling

--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -723,7 +723,7 @@ sdf = sdf.tumbling_window(timedelta(seconds=10)).agg(value=Sum()).final()
 # -> Timestamp=10001, value=1 -> emit {"start": 0, "end": 10000, "value": 2}, because the time has progressed beyond the window end. 
 ```
 
-`.final()` mode makes the window wait until the maximum observed timestamp for the topic partition passes the window end before emitting.
+By default, `.final()` mode makes the window wait until the maximum observed timestamp for the same message key passes the window end before emitting. Use `final(closing_strategy="partition")` to close windows based on the maximum observed timestamp for the whole topic partition.
 
 Emitting final results provides unique and complete values per window interval, but it adds some latency.
 Also, specifying a grace period using `grace_ms` will increase the latency, because the window now needs to wait for potential out-of-order events.

--- a/docs/windowing.md
+++ b/docs/windowing.md
@@ -850,7 +850,7 @@ described in [the "Updating Kafka Headers" section](./processing.md#updating-kaf
 
 Here are some general concepts about how windowed aggregations are implemented in Quix Streams:
 
-- Only time-based windows are supported. 
+- Quix Streams supports both time-based windows and count-based windows.
 - Every window is grouped by the current Kafka message key.
 - Messages with `None` key will be ignored.
 - The minimal window unit is a **millisecond**. More fine-grained values (e.g. microseconds) will be rounded towards the closest millisecond number.

--- a/quixstreams/sources/community/file/azure.py
+++ b/quixstreams/sources/community/file/azure.py
@@ -18,7 +18,7 @@ try:
 except ImportError as exc:
     raise ImportError(
         f"Package {exc.name} is missing: "
-        'run "pip install quixstreams[azure-file]" to use AzureFileOrigin'
+        'run "pip install quixstreams[azure-file]" to use AzureFileSource'
     ) from exc
 
 __all__ = (


### PR DESCRIPTION
Fixes
- Rename the Azure file source missing-dependency error from the stale AzureFileOrigin name to AzureFileSource

Docs
- Correct core documentation for version branding, offset reset options, state directory defaults, producer polling and partitioner behavior, legacy Quix deserialization, windowing semantics, GroupBy durations, topic creation timing, checkpoint order, state changelog timing, and schema registry serialization caveats

- Update quickstart and tutorial examples so they define the topics they use, show local state paths accurately, describe timestamp sources correctly, and use supported Application and source constructor arguments
- Correct connector source documentation for required CSV and Quix source arguments, MQTT source options, Kafka replicator guarantees, default Kinesis/Pub/Sub/file source topic names, and file source file_format parameters
- Correct connector sink documentation for Azure file sink imports, SinkBackpressureError usage and pause behavior, stream timeout validation/callback lifecycle, MQTT publish failure handling, cloud file sink append support, Elasticsearch metadata key decoding, and the Quix portal API endpoint