### PR TITLE
updated confluent-kafka version to be <=2.13.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-confluent-kafka[avro,json,protobuf,schemaregistry]>=2.8.2,<2.12
+confluent-kafka[avro,json,protobuf,schemaregistry]>=2.8.2,<=2.13.2
 rocksdict>=0.3,<0.4
 typing_extensions>=4.8
 orjson>=3.9,<4


### PR DESCRIPTION
## Description

Update the Kafka client dependency used by Quix Streams to confluent-kafka<=2.13.2 in requirements.txt.

This is needed for compatibility with downstream services that require confluent-kafka 2.13.2. Aligning Quix Streams with that version will avoid dependency resolver conflicts and keep builds reproducible.

## Requested Change
Update the Quix Streams dependency declarations for confluent-kafka and confluent-kafka[avro] to support version 2.13.2.

## Issue

https://github.com/quixio/quix-streams/issues/1139