### PR TITLE
fix: resume recovery-paused partitions on reassignment

### DIFF
--- a/quixstreams/state/recovery.py
+++ b/quixstreams/state/recovery.py
@@ -364,6 +364,7 @@ class RecoveryManager:
         self._last_progress_logged_time = time.monotonic()
         # Cache position results to avoid double calls in same iteration
         self._position_cache: Dict[str, Tuple[float, ConfluentPartition]] = {}
+        self._recovery_paused_data_tps: set[tuple[str, int]] = set()
 
     @property
     def partitions(self) -> Dict[int, Dict[str, RecoveryPartition]]:
@@ -446,8 +447,48 @@ class RecoveryManager:
                 if tp.topic in self._topic_manager.non_changelog_topics
             ]
             self._consumer.resume(non_changelog_tps)
+            self._forget_recovery_paused_data_partitions(non_changelog_tps)
         else:
             logger.debug("Recovery process interrupted; stopping.")
+
+    def _pause_for_recovery(self, partitions: List[ConfluentPartition]) -> None:
+        self._track_recovery_paused_data_partitions(partitions)
+        self._consumer.pause(partitions)
+
+    def _track_recovery_paused_data_partitions(
+        self, partitions: List[ConfluentPartition]
+    ) -> None:
+        non_changelog_topics = self._topic_manager.non_changelog_topics
+        self._recovery_paused_data_tps.update(
+            (tp.topic, tp.partition)
+            for tp in partitions
+            if tp.topic in non_changelog_topics
+        )
+
+    def _forget_recovery_paused_data_partitions(
+        self, partitions: List[ConfluentPartition]
+    ) -> None:
+        for tp in partitions:
+            self._recovery_paused_data_tps.discard((tp.topic, tp.partition))
+
+    def _resume_recovery_paused_data_partitions(
+        self, partitions: List[ConfluentPartition]
+    ) -> None:
+        if not self._recovery_paused_data_tps:
+            return
+
+        non_changelog_topics = self._topic_manager.non_changelog_topics
+        to_resume = [
+            tp
+            for tp in partitions
+            if tp.topic in non_changelog_topics
+            and (tp.topic, tp.partition) in self._recovery_paused_data_tps
+        ]
+        if not to_resume:
+            return
+
+        self._consumer.resume(to_resume)
+        self._forget_recovery_paused_data_partitions(to_resume)
 
     def _generate_recovery_partitions(
         self,
@@ -501,9 +542,8 @@ class RecoveryManager:
             committed_offsets=committed_offsets,
         )
 
-        assigned_tps = set(
-            (tp.topic, tp.partition) for tp in self._consumer.assignment()
-        )
+        current_assignment = self._consumer.assignment()
+        assigned_tps = set((tp.topic, tp.partition) for tp in current_assignment)
 
         for rp in recovery_partitions:
             changelog_name, partition = rp.changelog_name, rp.partition_num
@@ -532,13 +572,15 @@ class RecoveryManager:
             if self._running:
                 # Some partitions are already recovering,
                 # pausing only the source topic partition
