### PR TITLE
feat: opt-in time-based closing for tumbling windows on idle streams (#790)

### DIFF
--- a/quixstreams/dataframe/dataframe.py
+++ b/quixstreams/dataframe/dataframe.py
@@ -1091,6 +1091,7 @@ class StreamingDataFrame:
         on_late: Optional[WindowOnLateCallback] = None,
         before_update: Optional[WindowBeforeUpdateCallback] = None,
         after_update: Optional[WindowAfterUpdateCallback] = None,
+        close_on_idle: bool = False,
     ) -> TumblingTimeWindowDefinition:
         """
         Create a time-based tumbling window transformation on this StreamingDataFrame.
@@ -1171,6 +1172,13 @@ class StreamingDataFrame:
             If it returns `True`, the window will be expired immediately.
             Default - `None`.
 
+        :param close_on_idle: if `True`, close windows based on wall-clock time so
+            that windows on an idle stream (no new messages) still emit their
+            results once `window_end + grace_ms` passes in real time, instead of
+            waiting for the next message to advance event time.
+            Only supported with `final(closing_strategy="partition")`.
+            Default - `False` (event-time only, unchanged behavior).
+
         :return: `TumblingTimeWindowDefinition` instance representing the tumbling window
             configuration.
             This object can be further configured with aggregation functions
@@ -1188,6 +1196,7 @@ class StreamingDataFrame:
             on_late=on_late,
             before_update=before_update,
             after_update=after_update,
+            close_on_idle=close_on_idle,
         )
 
     def tumbling_count_window(

--- a/quixstreams/dataframe/windows/definitions.py
+++ b/quixstreams/dataframe/windows/definitions.py
@@ -347,6 +347,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition[TimeWindow]):
         on_late: Optional[WindowOnLateCallback] = None,
         before_update: Optional[WindowBeforeUpdateCallback] = None,
         after_update: Optional[WindowAfterUpdateCallback] = None,
+        close_on_idle: bool = False,
     ):
         super().__init__(
             duration_ms=duration_ms,
@@ -357,6 +358,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition[TimeWindow]):
             before_update=before_update,
             after_update=after_update,
         )
+        self._close_on_idle = close_on_idle
 
     def _get_name(self, func_name: Optional[str]) -> str:
         prefix = f"{self._name}_tumbling_window" if self._name else "tumbling_window"
@@ -388,6 +390,7 @@ class TumblingTimeWindowDefinition(TimeWindowDefinition[TimeWindow]):
             on_late=self._on_late,
             before_update=self._before_update,
             after_update=self._after_update,
+            close_on_idle=self._close_on_idle,
         )
 
 

--- a/quixstreams/dataframe/windows/time_based.py
+++ b/quixstreams/dataframe/windows/time_based.py
@@ -51,6 +51,7 @@ class TimeWindow(Window):
         on_late: Optional[WindowOnLateCallback] = None,
         before_update: Optional[WindowBeforeUpdateCallback] = None,
         after_update: Optional[WindowAfterUpdateCallback] = None,
+        close_on_idle: bool = False,
     ):
         super().__init__(
             name=name,
@@ -63,8 +64,15 @@ class TimeWindow(Window):
         self._on_late = on_late
         self._before_update = before_update
         self._after_update = after_update
+        self._close_on_idle = close_on_idle
 
         self._closing_strategy = ClosingStrategy.KEY
+
+    @property
+    def close_on_idle(self) -> bool:
+        """Whether this window closes on wall-clock idle timeout, not only on
+        new messages. See `expire_idle`."""
+        return self._close_on_idle
 
     def final(
         self, closing_strategy: ClosingStrategyValues = "key"
@@ -96,6 +104,15 @@ class TimeWindow(Window):
               Default - `"key"`.
         """
         self._closing_strategy = ClosingStrategy.new(closing_strategy)
