### PR TITLE
fix: Fix two TTL-sweep data-loss bugs on same-flush refreshed keys

### DIFF
--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -273,8 +273,14 @@ class RocksDBStorePartition(StorePartition):
         # Keys re-written into the default CF in this same flush. The TTL sweep
         # reads committed disk state (not this uncommitted batch), so it must not
         # delete a key the batch just refreshed — otherwise the stale-read delete
-        # clobbers the fresh write.
+        # clobbers the fresh write. Track TTL-index keys too: a refreshed value
+        # can legitimately stage the same expiry index key the sweep is visiting.
         staged_default_keys: set[bytes] = set()
+        staged_ttl_index_keys: set[bytes] = set()
+        # Only track staged keys when a sweep will actually consume them. For
+        # legacy / unflipped partitions (the 99% no-TTL workload) the sweep never
+        # runs, so this keeps the inner write loop byte-identical to v3.23.6.
+        track_staged = self.uses_ttl_stamps
         for cf_name in column_families:
             cf_handle = self.get_column_family_handle(cf_name)
 
@@ -282,8 +288,11 @@ class RocksDBStorePartition(StorePartition):
             for prefix_update_cache in updates.values():
                 for key, value in prefix_update_cache.items():
                     batch.put(key, value, cf_handle)
-                    if cf_name == "default":
-                        staged_default_keys.add(key)
+                    if track_staged:
+                        if cf_name == "default":
+                            staged_default_keys.add(key)
+                        elif cf_name == TTL_INDEX_CF_NAME:
+                            staged_ttl_index_keys.add(key)
 
             deletes = cache.get_deletes(cf_name=cf_name)
             for key in deletes:
@@ -297,7 +306,11 @@ class RocksDBStorePartition(StorePartition):
             )
 
         if self.uses_ttl_stamps:
-            self._run_sweep(batch=batch, staged_default_keys=staged_default_keys)
+            self._run_sweep(
+                batch=batch,
+                staged_default_keys=staged_default_keys,
+                staged_ttl_index_keys=staged_ttl_index_keys,
+            )
 
         # Save the latest changelog topic offset to know where to recover from
         # It may be None if changelog topics are disabled
@@ -601,7 +614,10 @@ class RocksDBStorePartition(StorePartition):
     # ------------------------------------------------------------------
 
     def _run_sweep(
-        self, batch: WriteBatch, staged_default_keys: "set[bytes] | None" = None
+        self,
+        batch: WriteBatch,
+        staged_default_keys: "set[bytes] | None" = None,
+        staged_ttl_index_keys: "set[bytes] | None" = None,
     ) -> None:
         """
         Bounded-budget sweep over the secondary expiry index.
@@ -612,8 +628,13 @@ class RocksDBStorePartition(StorePartition):
         ``staged_default_keys`` are the default-CF keys re-written in this same
         flush. The sweep reads committed disk state, which is stale for those
         keys, so it must never delete them here.
+
+        ``staged_ttl_index_keys`` are the TTL-index entries written in this
+        batch. If a fresh write reuses the same expiry stamp as the stale index
+        entry being swept, deleting that index key would orphan the fresh value.
         """
         staged_default_keys = staged_default_keys or frozenset()
+        staged_ttl_index_keys = staged_ttl_index_keys or frozenset()
         if self._high_water_ms is None:
             # Cold start: no event-time established yet — skip the sweep.
             return
@@ -627,6 +648,10 @@ class RocksDBStorePartition(StorePartition):
         main_cf = self.get_or_create_column_family("default")
         index_handle = self.get_column_family_handle(TTL_INDEX_CF_NAME)
         main_handle = self.get_column_family_handle("default")
+
+        def delete_index_if_not_staged(index_key: bytes) -> None:
+            if index_key not in staged_ttl_index_keys:
+                batch.delete(index_key, index_handle)
 
         # Bound the iterator at the cutoff stamp to skip future expiries
         # without paying for the iterator step. Build the cutoff prefix as
@@ -649,7 +674,7 @@ class RocksDBStorePartition(StorePartition):
             try:
                 idx_expires_at, user_key = decode_index_key(index_key)
             except ValueError:
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
                 continue
 
             if idx_expires_at > now_ms:
@@ -660,7 +685,7 @@ class RocksDBStorePartition(StorePartition):
             if main_value is None:
                 # Ghost: user deleted the main entry but the index still
                 # points at it. GC the orphaned index entry.
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
                 continue
 
             try:
@@ -672,25 +697,28 @@ class RocksDBStorePartition(StorePartition):
                     self._path,
                     user_key,
                 )
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
                 continue
 
             if main_expires_at == SENTINEL_NEVER:
                 # Ghost: key was overwritten by a plain ``state.set`` and
                 # is now permanent. Drop the stale index pointer only.
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
                 continue
 
-            if main_expires_at == idx_expires_at and user_key not in staged_default_keys:
+            if (
+                main_expires_at == idx_expires_at
+                and user_key not in staged_default_keys
+            ):
                 batch.delete(user_key, main_handle)
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
                 evicted += 1
             else:
                 # Ghost: key was overwritten with a fresh expiry stamp — either
                 # already committed, or re-written in this same batch (in which
                 # case the committed read above is stale). Drop only the stale
                 # index pointer; deleting the key would clobber the fresh write.
-                batch.delete(index_key, index_handle)
+                delete_index_if_not_staged(index_key)
 
         if evicted:
             logger.debug(

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -633,8 +633,10 @@ class RocksDBStorePartition(StorePartition):
         batch. If a fresh write reuses the same expiry stamp as the stale index
         entry being swept, deleting that index key would orphan the fresh value.
         """
-        staged_default_keys = staged_default_keys or frozenset()
-        staged_ttl_index_keys = staged_ttl_index_keys or frozenset()
+        staged_default: "set[bytes] | frozenset[bytes]" = staged_default_keys or frozenset()
+        staged_ttl_index: "set[bytes] | frozenset[bytes]" = (
+            staged_ttl_index_keys or frozenset()
+        )
         if self._high_water_ms is None:
             # Cold start: no event-time established yet — skip the sweep.
             return
@@ -650,7 +652,7 @@ class RocksDBStorePartition(StorePartition):
         main_handle = self.get_column_family_handle("default")
 
         def delete_index_if_not_staged(index_key: bytes) -> None:
-            if index_key not in staged_ttl_index_keys:
+            if index_key not in staged_ttl_index:
                 batch.delete(index_key, index_handle)
 
         # Bound the iterator at the cutoff stamp to skip future expiries
@@ -708,7 +710,7 @@ class RocksDBStorePartition(StorePartition):
 
             if (
                 main_expires_at == idx_expires_at
-                and user_key not in staged_default_keys
+                and user_key not in staged_default
             ):
                 batch.delete(user_key, main_handle)
                 delete_index_if_not_staged(index_key)

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -270,6 +270,11 @@ class RocksDBStorePartition(StorePartition):
         # For unflipped partitions this commits the cache as-is — exactly the
         # v3.23.6 behavior. For flipped partitions the transaction layer has
         # already stamped values and emitted index-CF writes into the cache.
+        # Keys re-written into the default CF in this same flush. The TTL sweep
+        # reads committed disk state (not this uncommitted batch), so it must not
+        # delete a key the batch just refreshed — otherwise the stale-read delete
+        # clobbers the fresh write.
+        staged_default_keys: set[bytes] = set()
         for cf_name in column_families:
             cf_handle = self.get_column_family_handle(cf_name)
 
@@ -277,6 +282,8 @@ class RocksDBStorePartition(StorePartition):
             for prefix_update_cache in updates.values():
                 for key, value in prefix_update_cache.items():
                     batch.put(key, value, cf_handle)
+                    if cf_name == "default":
+                        staged_default_keys.add(key)
 
             deletes = cache.get_deletes(cf_name=cf_name)
             for key in deletes:
@@ -290,7 +297,7 @@ class RocksDBStorePartition(StorePartition):
             )
 
         if self.uses_ttl_stamps:
-            self._run_sweep(batch=batch)
+            self._run_sweep(batch=batch, staged_default_keys=staged_default_keys)
 
         # Save the latest changelog topic offset to know where to recover from
         # It may be None if changelog topics are disabled
@@ -593,13 +600,20 @@ class RocksDBStorePartition(StorePartition):
     # TTL machinery (only used when ``uses_ttl_stamps`` is True).
     # ------------------------------------------------------------------
 
-    def _run_sweep(self, batch: WriteBatch) -> None:
+    def _run_sweep(
+        self, batch: WriteBatch, staged_default_keys: "set[bytes] | None" = None
+    ) -> None:
         """
         Bounded-budget sweep over the secondary expiry index.
 
         Called from :meth:`write` so any deletes go into the same batch as
         the user-driven writes for atomicity.
+
+        ``staged_default_keys`` are the default-CF keys re-written in this same
+        flush. The sweep reads committed disk state, which is stale for those
+        keys, so it must never delete them here.
         """
+        staged_default_keys = staged_default_keys or frozenset()
         if self._high_water_ms is None:
             # Cold start: no event-time established yet — skip the sweep.
             return
@@ -667,12 +681,15 @@ class RocksDBStorePartition(StorePartition):
                 batch.delete(index_key, index_handle)
                 continue
 
-            if main_expires_at == idx_expires_at:
+            if main_expires_at == idx_expires_at and user_key not in staged_default_keys:
                 batch.delete(user_key, main_handle)
                 batch.delete(index_key, index_handle)
                 evicted += 1
             else:
-                # Ghost: key was overwritten with a fresh expiry stamp.
+                # Ghost: key was overwritten with a fresh expiry stamp — either
+                # already committed, or re-written in this same batch (in which
+                # case the committed read above is stale). Drop only the stale
+                # index pointer; deleting the key would clobber the fresh write.
                 batch.delete(index_key, index_handle)
 
         if evicted:

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -633,7 +633,9 @@ class RocksDBStorePartition(StorePartition):
         batch. If a fresh write reuses the same expiry stamp as the stale index
         entry being swept, deleting that index key would orphan the fresh value.
         """
-        staged_default: "set[bytes] | frozenset[bytes]" = staged_default_keys or frozenset()
+        staged_default: "set[bytes] | frozenset[bytes]" = (
+            staged_default_keys or frozenset()
+        )
         staged_ttl_index: "set[bytes] | frozenset[bytes]" = (
             staged_ttl_index_keys or frozenset()
         )
@@ -708,10 +710,7 @@ class RocksDBStorePartition(StorePartition):
                 delete_index_if_not_staged(index_key)
                 continue
 
-            if (
-                main_expires_at == idx_expires_at
-                and user_key not in staged_default
-            ):
+            if main_expires_at == idx_expires_at and user_key not in staged_default:
                 batch.delete(user_key, main_handle)
                 delete_index_if_not_staged(index_key)
                 evicted += 1

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -1,4 +1,5 @@
 import time
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +11,8 @@ from quixstreams.state.rocksdb import (
     RocksDBStorePartition,
 )
 from quixstreams.state.rocksdb.exceptions import RocksDBCorruptedError
+from quixstreams.state.rocksdb.metadata import TTL_INDEX_CF_NAME
+from quixstreams.state.rocksdb.ttl_codec import encode_index_key
 from quixstreams.state.serialization import append_integer
 
 
@@ -167,6 +170,54 @@ class TestRocksDBStorePartition:
 
     def test_ensure_metadata_cf(self, store_partition: RocksDBStorePartition):
         assert store_partition.get_or_create_column_family("__metadata__")
+
+    def test_ttl_sweep_preserves_rewritten_same_stamp_index(
+        self, store_partition_factory
+    ):
+        prefix = b"__key__"
+        ttl = timedelta(milliseconds=100)
+
+        with store_partition_factory() as partition:
+            tx1 = partition.begin()
+            tx1.set(key="k", value="v1", prefix=prefix, timestamp=1000, ttl=ttl)
+            user_key = tx1._serialize_key(key="k", prefix=prefix)
+            index_key = encode_index_key(1100, user_key)
+            tx1.prepare(processed_offsets={"topic": 1})
+            tx1.flush(changelog_offset=1)
+
+            tx2 = partition.begin()
+            # Advance high-water while re-writing k with the same expired stamp.
+            # The sweep reads the old committed index key while the fresh index
+            # key is staged in the same WriteBatch.
+            tx2.set(
+                key="advance",
+                value="tick",
+                prefix=prefix,
+                timestamp=2000,
+                ttl=ttl,
+            )
+            tx2.set(key="k", value="v2", prefix=prefix, timestamp=1000, ttl=ttl)
+            tx2.prepare(processed_offsets={"topic": 2})
+            tx2.flush(changelog_offset=2)
+
+            index_cf = partition.get_or_create_column_family(TTL_INDEX_CF_NAME)
+            main_cf = partition.get_or_create_column_family("default")
+            assert index_cf.get(index_key, default=None) == b""
+            assert main_cf.get(user_key, default=None) is not None
+
+            tx3 = partition.begin()
+            tx3.set(
+                key="advance2",
+                value="tick",
+                prefix=prefix,
+                timestamp=2001,
+                ttl=ttl,
+            )
+            tx3.prepare(processed_offsets={"topic": 3})
+            tx3.flush(changelog_offset=3)
+
+            assert index_cf.get(index_key, default=None) is None
+            assert main_cf.get(user_key, default=None) is None
 
     @pytest.mark.parametrize(
         ["backwards", "expected"],

--- a/tests/test_quixstreams/test_state/test_transaction.py
+++ b/tests/test_quixstreams/test_state/test_transaction.py
@@ -543,6 +543,31 @@ class TestPartitionTransaction:
                 CHANGELOG_PROCESSED_OFFSETS_MESSAGE_HEADER: dumps(processed_offsets),
             }
 
+    def test_ttl_refresh_after_expiry_survives_sweep(self, store_partition_factory):
+        """A key refreshed with a fresh TTL after its previous stamp expired must
+        survive the same-flush sweep. The sweep reads committed disk state, so it
+        must not delete a key the batch just re-wrote (regression: data loss).
+        """
+        from datetime import timedelta
+
+        prefix = b"__key__"
+        ttl = timedelta(milliseconds=100)
+        with store_partition_factory() as partition:
+            # t=1000: write k -> expires 1100
+            tx1 = partition.begin()
+            tx1.set(key="k", value="v1", prefix=prefix, timestamp=1000, ttl=ttl)
+            tx1.prepare(processed_offsets={"topic": 1})
+            tx1.flush(changelog_offset=1)
+
+            # t=2000: refresh k with a fresh ttl -> expires 2100 (still alive)
+            tx2 = partition.begin()
+            tx2.set(key="k", value="v2", prefix=prefix, timestamp=2000, ttl=ttl)
+            tx2.prepare(processed_offsets={"topic": 2})
+            tx2.flush(changelog_offset=2)
+
+            tx3 = partition.begin()
+            assert tx3.get(key="k", prefix=prefix) == "v2"
+
 
 class TestPartitionTransactionCache:
     def test_set_get_key_present(self, cache: PartitionTransactionCache):


### PR DESCRIPTION
The RocksDB TTL sweep runs inside `write()` after the transaction's writes are already staged into the `WriteBatch`, but it reads the main value via `main_cf.get()`, which sees committed disk state — not the uncommitted batch. This stale read causes two distinct data-loss bugs when a key is refreshed (re-`set` with a fresh TTL) in the same flush that the sweep runs, i.e. the most natural TTL usage: `state.set(k, v, ttl=...)` to keep a key alive.

1. Silent value deletion: when a key with an expired stamp is refreshed in the same flush, the sweep reads the stale committed value, sees its old stamp still matching the old index entry, and stages `batch.delete(user_key)` after the batch's fresh `put`. RocksDB applies batch ops in order, so the delete wins and the just-written value is silently removed from disk.

2. Orphaned index entry: when the refresh reuses an expiry stamp byte-identical to the prior (now-expired) committed stamp, it stages an index key identical to the stale one the sweep is visiting. The sweep's index-delete lands after the fresh index put, so the delete wins and leaves the value with no index entry — an orphan that can never be swept later (a permanent leak of dead data).

Fixes
- TTL sweep no longer deletes a key that was refreshed in the same flush: default-CF keys re-written in the flush are passed into the sweep, which skips deleting any of them and drops only the stale index pointer, preventing silent loss of values kept alive via `state.set(k, v, ttl=...)`.
- TTL sweep no longer orphans a same-stamp refreshed key: every sweep index-delete is routed through a helper that skips index keys staged in the same batch, so a refresh reusing the prior expiry stamp keeps its fresh index entry instead of being left unsweepable.

Both fixes gate the extra staged-key tracking on `uses_ttl_stamps`, so the legacy no-TTL write loop (the 99% workload) stays byte-identical to v3.23.6. Each fix ships with a red/green regression test.

Co-authored-by: Vedant Agarwal <vedantagwl10@gmail.com>
