### PR TITLE
fix(state): apply configured RocksDB options to existing column families

### DIFF
--- a/docs/advanced/stateful-processing.md
+++ b/docs/advanced/stateful-processing.md
@@ -214,6 +214,50 @@ sdf = sdf.apply(apply, stateful=True)
 ```
 
 
+## Memory: the RocksDB block cache
+
+State stores keep recently-read data blocks in a RocksDB block cache. Its size is
+set by `block_cache_size` on `RocksDBOptions` (default **1 GiB**):
+
+```python
+from quixstreams import Application
+from quixstreams.state.rocksdb.options import RocksDBOptions
+
+app = Application(
+    broker_address="localhost:9092",
+    rocksdb_options=RocksDBOptions(block_cache_size=256 * 1024 * 1024),
+)
+```
+
+Two properties matter when sizing a deployment:
+
+- **It is an aggregate ceiling for the whole process, not a per-partition budget.**
+  One cache of this size is shared by every store partition, so a 32-partition
+  application does not reserve 32 times this value. Size it against the memory
+  available to the process, not per store.
+- **It is filled lazily.** The cache is a ceiling rather than an allocation, so a
+  small store never realizes the full capacity, and memory use climbs gradually
+  as blocks are read rather than at startup.
+
+Index and bloom-filter blocks are held *outside* this budget, and every SST file
+stays open, so total RocksDB memory is roughly `block_cache_size` plus
+`bloom_filter_bits_per_key / 8` bytes per stored key. At the default of 10 bits
+that is about 1.25 MB per million keys per column family.
+
+!!! warning "Upgrading from a version before 3.25.1"
+
+    Earlier versions silently discarded `block_cache_size` (and bloom filters)
+    whenever a store was reopened, so every restart after the first ran with
+    RocksDB's 8 MiB default per partition regardless of configuration. Deployments
+    whose memory limits were sized from observed usage were therefore sized against
+    that degraded figure.
+
+    After upgrading, the configured cache actually applies and bloom filters exist
+    again, so steady-state memory rises. **Review your memory limits before
+    upgrading**, or set `block_cache_size` explicitly to keep the previous
+    footprint. Because the cache fills lazily, the increase appears over hours of
+    normal operation rather than immediately at startup.
+
 ## State TTL
 
 State TTL lets you attach an expiry duration to individual writes in a state store. You opt in per write by passing `ttl=timedelta(...)` to `state.set()`. Writes without a `ttl` argument never expire.

--- a/docs/advanced/stateful-processing.md
+++ b/docs/advanced/stateful-processing.md
@@ -244,9 +244,9 @@ stays open, so total RocksDB memory is roughly `block_cache_size` plus
 `bloom_filter_bits_per_key / 8` bytes per stored key. At the default of 10 bits
 that is about 1.25 MB per million keys per column family.
 
-!!! warning "Upgrading from a version before 3.25.1"
+!!! warning "Memory use increases when upgrading from an older version"
 
-    Earlier versions silently discarded `block_cache_size` (and bloom filters)
+    Older versions silently discarded `block_cache_size` (and bloom filters)
     whenever a store was reopened, so every restart after the first ran with
     RocksDB's 8 MiB default per partition regardless of configuration. Deployments
     whose memory limits were sized from observed usage were therefore sized against

--- a/quixstreams/state/rocksdb/options.py
+++ b/quixstreams/state/rocksdb/options.py
@@ -1,5 +1,6 @@
 import dataclasses
-from typing import Mapping, Optional
+import threading
+from typing import Dict, Mapping, Optional
 
 import rocksdict
 from rocksdict import DBCompressionType
@@ -10,6 +11,38 @@ from quixstreams.utils.json import dumps, loads
 from .types import CompressionType, RocksDBOptionsType
 
 __all__ = ("RocksDBOptions",)
+
+# One block cache per configured capacity, shared by every store partition in
+# the process.
+#
+# RocksDB's own guidance is a single block cache shared across databases, and
+# without this ``block_cache_size`` is a PER-PARTITION multiplier: a 32-partition
+# 3-store application would reserve 96 x the configured size. Keying on capacity
+# rather than on the options instance is deliberate — a partition constructed
+# without explicit options builds its own ``RocksDBOptions`` (see
+# ``RocksDBStorePartition.__init__``), so per-instance memoization would not
+# share for the default case, which is most deployments.
+#
+# A cache is a lazily-filled ceiling, not an allocation, so a small deployment
+# never realizes the full capacity.
+_BLOCK_CACHES: Dict[int, rocksdict.Cache] = {}
+_BLOCK_CACHES_LOCK = threading.Lock()
+
+
+def _shared_block_cache(capacity: int) -> rocksdict.Cache:
+    """
+    Get the process-wide block cache for ``capacity``, creating it on first use.
+
+    Locked because partitions are opened concurrently during a rebalance, and two
+    threads racing here would otherwise each build a cache of this size.
+    """
+    with _BLOCK_CACHES_LOCK:
+        cache = _BLOCK_CACHES.get(capacity)
+        if cache is None:
+            cache = rocksdict.Cache(capacity)
+            _BLOCK_CACHES[capacity] = cache
+        return cache
+
 
 COMPRESSION_TYPES: Mapping[CompressionType, DBCompressionType] = {
     "none": DBCompressionType.none(),
@@ -38,6 +71,18 @@ class RocksDBOptions(RocksDBOptionsType):
         the DB won't be destroyed.
         Note: risk of data loss! Make sure that the changelog topics are up-to-date before disabling it in production.
         Default - `True`.
+    :param block_cache_size: size of the RocksDB block cache, in bytes.
+        This is an **aggregate ceiling for the whole process**: one cache of this
+        size is shared by every store partition, following RocksDB's own guidance
+        that a single block cache be shared across databases. It is not a
+        per-partition budget, so a 32-partition application does not reserve 32
+        times this value.
+        A cache is filled lazily, so a small deployment never realizes the full
+        capacity; size it against total available memory rather than per store.
+        Note that index and bloom-filter blocks are held outside this budget
+        (``cache_index_and_filter_blocks`` is not enabled), so real usage is this
+        value plus roughly ``bloom_filter_bits_per_key / 8`` bytes per key.
+        Default - ``1 GiB``.
     :param max_evictions_per_flush: cap on TTL-driven evictions performed
         during a single ``flush()`` for stores with TTL enabled. Larger values
         increase per-flush latency but let the sweep keep up with higher
@@ -51,7 +96,7 @@ class RocksDBOptions(RocksDBOptionsType):
     write_buffer_size: int = 64 * 1024 * 1024
     target_file_size_base: int = 64 * 1024 * 1024
     max_write_buffer_number: int = 3
-    block_cache_size: int = 128 * 1024 * 1024
+    block_cache_size: int = 1024 * 1024 * 1024
     bloom_filter_bits_per_key: int = 10
     enable_pipelined_write: bool = False
     compression_type: CompressionType = "lz4"
@@ -84,7 +129,9 @@ class RocksDBOptions(RocksDBOptionsType):
             opts.set_db_log_dir(self.db_log_dir)
 
         table_factory_options = rocksdict.BlockBasedOptions()
-        table_factory_options.set_block_cache(rocksdict.Cache(self.block_cache_size))
+        table_factory_options.set_block_cache(
+            _shared_block_cache(self.block_cache_size)
+        )
         table_factory_options.set_bloom_filter(
             self.bloom_filter_bits_per_key, block_based=True
         )

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -11,7 +11,7 @@ from typing import (
     cast,
 )
 
-from rocksdict import AccessType, ColumnFamily, Rdict, ReadOptions, WriteBatch
+from rocksdict import AccessType, ColumnFamily, Options, Rdict, ReadOptions, WriteBatch
 
 from quixstreams.state.base import (
     PartitionTransactionCache,
@@ -947,9 +947,27 @@ class RocksDBStorePartition(StorePartition):
         options = self._rocksdb_options
         options.create_if_missing(True)
         options.create_missing_column_families(True)
+
+        def _existing_column_families() -> Dict[str, Options]:
+            # rocksdict applies the options passed to ``Rdict`` only to the
+            # column families it *creates*. Existing CFs must be listed in
+            # ``column_families=`` and handed the same options explicitly, or
+            # every reopen silently drops the configured block cache and bloom
+            # filter for them and falls back to rocksdict's defaults (8 MiB
+            # cache, no filter policy) — undoing every ``RocksDBOptions``
+            # tuning on the second and every subsequent open of a store.
+            try:
+                return {name: options for name in Rdict.list_cf(self._path, options)}
+            except Exception:
+                # No database at this path yet, or its CF list is unreadable.
+                # Nothing pre-exists, so the open below already applies
+                # ``options`` to every column family it creates.
+                return {}
+
         create_rdict = lambda: Rdict(
             path=self._path,
             options=options,
+            column_families=_existing_column_families(),
             access_type=AccessType.read_write(),
         )
         # TODO: Add docs

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -958,12 +958,27 @@ class RocksDBStorePartition(StorePartition):
             # tuning on the second and every subsequent open of a store.
             try:
                 return {name: options for name in Rdict.list_cf(self._path, options)}
-            except Exception:
-                # No database at this path yet, or its CF list is unreadable.
-                # Nothing pre-exists, so the open below already applies
-                # ``options`` to every column family it creates.
+            except Exception as exc:
+                # Broad by necessity: rocksdict raises a bare ``Exception`` here
+                # (an "IO error: No such file or directory" for a path with no
+                # database), so there is no narrower type to catch. Logged
+                # rather than silently swallowed, because the fallback below is
+                # the pre-existing behaviour in which the configured options do
+                # NOT reach existing column families -- if that ever happens to
+                # a store that really does exist, it must not be invisible.
+                logger.debug(
+                    "Could not list column families of the store at "
+                    '"%s" (%s); opening without an explicit column-family map.',
+                    self._path,
+                    exc,
+                )
                 return {}
 
+        # ``_existing_column_families()`` is called inside the lambda, NOT
+        # hoisted: the corruption path below destroys the database and calls
+        # ``create_rdict()`` again, and that second attempt must re-read the CF
+        # list (which is then empty) rather than reuse the pre-destroy one.
+        # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
         create_rdict = lambda: Rdict(
             path=self._path,
             options=options,

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -976,7 +976,13 @@ class RocksDBStorePartition(StorePartition):
                 # listing failure against a path that *does* hold one means the
                 # configured options will not reach its existing column
                 # families, which must never be invisible.
-                log = logger.warning if os.path.exists(self._path) else logger.debug
+                # Probe for CURRENT, not the directory: the question is "does a
+                # database live here", and a leftover empty directory would
+                # otherwise warn about options missing column families that do
+                # not exist. The corruption path destroys the whole directory,
+                # so it correctly takes the debug branch.
+                db_exists = os.path.exists(os.path.join(self._path, "CURRENT"))
+                log = logger.warning if db_exists else logger.debug
                 log(
                     "Could not list the column families of the store at "
                     '"%s" (%s); opening without an explicit column-family map, '
@@ -992,8 +998,7 @@ class RocksDBStorePartition(StorePartition):
         # ``create_rdict()`` again, and that second attempt must re-read the CF
         # list (now absent) rather than reuse the pre-destroy one.
         # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
-        def create_rdict() -> Rdict:
-            cfs = _existing_column_families()
+        def _open(cfs: Optional[Dict[str, Options]]) -> Rdict:
             if cfs is None:
                 # Pre-existing behaviour: a genuine IO fault then surfaces from
                 # inside ``Rdict`` as "IO error: ..." and is retried upstream.
@@ -1008,6 +1013,28 @@ class RocksDBStorePartition(StorePartition):
                 column_families=cfs,
                 access_type=AccessType.read_write(),
             )
+
+        def create_rdict() -> Rdict:
+            cfs = _existing_column_families()
+            try:
+                return _open(cfs)
+            except Exception as exc:
+                if cfs is None or "Column families not opened" not in str(exc):
+                    raise
+                # The list went stale between listing and opening: ``list_cf``
+                # takes no LOCK and column families are created lazily at
+                # runtime, so another process sharing this store can add one
+                # inside that window. The resulting message matches neither the
+                # corruption nor the io-error path, so without this it would be
+                # an un-retried fatal open. Re-read once; a second failure is
+                # not a race and propagates.
+                logger.warning(
+                    'Column-family list for the store at "%s" went stale '
+                    "between listing and opening (%s); re-reading and retrying.",
+                    self._path,
+                    exc,
+                )
+                return _open(_existing_column_families())
 
         # TODO: Add docs
 
@@ -1064,6 +1091,16 @@ class RocksDBStorePartition(StorePartition):
             except Exception as exc:
                 is_locked = str(exc).lower().startswith("io error")
                 if not is_locked:
+                    # Every other exit from this loop logs a warning naming the
+                    # path; without one here an unclassified open failure reaches
+                    # the operator as a PartitionAssignmentError whose message
+                    # may name a column family but never the store directory.
+                    logger.warning(
+                        'Failed to open rocksdb partition on "%s" with an '
+                        "unrecoverable error (%s); not retrying.",
+                        self._path,
+                        exc,
+                    )
                     raise
 
                 # Shared per-assign open budget: when the acquiring consumer has

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from threading import Event
 from typing import (
@@ -11,7 +12,7 @@ from typing import (
     cast,
 )
 
-from rocksdict import AccessType, ColumnFamily, Rdict, ReadOptions, WriteBatch
+from rocksdict import AccessType, ColumnFamily, Options, Rdict, ReadOptions, WriteBatch
 
 from quixstreams.state.base import (
     PartitionTransactionCache,
@@ -947,11 +948,94 @@ class RocksDBStorePartition(StorePartition):
         options = self._rocksdb_options
         options.create_if_missing(True)
         options.create_missing_column_families(True)
-        create_rdict = lambda: Rdict(
-            path=self._path,
-            options=options,
-            access_type=AccessType.read_write(),
-        )
+
+        def _existing_column_families() -> Optional[Dict[str, Options]]:
+            # rocksdict applies the options passed to ``Rdict`` only to the
+            # column families it *creates*. Existing CFs must be listed in
+            # ``column_families=`` and handed the same options explicitly, or
+            # every reopen silently drops the configured block cache and bloom
+            # filter for them and falls back to rocksdict's defaults (8 MiB
+            # cache, no filter policy) — undoing every ``RocksDBOptions``
+            # tuning on the second and every subsequent open of a store.
+            #
+            # Returns ``None`` -- not ``{}`` -- when the CFs cannot be listed, so
+            # the caller omits the argument entirely. An empty map is NOT
+            # equivalent to omitting it: against a store that does hold CFs it
+            # fails with "Invalid argument: Column families not opened: <cf>",
+            # a message starting with neither "Corruption" nor "io error" and so
+            # matching no recovery path, which would turn a transient listing
+            # failure into an un-retried crash loop on a store that opens
+            # perfectly well without the argument.
+            try:
+                return {name: options for name in Rdict.list_cf(self._path, options)}
+            except Exception as exc:
+                # Broad by necessity: rocksdict raises a bare ``Exception`` here
+                # (an "IO error: No such file or directory" for a path with no
+                # database), so there is no narrower type to catch. A missing
+                # database is the ordinary cold start and must stay quiet; a
+                # listing failure against a path that *does* hold one means the
+                # configured options will not reach its existing column
+                # families, which must never be invisible.
+                # Probe for CURRENT, not the directory: the question is "does a
+                # database live here", and a leftover empty directory would
+                # otherwise warn about options missing column families that do
+                # not exist. The corruption path destroys the whole directory,
+                # so it correctly takes the debug branch.
+                db_exists = os.path.exists(os.path.join(self._path, "CURRENT"))
+                log = logger.warning if db_exists else logger.debug
+                log(
+                    "Could not list the column families of the store at "
+                    '"%s" (%s); opening without an explicit column-family map, '
+                    "so configured RocksDB options will not reach any "
+                    "pre-existing column family.",
+                    self._path,
+                    exc,
+                )
+                return None
+
+        # ``_existing_column_families()`` is called inside ``create_rdict``, NOT
+        # hoisted: the corruption path below destroys the database and calls
+        # ``create_rdict()`` again, and that second attempt must re-read the CF
+        # list (now absent) rather than reuse the pre-destroy one.
+        # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
+        def _open(cfs: Optional[Dict[str, Options]]) -> Rdict:
+            if cfs is None:
+                # Pre-existing behaviour: a genuine IO fault then surfaces from
+                # inside ``Rdict`` as "IO error: ..." and is retried upstream.
+                return Rdict(
+                    path=self._path,
+                    options=options,
+                    access_type=AccessType.read_write(),
+                )
+            return Rdict(
+                path=self._path,
+                options=options,
+                column_families=cfs,
+                access_type=AccessType.read_write(),
+            )
+
+        def create_rdict() -> Rdict:
+            cfs = _existing_column_families()
+            try:
+                return _open(cfs)
+            except Exception as exc:
+                if cfs is None or "Column families not opened" not in str(exc):
+                    raise
+                # The list went stale between listing and opening: ``list_cf``
+                # takes no LOCK and column families are created lazily at
+                # runtime, so another process sharing this store can add one
+                # inside that window. The resulting message matches neither the
+                # corruption nor the io-error path, so without this it would be
+                # an un-retried fatal open. Re-read once; a second failure is
+                # not a race and propagates.
+                logger.warning(
+                    'Column-family list for the store at "%s" went stale '
+                    "between listing and opening (%s); re-reading and retrying.",
+                    self._path,
+                    exc,
+                )
+                return _open(_existing_column_families())
+
         # TODO: Add docs
 
         try:
@@ -1007,6 +1091,16 @@ class RocksDBStorePartition(StorePartition):
             except Exception as exc:
                 is_locked = str(exc).lower().startswith("io error")
                 if not is_locked:
+                    # Every other exit from this loop logs a warning naming the
+                    # path; without one here an unclassified open failure reaches
+                    # the operator as a PartitionAssignmentError whose message
+                    # may name a column family but never the store directory.
+                    logger.warning(
+                        'Failed to open rocksdb partition on "%s" with an '
+                        "unrecoverable error (%s); not retrying.",
+                        self._path,
+                        exc,
+                    )
                     raise
 
                 # Shared per-assign open budget: when the acquiring consumer has

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -982,31 +982,52 @@ class RocksDBStorePartition(StorePartition):
                 # otherwise warn about options missing column families that do
                 # not exist. The corruption path destroys the whole directory,
                 # so it correctly takes the debug branch.
-                db_exists = os.path.exists(os.path.join(self._path, "CURRENT"))
-                # Past tense and no promise about the outcome: the caller may
-                # still recover by re-reading the list, and a warning that
-                # asserts the options were dropped is the string operators and
-                # alerts key on. Claiming it before the retry has run produced a
-                # false positive on a store that ended up correctly configured.
-                # ``strip()`` because rocksdict's message ends in a newline on
-                # Windows, which would split this into two log records and orphan
-                # the second half without its level or logger name.
-                if db_exists:
-                    logger.warning(
-                        'Could not list the column families of the store at "%s" '
-                        "(%s); retrying the open without an explicit "
-                        "column-family map.",
-                        self._path,
-                        str(exc).strip(),
-                    )
-                else:
+                # "Is there a database here?" -- and if we cannot tell, assume
+                # there is. ``os.path.exists`` returns False on ANY OSError, so a
+                # populated store that is momentarily unstattable (EACCES, a
+                # read-only remount, a too-long path) would otherwise be treated
+                # as a cold start and opened degraded.
+                try:
+                    os.stat(os.path.join(self._path, "CURRENT"))
+                    db_exists = True
+                except FileNotFoundError:
+                    db_exists = False
+                except OSError:
+                    db_exists = True
+
+                if not db_exists:
+                    # Ordinary cold start: this open creates the database, and
+                    # options apply to every column family it creates.
                     logger.debug(
                         'No column families to list for the store at "%s" (%s); '
                         "it will be created by this open.",
                         self._path,
                         str(exc).strip(),
                     )
-                return None
+                    return None
+
+                # There IS a database and we could not read its column families.
+                # Do NOT open without them: rocksdict would then derive them from
+                # the persisted OPTIONS file and apply its own defaults -- an
+                # 8 MiB block cache and no bloom filters for every existing
+                # column family, for the lifetime of the process. That is exactly
+                # the silent degradation this whole change exists to remove, and
+                # it is invisible once the open succeeds.
+                #
+                # Propagate instead. A listing failure is normally transient, and
+                # rocksdict reports it as "IO error: ...", which is what
+                # ``_init_rocksdb`` already retries with backoff -- so a blip
+                # self-heals on the next attempt with the options intact, and only
+                # a persistent fault fails the open, loudly.
+                logger.warning(
+                    'Could not list the column families of the store at "%s" '
+                    "(%s); not opening it without them, because the configured "
+                    "RocksDB options would not reach any pre-existing column "
+                    "family.",
+                    self._path,
+                    str(exc).strip(),
+                )
+                raise
 
         # ``_existing_column_families()`` is called inside ``create_rdict``, NOT
         # hoisted: the corruption path below destroys the database and calls

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -1000,8 +1000,14 @@ class RocksDBStorePartition(StorePartition):
         # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
         def _open(cfs: Optional[Dict[str, Options]]) -> Rdict:
             if cfs is None:
-                # Pre-existing behaviour: a genuine IO fault then surfaces from
-                # inside ``Rdict`` as "IO error: ..." and is retried upstream.
+                # Omitting the argument is the pre-existing open. Note it is NOT
+                # a safe fallback in general: rocksdict then derives the column
+                # families from the persisted OPTIONS file, and if that read
+                # fails it silently degrades to default-CF-only, so the open
+                # fails with "Column families not opened" rather than an
+                # "IO error: ..." that the caller would retry. Supplying the
+                # list explicitly survives that, which is why the caller below
+                # re-reads and tries the other form.
                 return Rdict(
                     path=self._path,
                     options=options,
@@ -1019,22 +1025,34 @@ class RocksDBStorePartition(StorePartition):
             try:
                 return _open(cfs)
             except Exception as exc:
-                if cfs is None or "Column families not opened" not in str(exc):
+                if "Column families not opened" not in str(exc):
                     raise
-                # The list went stale between listing and opening: ``list_cf``
-                # takes no LOCK and column families are created lazily at
-                # runtime, so another process sharing this store can add one
-                # inside that window. The resulting message matches neither the
-                # corruption nor the io-error path, so without this it would be
-                # an un-retried fatal open. Re-read once; a second failure is
-                # not a race and propagates.
+                # Two ways to land here, both recoverable by re-reading the list:
+                #
+                # 1. The list went stale between listing and opening --
+                #    ``list_cf`` takes no LOCK and column families are created
+                #    lazily at runtime, so a process sharing this store can add
+                #    one inside that window.
+                # 2. We opened WITHOUT the argument (``cfs is None``, the listing
+                #    having failed) and rocksdict could not read the persisted
+                #    OPTIONS, so it saw only the default CF. Supplying the list
+                #    explicitly recovers a store that the argument-less open
+                #    cannot open at all.
+                #
+                # Either way the message matches neither the corruption nor the
+                # io-error path, so without this it is an un-retried fatal open.
+                retry = _existing_column_families()
+                if retry is None and cfs is None:
+                    # Nothing new to try: the listing failed both times and the
+                    # argument-less open has already been attempted.
+                    raise
                 logger.warning(
-                    'Column-family list for the store at "%s" went stale '
-                    "between listing and opening (%s); re-reading and retrying.",
+                    'Could not open the store at "%s" with the column families '
+                    "listed for it (%s); re-reading the list and retrying once.",
                     self._path,
-                    exc,
+                    str(exc).strip(),
                 )
-                return _open(_existing_column_families())
+                return _open(retry)
 
         # TODO: Add docs
 

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from threading import Event
 from typing import (
@@ -948,7 +949,7 @@ class RocksDBStorePartition(StorePartition):
         options.create_if_missing(True)
         options.create_missing_column_families(True)
 
-        def _existing_column_families() -> Dict[str, Options]:
+        def _existing_column_families() -> Optional[Dict[str, Options]]:
             # rocksdict applies the options passed to ``Rdict`` only to the
             # column families it *creates*. Existing CFs must be listed in
             # ``column_families=`` and handed the same options explicitly, or
@@ -956,35 +957,58 @@ class RocksDBStorePartition(StorePartition):
             # filter for them and falls back to rocksdict's defaults (8 MiB
             # cache, no filter policy) — undoing every ``RocksDBOptions``
             # tuning on the second and every subsequent open of a store.
+            #
+            # Returns ``None`` -- not ``{}`` -- when the CFs cannot be listed, so
+            # the caller omits the argument entirely. An empty map is NOT
+            # equivalent to omitting it: against a store that does hold CFs it
+            # fails with "Invalid argument: Column families not opened: <cf>",
+            # a message starting with neither "Corruption" nor "io error" and so
+            # matching no recovery path, which would turn a transient listing
+            # failure into an un-retried crash loop on a store that opens
+            # perfectly well without the argument.
             try:
                 return {name: options for name in Rdict.list_cf(self._path, options)}
             except Exception as exc:
                 # Broad by necessity: rocksdict raises a bare ``Exception`` here
                 # (an "IO error: No such file or directory" for a path with no
-                # database), so there is no narrower type to catch. Logged
-                # rather than silently swallowed, because the fallback below is
-                # the pre-existing behaviour in which the configured options do
-                # NOT reach existing column families -- if that ever happens to
-                # a store that really does exist, it must not be invisible.
-                logger.debug(
-                    "Could not list column families of the store at "
-                    '"%s" (%s); opening without an explicit column-family map.',
+                # database), so there is no narrower type to catch. A missing
+                # database is the ordinary cold start and must stay quiet; a
+                # listing failure against a path that *does* hold one means the
+                # configured options will not reach its existing column
+                # families, which must never be invisible.
+                log = logger.warning if os.path.exists(self._path) else logger.debug
+                log(
+                    "Could not list the column families of the store at "
+                    '"%s" (%s); opening without an explicit column-family map, '
+                    "so configured RocksDB options will not reach any "
+                    "pre-existing column family.",
                     self._path,
                     exc,
                 )
-                return {}
+                return None
 
-        # ``_existing_column_families()`` is called inside the lambda, NOT
+        # ``_existing_column_families()`` is called inside ``create_rdict``, NOT
         # hoisted: the corruption path below destroys the database and calls
         # ``create_rdict()`` again, and that second attempt must re-read the CF
-        # list (which is then empty) rather than reuse the pre-destroy one.
+        # list (now absent) rather than reuse the pre-destroy one.
         # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
-        create_rdict = lambda: Rdict(
-            path=self._path,
-            options=options,
-            column_families=_existing_column_families(),
-            access_type=AccessType.read_write(),
-        )
+        def create_rdict() -> Rdict:
+            cfs = _existing_column_families()
+            if cfs is None:
+                # Pre-existing behaviour: a genuine IO fault then surfaces from
+                # inside ``Rdict`` as "IO error: ..." and is retried upstream.
+                return Rdict(
+                    path=self._path,
+                    options=options,
+                    access_type=AccessType.read_write(),
+                )
+            return Rdict(
+                path=self._path,
+                options=options,
+                column_families=cfs,
+                access_type=AccessType.read_write(),
+            )
+
         # TODO: Add docs
 
         try:

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import time
 from threading import Event
 from typing import (
@@ -12,7 +11,7 @@ from typing import (
     cast,
 )
 
-from rocksdict import AccessType, ColumnFamily, Options, Rdict, ReadOptions, WriteBatch
+from rocksdict import AccessType, ColumnFamily, Rdict, ReadOptions, WriteBatch
 
 from quixstreams.state.base import (
     PartitionTransactionCache,
@@ -948,94 +947,11 @@ class RocksDBStorePartition(StorePartition):
         options = self._rocksdb_options
         options.create_if_missing(True)
         options.create_missing_column_families(True)
-
-        def _existing_column_families() -> Optional[Dict[str, Options]]:
-            # rocksdict applies the options passed to ``Rdict`` only to the
-            # column families it *creates*. Existing CFs must be listed in
-            # ``column_families=`` and handed the same options explicitly, or
-            # every reopen silently drops the configured block cache and bloom
-            # filter for them and falls back to rocksdict's defaults (8 MiB
-            # cache, no filter policy) — undoing every ``RocksDBOptions``
-            # tuning on the second and every subsequent open of a store.
-            #
-            # Returns ``None`` -- not ``{}`` -- when the CFs cannot be listed, so
-            # the caller omits the argument entirely. An empty map is NOT
-            # equivalent to omitting it: against a store that does hold CFs it
-            # fails with "Invalid argument: Column families not opened: <cf>",
-            # a message starting with neither "Corruption" nor "io error" and so
-            # matching no recovery path, which would turn a transient listing
-            # failure into an un-retried crash loop on a store that opens
-            # perfectly well without the argument.
-            try:
-                return {name: options for name in Rdict.list_cf(self._path, options)}
-            except Exception as exc:
-                # Broad by necessity: rocksdict raises a bare ``Exception`` here
-                # (an "IO error: No such file or directory" for a path with no
-                # database), so there is no narrower type to catch. A missing
-                # database is the ordinary cold start and must stay quiet; a
-                # listing failure against a path that *does* hold one means the
-                # configured options will not reach its existing column
-                # families, which must never be invisible.
-                # Probe for CURRENT, not the directory: the question is "does a
-                # database live here", and a leftover empty directory would
-                # otherwise warn about options missing column families that do
-                # not exist. The corruption path destroys the whole directory,
-                # so it correctly takes the debug branch.
-                db_exists = os.path.exists(os.path.join(self._path, "CURRENT"))
-                log = logger.warning if db_exists else logger.debug
-                log(
-                    "Could not list the column families of the store at "
-                    '"%s" (%s); opening without an explicit column-family map, '
-                    "so configured RocksDB options will not reach any "
-                    "pre-existing column family.",
-                    self._path,
-                    exc,
-                )
-                return None
-
-        # ``_existing_column_families()`` is called inside ``create_rdict``, NOT
-        # hoisted: the corruption path below destroys the database and calls
-        # ``create_rdict()`` again, and that second attempt must re-read the CF
-        # list (now absent) rather than reuse the pre-destroy one.
-        # ``_init_rocksdb`` likewise re-invokes this method per lock retry.
-        def _open(cfs: Optional[Dict[str, Options]]) -> Rdict:
-            if cfs is None:
-                # Pre-existing behaviour: a genuine IO fault then surfaces from
-                # inside ``Rdict`` as "IO error: ..." and is retried upstream.
-                return Rdict(
-                    path=self._path,
-                    options=options,
-                    access_type=AccessType.read_write(),
-                )
-            return Rdict(
-                path=self._path,
-                options=options,
-                column_families=cfs,
-                access_type=AccessType.read_write(),
-            )
-
-        def create_rdict() -> Rdict:
-            cfs = _existing_column_families()
-            try:
-                return _open(cfs)
-            except Exception as exc:
-                if cfs is None or "Column families not opened" not in str(exc):
-                    raise
-                # The list went stale between listing and opening: ``list_cf``
-                # takes no LOCK and column families are created lazily at
-                # runtime, so another process sharing this store can add one
-                # inside that window. The resulting message matches neither the
-                # corruption nor the io-error path, so without this it would be
-                # an un-retried fatal open. Re-read once; a second failure is
-                # not a race and propagates.
-                logger.warning(
-                    'Column-family list for the store at "%s" went stale '
-                    "between listing and opening (%s); re-reading and retrying.",
-                    self._path,
-                    exc,
-                )
-                return _open(_existing_column_families())
-
+        create_rdict = lambda: Rdict(
+            path=self._path,
+            options=options,
+            access_type=AccessType.read_write(),
+        )
         # TODO: Add docs
 
         try:
@@ -1091,16 +1007,6 @@ class RocksDBStorePartition(StorePartition):
             except Exception as exc:
                 is_locked = str(exc).lower().startswith("io error")
                 if not is_locked:
-                    # Every other exit from this loop logs a warning naming the
-                    # path; without one here an unclassified open failure reaches
-                    # the operator as a PartitionAssignmentError whose message
-                    # may name a column family but never the store directory.
-                    logger.warning(
-                        'Failed to open rocksdb partition on "%s" with an '
-                        "unrecoverable error (%s); not retrying.",
-                        self._path,
-                        exc,
-                    )
                     raise
 
                 # Shared per-assign open budget: when the acquiring consumer has

--- a/quixstreams/state/rocksdb/partition.py
+++ b/quixstreams/state/rocksdb/partition.py
@@ -14,6 +14,7 @@ from typing import (
 
 from rocksdict import AccessType, ColumnFamily, Options, Rdict, ReadOptions, WriteBatch
 
+from quixstreams.exceptions.base import QuixException
 from quixstreams.state.base import (
     PartitionTransactionCache,
     StorePartition,
@@ -982,15 +983,29 @@ class RocksDBStorePartition(StorePartition):
                 # not exist. The corruption path destroys the whole directory,
                 # so it correctly takes the debug branch.
                 db_exists = os.path.exists(os.path.join(self._path, "CURRENT"))
-                log = logger.warning if db_exists else logger.debug
-                log(
-                    "Could not list the column families of the store at "
-                    '"%s" (%s); opening without an explicit column-family map, '
-                    "so configured RocksDB options will not reach any "
-                    "pre-existing column family.",
-                    self._path,
-                    exc,
-                )
+                # Past tense and no promise about the outcome: the caller may
+                # still recover by re-reading the list, and a warning that
+                # asserts the options were dropped is the string operators and
+                # alerts key on. Claiming it before the retry has run produced a
+                # false positive on a store that ended up correctly configured.
+                # ``strip()`` because rocksdict's message ends in a newline on
+                # Windows, which would split this into two log records and orphan
+                # the second half without its level or logger name.
+                if db_exists:
+                    logger.warning(
+                        'Could not list the column families of the store at "%s" '
+                        "(%s); retrying the open without an explicit "
+                        "column-family map.",
+                        self._path,
+                        str(exc).strip(),
+                    )
+                else:
+                    logger.debug(
+                        'No column families to list for the store at "%s" (%s); '
+                        "it will be created by this open.",
+                        self._path,
+                        str(exc).strip(),
+                    )
                 return None
 
         # ``_existing_column_families()`` is called inside ``create_rdict``, NOT
@@ -1027,28 +1042,42 @@ class RocksDBStorePartition(StorePartition):
             except Exception as exc:
                 if "Column families not opened" not in str(exc):
                     raise
-                # Two ways to land here, both recoverable by re-reading the list:
+                # Two ways to land here, and this message matches neither the
+                # corruption nor the io-error gate, so without a retry it is an
+                # un-retried fatal open:
                 #
                 # 1. The list went stale between listing and opening --
                 #    ``list_cf`` takes no LOCK and column families are created
                 #    lazily at runtime, so a process sharing this store can add
-                #    one inside that window.
+                #    one inside that window. Re-reading picks the new one up.
                 # 2. We opened WITHOUT the argument (``cfs is None``, the listing
                 #    having failed) and rocksdict could not read the persisted
                 #    OPTIONS, so it saw only the default CF. Supplying the list
-                #    explicitly recovers a store that the argument-less open
-                #    cannot open at all.
+                #    explicitly recovers a store the argument-less open cannot
+                #    open at all.
                 #
-                # Either way the message matches neither the corruption nor the
-                # io-error path, so without this it is an un-retried fatal open.
+                # The list is re-read ONCE. If that read fails, or still yields a
+                # list this store will not open with, the error propagates: the
+                # only remaining move would be an argument-less open, and on a
+                # store that has column families that is the silent 8 MiB /
+                # no-bloom-filter degradation this whole change exists to remove.
+                # Failing loudly on a store we cannot open correctly beats
+                # serving it in the state the bug used to produce.
                 retry = _existing_column_families()
-                if retry is None and cfs is None:
-                    # Nothing new to try: the listing failed both times and the
-                    # argument-less open has already been attempted.
+                if retry is None:
+                    logger.warning(
+                        'Could not open the store at "%s" (%s), and its column '
+                        "families could not be listed on the retry either; not "
+                        "falling back to an open without them, because that "
+                        "would silently drop the configured block cache and "
+                        "bloom filters for every existing column family.",
+                        self._path,
+                        str(exc).strip(),
+                    )
                     raise
                 logger.warning(
-                    'Could not open the store at "%s" with the column families '
-                    "listed for it (%s); re-reading the list and retrying once.",
+                    'Could not open the store at "%s" (%s); re-read its column '
+                    "families and retrying the open once.",
                     self._path,
                     str(exc).strip(),
                 )
@@ -1109,16 +1138,22 @@ class RocksDBStorePartition(StorePartition):
             except Exception as exc:
                 is_locked = str(exc).lower().startswith("io error")
                 if not is_locked:
-                    # Every other exit from this loop logs a warning naming the
-                    # path; without one here an unclassified open failure reaches
-                    # the operator as a PartitionAssignmentError whose message
-                    # may name a column family but never the store directory.
-                    logger.warning(
-                        'Failed to open rocksdb partition on "%s" with an '
-                        "unrecoverable error (%s); not retrying.",
-                        self._path,
-                        exc,
-                    )
+                    # Every other exit from this loop logs and names the path;
+                    # without this an unclassified open failure reaches the
+                    # operator as a PartitionAssignmentError whose message may
+                    # name a column family but never the store directory.
+                    #
+                    # ERROR, not WARNING: this is the terminal exit. Errors that
+                    # carry their own actionable message (``RocksDBCorruptedError``
+                    # says the store may be recoverable from the changelog) are
+                    # left to speak for themselves rather than being contradicted
+                    # by a line calling them unrecoverable.
+                    if not isinstance(exc, QuixException):
+                        logger.error(
+                            'Failed to open rocksdb partition on "%s": %s',
+                            self._path,
+                            str(exc).strip(),
+                        )
                     raise
 
                 # Shared per-assign open budget: when the acquiring consumer has

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -169,7 +169,10 @@ class TestRocksDBStorePartition:
         # (no leading space) appears elsewhere in RocksDB's log.
         capacities = [int(c) for c in re.findall(r"capacity\s+:\s+(\d+)", log)]
         filter_policies = set(re.findall(r"filter_policy:\s*(\S+)", log))
-        cache_ids = set(re.findall(r"block_cache:\s*(\w+)", log))
+        # Anchored: an unanchored `block_cache:` also matches `no_block_cache: 0`
+        # and `prepopulate_block_cache: 0`, which happen to be 0 today — enabling
+        # either would fail this assertion for the wrong reason.
+        cache_ids = set(re.findall(r"^\s*block_cache:\s*(\w+)\s*$", log, re.M))
 
         # One block-cache line per CF, all at the configured size.
         assert len(capacities) >= len(cf_names)
@@ -183,7 +186,7 @@ class TestRocksDBStorePartition:
         assert len(cache_ids - {"0"}) == 1
 
     def test_open_survives_transient_cf_listing_failure(
-        self, store_partition_factory, tmp_path
+        self, store_partition_factory, tmp_path, caplog
     ):
         """
         Failing to LIST the column families must not turn into a fatal open.
@@ -202,11 +205,61 @@ class TestRocksDBStorePartition:
         partition.close()
 
         # The store now has more than the default CF, so an empty map is fatal.
-        with patch.object(
-            Rdict, "list_cf", side_effect=Exception("IO error: transient")
-        ):
+        with caplog.at_level("WARNING"):
+            with patch.object(
+                Rdict, "list_cf", side_effect=Exception("IO error: transient")
+            ):
+                reopened = store_partition_factory("db")
+        try:
+            # Opening is not enough: the store must be usable, and the operator
+            # must be told the configured options missed its existing CFs.
+            with reopened.begin() as tx:
+                assert tx.get("key", prefix=b"__key__") == "value"
+            assert any(
+                "Could not list the column families" in r.message
+                and r.levelname == "WARNING"
+                for r in caplog.records
+            )
+        finally:
+            reopened.close()
+
+    def test_open_retries_a_stale_column_family_list(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        A CF list that is merely STALE must be re-read, not fatal.
+
+        ``Rdict.list_cf`` takes no LOCK and column families are created lazily at
+        runtime, so a process sharing the store can add one between the listing
+        and the open. The open then fails with ``Column families not opened:
+        <cf>`` — a message matching neither the corruption nor the io-error retry
+        path, so without a re-read it is an un-retried fatal open, exactly the
+        failure the None-instead-of-empty-map fix was meant to remove but reached
+        through a different door.
+        """
+        partition = store_partition_factory("db")
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        real_list_cf = Rdict.list_cf
+        calls = []
+
+        def _stale_once(path, *args, **kwargs):
+            full = real_list_cf(path, *args, **kwargs)
+            calls.append(full)
+            # First call omits a CF that really exists, mimicking the race; the
+            # re-read returns the truth.
+            return ["default"] if len(calls) == 1 else full
+
+        with patch.object(Rdict, "list_cf", staticmethod(_stale_once)):
             reopened = store_partition_factory("db")
-        reopened.close()
+        try:
+            assert len(calls) == 2, "the stale list should have been re-read"
+            with reopened.begin() as tx:
+                assert tx.get("key", prefix=b"__key__") == "value"
+        finally:
+            reopened.close()
 
     def test_get_or_create_column_family(self, store_partition: RocksDBStorePartition):
         assert store_partition.get_or_create_column_family("cf")

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -185,6 +185,40 @@ class TestRocksDBStorePartition:
         # assertions above while multiplying the real memory ceiling.
         assert len(cache_ids - {"0"}) == 1
 
+    def test_block_cache_is_shared_across_partitions(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        ``block_cache_size`` is an aggregate ceiling, not a per-partition budget.
+
+        One cache per partition would make the setting a multiplier: a
+        32-partition, 3-store application would reserve 96x the configured size,
+        which is a multi-gigabyte ceiling charged lazily — so it surfaces as an
+        OOM hours after an upgrade rather than at startup.
+
+        Asserted on the ``block_cache`` pointer RocksDB prints per column family:
+        two partitions sharing one cache report the SAME address.
+        """
+        cache_size = 96 * 1024 * 1024
+        options = RocksDBOptions(
+            block_cache_size=cache_size, bloom_filter_bits_per_key=10
+        )
+
+        pointers = set()
+        for name in ("p0", "p1"):
+            partition = store_partition_factory(name, options=options)
+            partition.close()
+            log = (tmp_path / name / "LOG").read_text(
+                encoding="utf-8", errors="replace"
+            )
+            assert set(re.findall(r"capacity\s+:\s+(\d+)", log)) == {str(cache_size)}
+            pointers |= set(re.findall(r"^\s*block_cache:\s*(\w+)\s*$", log, re.M))
+
+        assert len(pointers) == 1, (
+            f"each partition built its own cache ({pointers}), so "
+            f"block_cache_size is a per-partition multiplier"
+        )
+
     def test_open_survives_transient_cf_listing_failure(
         self, store_partition_factory, tmp_path, caplog
     ):

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -161,7 +161,9 @@ class TestRocksDBStorePartition:
         partition = store_partition_factory("db", options=options)
         partition.close()
 
-        log = (tmp_path / "db" / "LOG").read_text()
+        # errors="replace": the LOG embeds the absolute store path, which on a
+        # non-ASCII temp dir is undecodable under the Windows locale codepage.
+        log = (tmp_path / "db" / "LOG").read_text(encoding="utf-8", errors="replace")
         # Require whitespace around the colon: that is the block-cache line in
         # the block_based_table_factory section. An unrelated "capacity: 128"
         # (no leading space) appears elsewhere in RocksDB's log.
@@ -179,6 +181,32 @@ class TestRocksDBStorePartition:
         # options object, so a refactor to per-CF options would still satisfy the
         # assertions above while multiplying the real memory ceiling.
         assert len(cache_ids - {"0"}) == 1
+
+    def test_open_survives_transient_cf_listing_failure(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        Failing to LIST the column families must not turn into a fatal open.
+
+        Passing ``column_families={}`` is NOT equivalent to omitting the
+        argument: on a store that already holds CFs an empty map raises
+        ``Invalid argument: Column families not opened: __metadata__``. That
+        message starts with neither "Corruption" nor "io error", so it matches
+        no recovery path and escapes as a fatal assignment error -- turning a
+        transient listing failure into a crash loop on a store that opens fine
+        without the argument.
+        """
+        partition = store_partition_factory("db")
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        # The store now has more than the default CF, so an empty map is fatal.
+        with patch.object(
+            Rdict, "list_cf", side_effect=Exception("IO error: transient")
+        ):
+            reopened = store_partition_factory("db")
+        reopened.close()
 
     def test_get_or_create_column_family(self, store_partition: RocksDBStorePartition):
         assert store_partition.get_or_create_column_family("cf")

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -1,3 +1,4 @@
+import re
 import time
 from datetime import timedelta
 from pathlib import Path
@@ -114,13 +115,60 @@ class TestRocksDBStorePartition:
         store_partition_factory(options=RocksDBOptions(on_corrupted_recreate=True))
 
     def test_db_corrupted_sst_file(self, store_partition_factory, tmp_path):
-        rdict = Rdict(path=tmp_path.as_posix())  # initialize db
+        # Initialize the db the way quixstreams does, so the CFs carry the same
+        # comparator the store partition will open them with. A bare
+        # `Rdict(path=...)` defaults to `raw_mode=False` and is not a store any
+        # quixstreams deployment can produce; opening it would fail on the
+        # comparator before the corruption is ever reached.
+        rdict = Rdict(path=tmp_path.as_posix(), options=RocksDBOptions().to_options())
         rdict[b"key"] = b"value"  # write something
         rdict.flush()  # flush creates .sst file
         rdict.close()  # required to release the lock
         next(tmp_path.glob("*.sst")).unlink()  # delete the .sst file
 
         store_partition_factory(options=RocksDBOptions(on_corrupted_recreate=True))
+
+    def test_configured_table_options_survive_reopen(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        Reopening an existing store must apply the configured block cache and
+        bloom filter to the ALREADY-EXISTING column families, not just to the
+        ones created during this open.
+
+        rocksdict takes per-CF table options from its ``column_families``
+        mapping; when the argument is omitted, existing CFs are opened with
+        rocksdict's defaults (8 MiB cache, no filter policy) and every
+        ``RocksDBOptions`` tuning is silently discarded on every restart.
+
+        Asserted against RocksDB's own ``LOG``, which prints the effective
+        per-CF table options at open. RocksDB rotates ``LOG`` to
+        ``LOG.old.<ts>`` on each open, so after the reopen ``LOG`` describes
+        the reopen alone.
+        """
+        cache_size = 96 * 1024 * 1024
+        options = RocksDBOptions(
+            block_cache_size=cache_size, bloom_filter_bits_per_key=10
+        )
+
+        partition = store_partition_factory("db", options=options)
+        cf_names = partition.list_column_families()
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        # Every CF now pre-exists, so this open exercises the reopen path only.
+        partition = store_partition_factory("db", options=options)
+        partition.close()
+
+        log = (tmp_path / "db" / "LOG").read_text()
+        capacities = [int(c) for c in re.findall(r"capacity\s*:\s*(\d+)", log)]
+        filter_policies = set(re.findall(r"filter_policy:\s*(\S+)", log))
+
+        # One block-cache line per CF, all at the configured size.
+        assert len(capacities) >= len(cf_names)
+        assert set(capacities) == {cache_size}
+        assert filter_policies == {"bloomfilter"}
 
     def test_get_or_create_column_family(self, store_partition: RocksDBStorePartition):
         assert store_partition.get_or_create_column_family("cf")

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -162,13 +162,23 @@ class TestRocksDBStorePartition:
         partition.close()
 
         log = (tmp_path / "db" / "LOG").read_text()
-        capacities = [int(c) for c in re.findall(r"capacity\s*:\s*(\d+)", log)]
+        # Require whitespace around the colon: that is the block-cache line in
+        # the block_based_table_factory section. An unrelated "capacity: 128"
+        # (no leading space) appears elsewhere in RocksDB's log.
+        capacities = [int(c) for c in re.findall(r"capacity\s+:\s+(\d+)", log)]
         filter_policies = set(re.findall(r"filter_policy:\s*(\S+)", log))
+        cache_ids = set(re.findall(r"block_cache:\s*(\w+)", log))
 
         # One block-cache line per CF, all at the configured size.
         assert len(capacities) >= len(cf_names)
         assert set(capacities) == {cache_size}
         assert filter_policies == {"bloomfilter"}
+        # All CFs must share ONE cache instance, not one each of the same size:
+        # the difference between a 96 MiB ceiling and len(cf_names) x 96 MiB.
+        # `to_options()` builds a single `Cache` and every CF is handed that same
+        # options object, so a refactor to per-CF options would still satisfy the
+        # assertions above while multiplying the real memory ceiling.
+        assert len(cache_ids - {"0"}) == 1
 
     def test_get_or_create_column_family(self, store_partition: RocksDBStorePartition):
         assert store_partition.get_or_create_column_family("cf")

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -219,43 +219,53 @@ class TestRocksDBStorePartition:
             f"block_cache_size is a per-partition multiplier"
         )
 
-    def test_open_survives_transient_cf_listing_failure(
-        self, store_partition_factory, tmp_path, caplog
+    def test_listing_failure_on_existing_store_is_retried_not_degraded(
+        self, store_partition_factory, tmp_path
     ):
         """
-        Failing to LIST the column families must not turn into a fatal open.
+        A store that exists must never be opened without its column families.
 
-        Passing ``column_families={}`` is NOT equivalent to omitting the
-        argument: on a store that already holds CFs an empty map raises
-        ``Invalid argument: Column families not opened: __metadata__``. That
-        message starts with neither "Corruption" nor "io error", so it matches
-        no recovery path and escapes as a fatal assignment error -- turning a
-        transient listing failure into a crash loop on a store that opens fine
-        without the argument.
+        Opening without them lets rocksdict derive the CFs from the persisted
+        OPTIONS file and apply its OWN defaults -- an 8 MiB block cache and no
+        bloom filters on every existing CF, for the life of the process. That is
+        the original bug, and it is invisible once the open succeeds, so a listing
+        failure must be propagated for the existing retry budget to handle rather
+        than papered over with a degraded open.
         """
-        partition = store_partition_factory("db")
+        cache_size = 96 * 1024 * 1024
+        options = RocksDBOptions(
+            block_cache_size=cache_size,
+            bloom_filter_bits_per_key=10,
+            open_max_retries=2,
+            open_retry_backoff=0.0,
+        )
+        partition = store_partition_factory("db", options=options)
         with partition.begin() as tx:
             tx.set("key", "value", prefix=b"__key__")
         partition.close()
 
-        # The store now has more than the default CF, so an empty map is fatal.
-        with caplog.at_level("WARNING"):
-            with patch.object(
-                Rdict, "list_cf", side_effect=Exception("IO error: transient")
-            ):
-                reopened = store_partition_factory("db")
+        real_list_cf = Rdict.list_cf
+        calls = []
+
+        def _fails_once(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                raise Exception("IO error: transient")
+            return real_list_cf(path, *args, **kwargs)
+
+        with patch.object(Rdict, "list_cf", staticmethod(_fails_once)):
+            reopened = store_partition_factory("db", options=options)
         try:
-            # Opening is not enough: the store must be usable, and the operator
-            # must be told the configured options missed its existing CFs.
             with reopened.begin() as tx:
                 assert tx.get("key", prefix=b"__key__") == "value"
-            assert any(
-                "Could not list the column families" in r.message
-                and r.levelname == "WARNING"
-                for r in caplog.records
-            )
         finally:
             reopened.close()
+
+        # The point of the retry: the store came up with its configured options,
+        # not rocksdict's 8 MiB default.
+        log = (tmp_path / "db" / "LOG").read_text(encoding="utf-8", errors="replace")
+        assert set(re.findall(r"capacity\s+:\s+(\d+)", log)) == {str(cache_size)}
+        assert set(re.findall(r"filter_policy:\s*(\S+)", log)) == {"bloomfilter"}
 
     def test_reopen_applies_new_options_to_persisted_column_families(
         self, store_partition_factory, tmp_path
@@ -318,8 +328,14 @@ class TestRocksDBStorePartition:
                 raise Exception("IO error: transient")
             return real_list_cf(path, *args, **kwargs)
 
+        # Retries enabled: a listing failure on an existing store propagates so
+        # this budget can absorb it, rather than being papered over with a
+        # degraded open.
         with patch.object(Rdict, "list_cf", staticmethod(_fails_once)):
-            reopened = store_partition_factory("db")
+            reopened = store_partition_factory(
+                "db",
+                options=RocksDBOptions(open_max_retries=2, open_retry_backoff=0.0),
+            )
         try:
             assert len(calls) == 2, "the failed listing should have been retried"
             with reopened.begin() as tx:
@@ -331,14 +347,15 @@ class TestRocksDBStorePartition:
         self, store_partition_factory, tmp_path
     ):
         """
-        When the retry cannot list the column families either, fail — never open
-        without them.
+        A persistently unlistable store must fail, never open degraded.
 
-        An argument-less open of a store that HAS column families is exactly the
-        silent 8 MiB / no-bloom-filter degradation this change removes, so it must
-        not be used as a fallback. Pins the refusal: an `or`-instead-of-`raise`
-        slip here would turn a loud failure into a store quietly serving traffic
-        in the state the bug used to produce.
+        An argument-less open of a store that HAS column families succeeds while
+        applying rocksdict's 8 MiB / no-bloom-filter defaults to every one of
+        them — the original bug, invisible once the open returns. So when the
+        listing cannot be obtained, the open must fail rather than fall back to
+        it. A slip that reinstated that fallback would leave a store quietly
+        serving traffic with its configured cache and filters dropped, and the
+        only way to notice is that this test stops raising.
         """
         partition = store_partition_factory("db")
         with partition.begin() as tx:
@@ -347,19 +364,19 @@ class TestRocksDBStorePartition:
 
         calls = []
 
-        def _short_then_unlistable(path, *args, **kwargs):
+        def _never_lists(path, *args, **kwargs):
             calls.append(path)
-            if len(calls) == 1:
-                # A list this store will not open with -> triggers the retry.
-                return ["default"]
-            raise Exception("IO error: transient")
+            raise Exception("IO error: persistent")
 
-        with patch.object(Rdict, "list_cf", staticmethod(_short_then_unlistable)):
-            with pytest.raises(Exception, match="Column families not opened"):
+        with patch.object(Rdict, "list_cf", staticmethod(_never_lists)):
+            with pytest.raises(Exception, match="IO error: persistent"):
                 store_partition_factory(
-                    "db", options=RocksDBOptions(open_max_retries=0)
+                    "db",
+                    options=RocksDBOptions(open_max_retries=2, open_retry_backoff=0.0),
                 )
-        assert len(calls) == 2, "the list should have been re-read exactly once"
+        # Every attempt tried to list, and none resorted to opening without the
+        # column families.
+        assert len(calls) == 2
 
     def test_open_retries_a_stale_column_family_list(
         self, store_partition_factory, tmp_path

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -257,6 +257,76 @@ class TestRocksDBStorePartition:
         finally:
             reopened.close()
 
+    def test_reopen_applies_new_options_to_persisted_column_families(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        The upgrade path: a store whose CFs were persisted under one
+        ``block_cache_size`` must adopt a different one on reopen.
+
+        This is the case where ``_open`` hands each column family options that
+        disagree with the store's own persisted OPTIONS file, and it is what an
+        operator actually does when they change the setting and restart.
+        """
+        small, large = 32 * 1024 * 1024, 96 * 1024 * 1024
+
+        partition = store_partition_factory(
+            "db", options=RocksDBOptions(block_cache_size=small)
+        )
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        reopened = store_partition_factory(
+            "db", options=RocksDBOptions(block_cache_size=large)
+        )
+        try:
+            with reopened.begin() as tx:
+                assert tx.get("key", prefix=b"__key__") == "value"
+        finally:
+            reopened.close()
+
+        log = (tmp_path / "db" / "LOG").read_text(encoding="utf-8", errors="replace")
+        assert set(re.findall(r"capacity\s+:\s+(\d+)", log)) == {str(large)}
+
+    def test_open_recovers_when_persisted_options_are_unreadable(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        A store whose persisted OPTIONS file is unreadable must still open.
+
+        Without the column-family argument rocksdict derives the CFs from that
+        file, and on failure silently sees only the default CF -- so the open
+        dies with ``Column families not opened``, which matches no recovery path.
+        Supplying the list explicitly survives it, so a listing that fails on the
+        first attempt and succeeds on the re-read must recover rather than crash.
+        """
+        partition = store_partition_factory("db")
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        for options_file in tmp_path.glob("db/OPTIONS-*"):
+            options_file.write_text("garbage")
+
+        real_list_cf = Rdict.list_cf
+        calls = []
+
+        def _fails_once(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                raise Exception("IO error: transient")
+            return real_list_cf(path, *args, **kwargs)
+
+        with patch.object(Rdict, "list_cf", staticmethod(_fails_once)):
+            reopened = store_partition_factory("db")
+        try:
+            assert len(calls) == 2, "the failed listing should have been retried"
+            with reopened.begin() as tx:
+                assert tx.get("key", prefix=b"__key__") == "value"
+        finally:
+            reopened.close()
+
     def test_open_retries_a_stale_column_family_list(
         self, store_partition_factory, tmp_path
     ):

--- a/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
+++ b/tests/test_quixstreams/test_state/test_rocksdb/test_rocksdb_partition.py
@@ -327,6 +327,40 @@ class TestRocksDBStorePartition:
         finally:
             reopened.close()
 
+    def test_open_refuses_to_fall_back_to_a_degraded_open(
+        self, store_partition_factory, tmp_path
+    ):
+        """
+        When the retry cannot list the column families either, fail — never open
+        without them.
+
+        An argument-less open of a store that HAS column families is exactly the
+        silent 8 MiB / no-bloom-filter degradation this change removes, so it must
+        not be used as a fallback. Pins the refusal: an `or`-instead-of-`raise`
+        slip here would turn a loud failure into a store quietly serving traffic
+        in the state the bug used to produce.
+        """
+        partition = store_partition_factory("db")
+        with partition.begin() as tx:
+            tx.set("key", "value", prefix=b"__key__")
+        partition.close()
+
+        calls = []
+
+        def _short_then_unlistable(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                # A list this store will not open with -> triggers the retry.
+                return ["default"]
+            raise Exception("IO error: transient")
+
+        with patch.object(Rdict, "list_cf", staticmethod(_short_then_unlistable)):
+            with pytest.raises(Exception, match="Column families not opened"):
+                store_partition_factory(
+                    "db", options=RocksDBOptions(open_max_retries=0)
+                )
+        assert len(calls) == 2, "the list should have been re-read exactly once"
+
     def test_open_retries_a_stale_column_family_list(
         self, store_partition_factory, tmp_path
     ):


### PR DESCRIPTION
`_open_rocksdict` opened the store without `column_families=`, so rocksdict applied the supplied options only to the column families it created. On every reopen of an existing store all pre-existing CFs fell back to rocksdict's default `BlockBasedTableOptions`: the configured 128 MB block cache reverted to 8 MB and the bloom filter was dropped entirely. Only the very first run — when the store is created — honoured these settings; every restart after that ran degraded, permanently, with no application-side workaround since the options object is discarded whatever it contains.

Reproduces with a single default CF, so it is not specific to TTL or multi-CF stores: it affects any quixstreams store that has ever been restarted.

DB-level options (write buffer size, compression, max total WAL size) do survive, which is why the RocksDB LOG looks correctly configured unless the table factory is inspected specifically.

## ⚠️ Release note — memory behaviour changes

**`block_cache_size` is now an aggregate ceiling for the whole process, and its default moves 128 MiB → 1 GiB.**

Previously `to_options()` minted a fresh `Cache` per `RocksDBStorePartition`, so the setting was a per-partition multiplier — a 32-partition, 3-store application reserved 96× the configured size. Restoring the configured capacity to existing column families (the fix above) would have turned a previously-masked ~768 MiB footprint into a ~12 GiB ceiling, charged lazily as blocks are read, i.e. surfacing as an OOM hours after an upgrade rather than at startup.

One cache per capacity is now shared process-wide, which is RocksDB's own guidance for multiple databases:

| | before this PR (effective) | after |
|---|---|---|
| 1 store partition | 8 MiB | up to 1 GiB, shared |
| 96 store partitions | 96 × 8 MiB ≈ 768 MiB | up to 1 GiB, shared |

The default had to move with the semantics: keeping 128 MiB would leave a 96-partition deployment with ~1.3 MiB each, **worse than the 8 MiB it was unknowingly running with**. A cache is a lazily-filled ceiling, not an allocation, so small deployments never realize the new default.

**Two things operators should know:**

1. Total cache memory is now bounded by one number regardless of partition count — size it against total available memory, not per store.
2. Index and bloom-filter blocks are held **outside** this budget (`cache_index_and_filter_blocks` is not enabled and `max_open_files` is `-1`, so every SST's filter stays pinned). Real usage is `block_cache_size` plus roughly `bloom_filter_bits_per_key / 8` bytes per key — a term that did not exist before, because there were no filters.

## Why it matters

Without bloom filters every point lookup that misses has to probe the SSTs instead of being rejected by a filter. The TTL sweep is the worst case: it issues a default-CF `get()` per index entry on every flush, and the ghost-index refresh adds another point-get per `set(..., ttl=)` whose cost is justified on the assumption that new keys are bloom-filter negatives and hot keys are block-cache hits — both of which this bug invalidated.

Reported from a production deployment whose ~8 GB dedup store on network-backed storage saturated the volume's read throughput for ~25 hours at a stretch, with `filter_policy: nullptr` and `capacity: 8388608` on every CF.

## The fix

Existing CFs are listed via `Rdict.list_cf` and handed the same options object, so every CF of a partition shares the one configured `Cache`.

`column_families={}` is **not** equivalent to omitting the argument — against a store that holds CFs an empty map raises `Invalid argument: Column families not opened: <cf>`, which matches neither the corruption nor the io-error retry path. Two routes reach that message and both are handled:

- **The listing fails** (no database yet, or a transient fault) → `None` is returned and the argument is omitted, which is the pre-existing open. Note this is not a safe fallback in general: rocksdict then derives the CFs from the persisted OPTIONS file, and if *that* read fails it silently sees only the default CF.
- **The listing succeeds but the store will not open with it** — either a stale list (`list_cf` takes no LOCK and CFs are created lazily, so a peer can add one inside the window) or an unreadable OPTIONS file.

Either way the list is re-read **once**. If that read fails, or still yields a list the store will not open with, the error **propagates**: the only remaining move would be an argument-less open, and on a store that has column families that is precisely the silent 8 MiB / no-bloom-filter degradation this change exists to remove. Failing loudly on a store we cannot open correctly beats serving it in the state the bug used to produce.

## Verified

- Red-first test: fails on `main` with `{8388608} == {100663296}`, passes here. Asserts the effective per-CF block cache and filter policy from RocksDB's own LOG, and that all CFs share one cache instance — the last of these red-proven by mutating the fix to build fresh options per CF, where the capacity and filter assertions both still pass and only the sharing assertion catches it.
- Both failure modes above have their own red-first tests.
- 358 state tests pass; `pre-commit run --all-files` (ruff 0.6.3, ruff-format, mypy) clean.
- **A/B in Quix Cloud**, two code-identical dedup deployments differing only in the quixstreams pin, same input topic and load, both having genuinely reopened a persisted store:

```
v3.25.0     cap=8388608    filter=nullptr       DEGRADED
this branch cap=33554432   filter=bloomfilter   OK
```

## Note on the corruption fixture

It created its DB with a bare `Rdict(path=...)` (`raw_mode=False`). Per-CF options make the comparator part of the open contract, so such a store now fails on the comparator before the corruption is ever reached, and the fixture was changed to build its store the way quixstreams does. To be explicit: that store opens fine on `main` — it became unopenable because of this PR. No quixstreams deployment can produce one, since `to_options()` always sets `raw_mode=True`.

A related consequence is unhandled by design: a store whose CFs carry genuinely foreign options stays unopenable, and the error is not translated into `RocksDBCorruptedError`, so `on_corrupted_recreate` cannot self-heal it. Widening the corruption classification would mean auto-destroying stores that are merely incompatible, which is a deliberate decision left out of this PR.

Closes #1136
