### PR TITLE
fix: scope TimestampedStore expiry to the prefix namespace

### DIFF
--- a/quixstreams/state/rocksdb/timestamped.py
+++ b/quixstreams/state/rocksdb/timestamped.py
@@ -203,7 +203,14 @@ class TimestampedPartitionTransaction(RocksDBPartitionTransaction):
                 if cached_key < key:
                     keys_to_delete.append((cached_key, prefix))
 
-            stored = self._partition.iter_items(lower_bound=prefix, upper_bound=key)
+            # Scope the lower bound to this prefix's namespace by appending the
+            # SEPARATOR. Without it, the bare prefix lets the range spill into
+            # other prefixes that share these bytes (e.g. b"key" vs b"key2"),
+            # deleting entries that belong to unrelated keys.
+            lower_bound = self._serialize_key(b"", prefix)
+            stored = self._partition.iter_items(
+                lower_bound=lower_bound, upper_bound=key
+            )
             for stored_key, _ in stored:
                 keys_to_delete.append((stored_key, prefix))
 

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_timestamped.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_timestamped.py
@@ -175,6 +175,24 @@ class TestTimestampedPartitionTransaction:
             assert tx.get_latest(timestamp=30, prefix=b"key1") == "112"
             assert tx.get_latest(timestamp=30, prefix=b"key2") == "212"
 
+    def test_expire_does_not_affect_keys_sharing_byte_prefix(
+        self, transaction: TimestampedPartitionTransaction
+    ):
+        # `b"key2"` shares its leading bytes with `b"key"`. Since the SEPARATOR
+        # (b"|", 0x7c) sorts after digits/letters, `b"key2|..."` orders before
+        # `b"key|..."`, so expiring `b"key"` must not reach into `b"key2"`.
+        with transaction(grace_ms=5) as tx:
+            tx.set_for_timestamp(timestamp=3, value="key2val", prefix=b"key2")
+
+        # Writing `b"key"` at a high timestamp advances its expiration watermark
+        # and triggers a sweep. `b"key2"` was never eligible under its own grace.
+        with transaction(grace_ms=5) as tx:
+            tx.set_for_timestamp(timestamp=100, value="keyval", prefix=b"key")
+
+        with transaction(grace_ms=5) as tx:
+            assert tx.get_latest(timestamp=3, prefix=b"key2") == "key2val"
+            assert tx.get_latest(timestamp=100, prefix=b"key") == "keyval"
+
     def test_set_for_timestamp_overwrites_value_with_same_timestamp(
         self,
         transaction: TimestampedPartitionTransaction,


### PR DESCRIPTION
## What

`TimestampedPartitionTransaction._expire()` built its RocksDB deletion range with the **bare prefix** as the lower bound:

```python
stored = self._partition.iter_items(lower_bound=prefix, upper_bound=key)
```

State keys are stored as `<prefix> + SEPARATOR + <timestamp>` (`SEPARATOR = b"|"`, `0x7c`). Because the lower bound omits the separator, the range `[b"key", b"key|<ts>")` spills into **other prefixes** whose bytes start with this prefix and whose next byte is `< 0x7c` (digits, letters, `-`, `.`, `_`). For example `b"key2|<ts>"` sorts before `b"key|<ts>"`, so expiring `key` silently deletes `key2`'s data.

This hits common key shapes (`key`/`key2`, `user_1`/`user_12`, numeric IDs) and the interval-join path, which uses message keys as state prefixes.

## Fix

Scope the lower bound to the prefix's namespace, matching every other range query in the file:

```python
lower_bound = self._serialize_key(b"", prefix)   # prefix + SEPARATOR
stored = self._partition.iter_items(lower_bound=lower_bound, upper_bound=key)
```

Sibling prefixes now sort outside the range while all genuine `<prefix>|<ts>` rows remain covered. The in-memory-cache half of `_expire` was already correctly prefix-scoped; only the `iter_items` range needed fixing.

## Tests

Added `test_expire_does_not_affect_keys_sharing_byte_prefix` (byte-prefixed `key`/`key2` pair — the case the existing `test_expire_multiple_keys` misses since it uses equal-length, non-nested prefixes). It fails without this change and passes with it. The full `tests/test_quixstreams/test_state/` suite passes (323), ruff clean.

Fixes #1122