-                self._consumer.pause(
+                self._pause_for_recovery(
                     [ConfluentPartition(topic=topic, partition=partition)]
                 )
             else:
                 # Recovery hasn't started yet, so pause ALL partitions
                 # and wait for Application to start recovery
-                self._consumer.pause(self._consumer.assignment())
+                self._pause_for_recovery(self._consumer.assignment())
+        else:
+            self._resume_recovery_paused_data_partitions(current_assignment)
 
     def _revoke_recovery_partitions(self, recovery_partitions: List[RecoveryPartition]):
         """

--- a/tests/test_quixstreams/test_state/test_recovery/test_recovery_manager.py
+++ b/tests/test_quixstreams/test_state/test_recovery/test_recovery_manager.py
@@ -14,6 +14,7 @@ from quixstreams.state.exceptions import (
 )
 from quixstreams.state.manager import SUPPORTED_STORES
 from quixstreams.state.metadata import CHANGELOG_CF_MESSAGE_HEADER
+from quixstreams.state.recovery import RecoveryManager
 from tests.utils import ConfluentKafkaMessageStub
 
 
@@ -471,6 +472,126 @@ class TestRecoveryManager:
 
         # Verify the changelog message was processed
         store_partition.recover_from_changelog_message.assert_called_once()
+
+    def test_recovery_paused_partition_is_resumed_when_reassigned(
+        self,
+    ):
+        """
+        Regression test for a data partition staying paused after recovery.
+
+        Recovery pauses the whole assignment before consuming changelogs. If a
+        paused data partition is temporarily missing from the assignment when
+        recovery completes, it must still be resumed when it is assigned again.
+        """
+
+        class TrackingConsumer:
+            def __init__(self, assignments):
+                self._assignments = assignments
+                self._assignment_call_count = 0
+                self.paused = set()
+                self.pause_calls = []
+                self.resume_calls = []
+
+            def assignment(self):
+                index = min(self._assignment_call_count, len(self._assignments) - 1)
+                self._assignment_call_count += 1
+                return self._assignments[index]
+
+            def pause(self, partitions):
+                self.pause_calls.append(partitions)
+                for tp in partitions:
+                    self.paused.add((tp.topic, tp.partition))
+
+            def resume(self, partitions):
+                self.resume_calls.append(partitions)
+                for tp in partitions:
+                    self.paused.discard((tp.topic, tp.partition))
+
+            def get_watermark_offsets(self, *_args, **_kwargs):
+                return 0, 10
+
+            def seek(self, *_args, **_kwargs):
+                return None
+
+            def poll(self, *_args, **_kwargs):
+                return None
+
+            def position(self, partitions):
+                return [
+                    ConfluentPartition(
+                        topic=tp.topic,
+                        partition=tp.partition,
+                        offset=10,
+                    )
+                    for tp in partitions
+                ]
+
+            def _broker_available(self):
+                return None
+
+        topic_name = str(uuid.uuid4())
+        store_name = "default"
+
+        def broker_topic(topic):
+            topic.broker_config = topic.create_config
+            return topic
+
+        topic_manager = TopicManager(
+            topic_admin=MagicMock(),
+            consumer_group=str(uuid.uuid4()),
+        )
+        with patch.object(
+            topic_manager, "_get_or_create_broker_topic", side_effect=broker_topic
+        ):
+            data_topic = topic_manager.topic(topic_name)
+            changelog_topic = topic_manager.changelog_topic(
+                stream_id=topic_name,
+                store_name=store_name,
+                config=TopicConfig(num_partitions=2, replication_factor=1),
+            )
+
+        data_tp_0 = TopicPartition(data_topic.name, 0)
+        data_tp_1 = TopicPartition(data_topic.name, 1)
+        changelog_tp_0 = TopicPartition(changelog_topic.name, 0)
+        changelog_tp_1 = TopicPartition(changelog_topic.name, 1)
+
+        consumer = TrackingConsumer(
+            assignments=[
+                [data_tp_0, data_tp_1, changelog_tp_0, changelog_tp_1],
+                [data_tp_0, data_tp_1, changelog_tp_0, changelog_tp_1],
+                [data_tp_0, changelog_tp_0],
+                [data_tp_1, changelog_tp_1],
+            ]
+        )
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+
+        recovering_store_partition = MagicMock(spec_set=StorePartition)
+        recovering_store_partition.get_changelog_offset.return_value = 5
+        caught_up_store_partition = MagicMock(spec_set=StorePartition)
+        caught_up_store_partition.get_changelog_offset.return_value = 9
+
+        recovery_manager.assign_partition(
+            topic=topic_name,
+            partition=0,
+            committed_offsets={topic_name: -1001},
+            store_partitions={store_name: recovering_store_partition},
+        )
+        assert (data_topic.name, 1) in consumer.paused
+
+        recovery_manager.do_recovery()
+
+        # Simulate the data partition being assigned again after recovery
+        # completed while it was missing from the assignment snapshot.
+        recovery_manager.assign_partition(
+            topic=topic_name,
+            partition=1,
+            committed_offsets={topic_name: -1001},
+            store_partitions={store_name: caught_up_store_partition},
+        )
+
+        assert (data_topic.name, 1) not in consumer.paused
 
 
 @pytest.mark.parametrize("store_type", SUPPORTED_STORES, indirect=True)


### PR DESCRIPTION
Fixes:
- Track data partitions paused by state recovery and resume them when they are assigned after recovery completes

Tests:
- Cover recovery completion where a paused data partition is absent from the assignment snapshot