+        if (
+            self._close_on_idle
+            and self._closing_strategy != ClosingStrategy.PARTITION
+        ):
+            raise ValueError(
+                'close_on_idle=True requires closing_strategy="partition"; '
+                "idle (wall-clock) closing is not supported for the "
+                f'"{closing_strategy}" strategy.'
+            )
         return super().final()
 
     def current(
@@ -125,7 +142,11 @@ class TimeWindow(Window):
               If timestamps between keys are not ordered, it may increase the number of discarded late messages.
               Default - `"key"`.
         """
-
+        if self._close_on_idle:
+            raise ValueError(
+                "close_on_idle=True is only supported with final() windows; "
+                "current() already emits results on every update."
+            )
         self._closing_strategy = ClosingStrategy.new(closing_strategy)
         return super().current()
 
@@ -290,6 +311,31 @@ class TimeWindow(Window):
             delete=True,
         ):
             yield key, self._results(aggregated, collected, window_start, window_end)
+
+    def expire_idle(
+        self,
+        transaction: WindowedPartitionTransaction,
+        now_ms: int,
+    ) -> Iterable[WindowKeyResult]:
+        """
+        Close windows based on wall-clock time instead of event time, so that
+        windows on an idle stream (no new messages) still emit their results.
+
+        A window is closed once `now_ms` passes `window_end + grace_ms`, which
+        mirrors the normal event-time expiry but uses the real clock as the
+        driver. Only takes effect when `close_on_idle=True`; requires the
+        "partition" closing strategy.
+
+        :param transaction: the windowed partition transaction to expire from.
+        :param now_ms: current wall-clock time in milliseconds.
+        :return: an iterable of closed (key, window result) pairs.
+        """
+        if not self._close_on_idle:
+            return
+        max_expired_window_end = now_ms - self._grace_ms
+        yield from self.expire_by_partition(
+            transaction, max_expired_window_end, self.collect
+        )
 
     def expire_by_key(
         self,

--- a/tests/test_quixstreams/test_dataframe/test_windows/test_tumbling.py
+++ b/tests/test_quixstreams/test_dataframe/test_windows/test_tumbling.py
@@ -16,6 +16,7 @@ def tumbling_window_definition_factory(state_manager, dataframe_factory):
         grace_ms: int = 0,
         before_update=None,
         after_update=None,
+        close_on_idle: bool = False,
     ) -> TumblingTimeWindowDefinition:
         sdf = dataframe_factory(
             state_manager=state_manager, registry=DataFrameRegistry()
@@ -26,6 +27,7 @@ def tumbling_window_definition_factory(state_manager, dataframe_factory):
             dataframe=sdf,
             before_update=before_update,
             after_update=after_update,
+            close_on_idle=close_on_idle,
         )
         return window_def
 
@@ -1395,3 +1397,94 @@ class TestCountTumblingWindow:
             )
             assert expired[0][1]["value"] == [4, 5, 6]
             assert len(updated) == 0
+
+
+class TestTumblingWindowCloseOnIdle:
+    def test_expire_idle_closes_window_on_wall_clock(
+        self, tumbling_window_definition_factory, state_manager
+    ):
+        # A single message opens window [0, 100). No further messages arrive, so
+        # event time never advances past the window end. With close_on_idle the
+        # wall clock alone closes the window once it passes window_end + grace.
+        window_def = tumbling_window_definition_factory(
+            duration_ms=100, grace_ms=0, close_on_idle=True
+        )
+        window = window_def.sum()
+        window.final(closing_strategy="partition")
+
+        store = state_manager.get_store(stream_id="test", store_name=window.name)
+        store.assign_partition(0)
+
+        with store.start_partition_transaction(0) as tx:
+            updated, expired = process(
+                window, value=1, key=b"key", transaction=tx, timestamp_ms=50
+            )
+            assert len(updated) == 1
+            assert not expired  # window still open, no message advanced event time
+
+            # Wall clock has not reached window_end yet -> still open.
+            assert list(window.expire_idle(tx, now_ms=99)) == []
+
+            # Wall clock passes window_end (grace=0) -> window closes on its own.
+            idle_expired = list(window.expire_idle(tx, now_ms=100))
+            assert len(idle_expired) == 1
+            assert idle_expired[0][1]["value"] == 1
+            assert idle_expired[0][1]["start"] == 0
+            assert idle_expired[0][1]["end"] == 100
+
+    def test_expire_idle_respects_grace(
+        self, tumbling_window_definition_factory, state_manager
+    ):
+        window_def = tumbling_window_definition_factory(
+            duration_ms=100, grace_ms=10, close_on_idle=True
+        )
+        window = window_def.sum()
+        window.final(closing_strategy="partition")
+
+        store = state_manager.get_store(stream_id="test", store_name=window.name)
+        store.assign_partition(0)
+
+        with store.start_partition_transaction(0) as tx:
+            process(window, value=5, key=b"key", transaction=tx, timestamp_ms=50)
+
+            # window_end=100, grace=10 -> closes only once now_ms >= 110.
+            assert list(window.expire_idle(tx, now_ms=105)) == []
+            idle_expired = list(window.expire_idle(tx, now_ms=110))
+            assert len(idle_expired) == 1
+            assert idle_expired[0][1]["value"] == 5
+            assert idle_expired[0][1]["end"] == 100
+
+    def test_expire_idle_noop_when_disabled(
+        self, tumbling_window_definition_factory, state_manager
+    ):
+        # Default close_on_idle=False -> expire_idle never closes anything.
+        window_def = tumbling_window_definition_factory(duration_ms=100, grace_ms=0)
+        window = window_def.sum()
+        window.final(closing_strategy="partition")
+
+        store = state_manager.get_store(stream_id="test", store_name=window.name)
+        store.assign_partition(0)
+
+        with store.start_partition_transaction(0) as tx:
+            process(window, value=1, key=b"key", transaction=tx, timestamp_ms=50)
+            assert list(window.expire_idle(tx, now_ms=10_000)) == []
+
+    def test_close_on_idle_requires_partition_strategy(
+        self, tumbling_window_definition_factory
+    ):
+        window_def = tumbling_window_definition_factory(
+            duration_ms=100, close_on_idle=True
+        )
+        window = window_def.sum()
+        with pytest.raises(ValueError, match='closing_strategy="partition"'):
+            window.final(closing_strategy="key")
+
+    def test_close_on_idle_rejected_by_current(
+        self, tumbling_window_definition_factory
+    ):
+        window_def = tumbling_window_definition_factory(
+            duration_ms=100, close_on_idle=True
+        )
+        window = window_def.sum()
+        with pytest.raises(ValueError, match="only supported with final"):
+            window.current(closing_strategy="partition")


### PR DESCRIPTION
Closes #790 (draft — opening early to get design feedback before finishing the app-loop wiring).

## Problem

Time-based windows only expire when a new message advances event time, so a stream that goes quiet never emits its final window. The current workaround is publishing dummy "heartbeat" messages on a timer to force a tumble.

## Approach

Opt-in `close_on_idle` flag on `tumbling_window()`. When enabled, windows close on **wall-clock** time once `window_end + grace_ms` passes — no new message required. The close-time math is unchanged; only the clock that drives it changes (event time → real time).

Scoped to `final(closing_strategy="partition")`, the one strategy where a whole partition can be expired by a single time threshold (`expire_by_partition`) instead of scanning every key. A new `TimeWindow.expire_idle(transaction, now_ms)` reuses that existing partition expiry:

```python
def expire_idle(self, transaction, now_ms):
    if not self._close_on_idle:
        return
    max_expired_window_end = now_ms - self._grace_ms
    yield from self.expire_by_partition(transaction, max_expired_window_end, self.collect)
```

Default is `False`, so existing pipelines are unaffected (event-time only).

## Open questions for maintainers

1. **Emitting downstream on idle.** `compose_all` only exposes per-topic root executors — there's no handle to the pipeline stage right after the window. What's the preferred way to route idle-closed windows downstream? This is the main thing gating a non-draft PR.
2. **Checkpoint with no offset.** An idle close consumes no new Kafka offset. Force a checkpoint flush, or defer to the next real message?
3. **Partition ownership after rebalance.** Idle closes must only fire for partitions this consumer still owns. Is there an existing assignment hook to read from, or should this check the assignment directly?

## Still to do

- [ ] App-loop hook calling `expire_idle` from the empty-poll (`rows is None`) branch
- [ ] Rebalance edge-case test
- [ ] Docs

## Tests

Added under `TestTumblingWindowCloseOnIdle`: closes on wall clock past `window_end`, respects grace, no-op when disabled, and validation rejects the key strategy and `current()`. Full windows suite passes locally (205 passed).

Happy to change direction — if the dummy-heartbeat approach built into the framework is preferred instead, I can do that.
