### PR TITLE
fix: TTL sweep no longer deletes a key refreshed in the same flush

### DIFF
--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -270,6 +270,11 @@ class RocksDBStorePartition(StorePartition):
         # For unflipped partitions this commits the cache as-is — exactly the
         # v3.23.6 behavior. For flipped partitions the transaction layer has
         # already stamped values and emitted index-CF writes into the cache.
+        # Keys re-written into the default CF in this same flush. The TTL sweep
+        # reads committed disk state (not this uncommitted batch), so it must not
+        # delete a key the batch just refreshed — otherwise the stale-read delete
+        # clobbers the fresh write.
+        staged_default_keys: set[bytes] = set()
         for cf_name in column_families:
             cf_handle = self.get_column_family_handle(cf_name)
 
@@ -277,6 +282,8 @@ class RocksDBStorePartition(StorePartition):
             for prefix_update_cache in updates.values():
                 for key, value in prefix_update_cache.items():
                     batch.put(key, value, cf_handle)
+                    if cf_name == "default":
+                        staged_default_keys.add(key)
 
             deletes = cache.get_deletes(cf_name=cf_name)
             for key in deletes:
@@ -290,7 +297,7 @@ class RocksDBStorePartition(StorePartition):
             )
 
         if self.uses_ttl_stamps:
-            self._run_sweep(batch=batch)
+            self._run_sweep(batch=batch, staged_default_keys=staged_default_keys)
 
         # Save the latest changelog topic offset to know where to recover from
         # It may be None if changelog topics are disabled
@@ -593,13 +600,20 @@ class RocksDBStorePartition(StorePartition):
     # TTL machinery (only used when ``uses_ttl_stamps`` is True).
     # ------------------------------------------------------------------
 
-    def _run_sweep(self, batch: WriteBatch) -> None:
+    def _run_sweep(
+        self, batch: WriteBatch, staged_default_keys: "set[bytes] | None" = None
+    ) -> None:
         """
         Bounded-budget sweep over the secondary expiry index.
 
         Called from :meth:`write` so any deletes go into the same batch as
         the user-driven writes for atomicity.
+
+        ``staged_default_keys`` are the default-CF keys re-written in this same
+        flush. The sweep reads committed disk state, which is stale for those
+        keys, so it must never delete them here.
         """
+        staged_default_keys = staged_default_keys or frozenset()
         if self._high_water_ms is None:
             # Cold start: no event-time established yet — skip the sweep.
             return
@@ -667,12 +681,15 @@ class RocksDBStorePartition(StorePartition):
                 batch.delete(index_key, index_handle)
                 continue
 
-            if main_expires_at == idx_expires_at:
+            if main_expires_at == idx_expires_at and user_key not in staged_default_keys:
                 batch.delete(user_key, main_handle)
                 batch.delete(index_key, index_handle)
                 evicted += 1
             else:
-                # Ghost: key was overwritten with a fresh expiry stamp.
+                # Ghost: key was overwritten with a fresh expiry stamp — either
+                # already committed, or re-written in this same batch (in which
+                # case the committed read above is stale). Drop only the stale
+                # index pointer; deleting the key would clobber the fresh write.
                 batch.delete(index_key, index_handle)
 
         if evicted:

--- a/tests/test_quixstreams/test_state/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_transaction.py
@@ -543,6 +543,31 @@ class TestPartitionTransaction:
                 CHANGELOG_PROCESSED_OFFSETS_MESSAGE_HEADER: dumps(processed_offsets),
             }
 
+    def test_ttl_refresh_after_expiry_survives_sweep(self, store_partition_factory):
+        """A key refreshed with a fresh TTL after its previous stamp expired must
+        survive the same-flush sweep. The sweep reads committed disk state, so it
+        must not delete a key the batch just re-wrote (regression: data loss).
+        """
+        from datetime import timedelta
+
+        prefix = b"__key__"
+        ttl = timedelta(milliseconds=100)
+        with store_partition_factory() as partition:
+            # t=1000: write k -> expires 1100
+            tx1 = partition.begin()
+            tx1.set(key="k", value="v1", prefix=prefix, timestamp=1000, ttl=ttl)
+            tx1.prepare(processed_offsets={"topic": 1})
+            tx1.flush(changelog_offset=1)
+
+            # t=2000: refresh k with a fresh ttl -> expires 2100 (still alive)
+            tx2 = partition.begin()
+            tx2.set(key="k", value="v2", prefix=prefix, timestamp=2000, ttl=ttl)
+            tx2.prepare(processed_offsets={"topic": 2})
+            tx2.flush(changelog_offset=2)
+
+            tx3 = partition.begin()
+            assert tx3.get(key="k", prefix=prefix) == "v2"
+
 
 class TestPartitionTransactionCache:
     def test_set_get_key_present(self, cache: PartitionTransactionCache):


### PR DESCRIPTION
## What

The TTL sweep (`_run_sweep`, called from `RocksDBStorePartition.write()`) can **silently delete a key that was just refreshed with a fresh TTL in the same flush** — data loss.

## Why

`write()` stages the transaction's writes into the `WriteBatch` first, then runs `_run_sweep`. The sweep reads the main value via `main_cf.get(user_key)`, which sees **committed disk state, not the uncommitted batch**. So when a key with an expired stamp is refreshed (re-`set` with a new TTL) in the same flush:

1. the batch stages `put(user_key, fresh_value)`;
2. the sweep reads the **stale** committed value, finds its old stamp still matches the old index entry (`main_expires_at == idx_expires_at`), and stages `batch.delete(user_key)`;
3. RocksDB applies batch ops in insertion order → the delete lands **after** the put and wins → the fresh value is removed from disk.

This hits the most natural TTL pattern: `state.set(k, v, ttl=...)` to keep a key alive.

### Reproduction
t=1000 `set(k, v1, ttl=100ms)` (expires 1100); t=2000 `set(k, v2, ttl=100ms)` (expires 2100, still alive since high-water=2000). After the second flush, `get(k)` returns `None` — the freshly-written `v2` was swept. (Added as a regression test; it fails on `main`, passes with this fix.)

## Fix

Pass the set of default-CF keys re-written in this flush into `_run_sweep` and **skip deleting any of them** — drop only the stale index pointer (the fresh stamp's own index entry governs its future expiry). Default behaviour for non-refreshed keys is unchanged.

Related to the TTL feature added in #1107.