### PR TITLE
RecoveryManager: survive a rebalance during changelog recovery without losing messages (sc-74868)

### DIFF
--- a/quixstreams/app.py
+++ b/quixstreams/app.py
@@ -1197,6 +1197,13 @@ class Application:
             tp for tp in topic_partitions if tp.topic not in non_changelog_topics
         ]
         self._consumer.pause(changelog_tps)
+        # The `assign()` above also resets the paused state of the data partitions.
+        # When this callback fires from the `poll()` inside a running recovery loop,
+        # those partitions must go back to paused before anything else runs, or the
+        # recovery loop starts fetching source messages it cannot process. Covers
+        # partitions that never reach `RecoveryManager.assign_partition` because
+        # they have no stateful store. No-op outside an active recovery.
+        self._state_manager.pause_assigned_data_partitions(topic_partitions)
 
         if self._state_manager.stores:
             non_changelog_tps = [

--- a/quixstreams/state/manager.py
+++ b/quixstreams/state/manager.py
@@ -364,6 +364,19 @@ class StateStoreManager:
         if self._recovery_manager:
             self._recovery_manager.resume_reassigned_data_partitions(partitions)
 
+    def pause_assigned_data_partitions(
+        self, partitions: List[ConfluentPartition]
+    ) -> None:
+        """
+        Pause the data partitions of a fresh assignment while recovery is running.
+
+        Delegates to the RecoveryManager; no-op when state recovery is not enabled
+        or no recovery loop is running.
+        See `RecoveryManager.pause_assigned_data_partitions`.
+        """
+        if self._recovery_manager:
+            self._recovery_manager.pause_assigned_data_partitions(partitions)
+
     def on_partition_revoke(
         self,
         stream_id: str,

--- a/quixstreams/state/recovery.py
+++ b/quixstreams/state/recovery.py
@@ -486,6 +486,9 @@ class RecoveryManager:
         # Cache position results to avoid double calls in same iteration
         self._position_cache: Dict[str, Tuple[float, ConfluentPartition]] = {}
         self._recovery_paused_data_tps: set[tuple[str, int]] = set()
+        # Data topic-partitions the recovery loop had to rewind because they were
+        # fetching while recovery was running. Reset by every `do_recovery` call.
+        self._recovery_rewound_data_tps: set[tuple[str, int]] = set()
 
     @property
     def partitions(self) -> Dict[int, Dict[str, RecoveryPartition]]:
@@ -540,6 +543,7 @@ class RecoveryManager:
         """
         logger.info("Beginning recovery check...")
         self._running = True
+        self._recovery_rewound_data_tps.clear()
 
         # Seek the changelog partitions to the previously saved position and resume
         # them. Partitions added later by a rebalance are primed the same way by
@@ -647,12 +651,47 @@ class RecoveryManager:
         in which case `assign_partition` never runs and the partition would stay
         paused indefinitely. Application calls this on every assignment to cover it.
 
-        Skipped while a recovery is pending/active (`has_assignments`): those pauses
-        are intentional and get resumed by `do_recovery`/`assign_partition`.
+        Skipped while a recovery is pending (`has_assignments`) or running
+        (`self._running`): those pauses are intentional and get resumed by
+        `do_recovery`/`assign_partition`. The `self._running` half matters when a
+        rebalance revokes the last recovering partition, which empties
+        `_recovery_partitions` while the loop is still on its way out.
         """
-        if not self._recovery_paused_data_tps or self.has_assignments:
+        if not self._recovery_paused_data_tps or self.has_assignments or self._running:
             return
         self._resume_recovery_paused_data_partitions(partitions)
+
+    def pause_assigned_data_partitions(
+        self, partitions: List[ConfluentPartition]
+    ) -> None:
+        """
+        Pause the data partitions of a fresh assignment while recovery is running.
+
+        `Consumer.assign()` resets the paused state of every partition in the new
+        assignment, so a rebalance landing mid-recovery (this runs from the
+        assignment callback fired inside `_recovery_loop`'s `poll`) un-pauses the
+        data partitions recovery paused. Any of them would then feed source-topic
+        messages into the recovery loop. Partitions with no stateful store never
+        reach `assign_partition`, so that is not enough to re-pause them.
+
+        No-op unless a recovery loop is running; `do_recovery` resumes every
+        non-changelog partition of the assignment when the loop finishes.
+
+        :param partitions: the topic partitions just assigned to the consumer
+        """
+        if not self._running:
+            return
+
+        non_changelog_topics = self._topic_manager.non_changelog_topics
+        to_pause = [tp for tp in partitions if tp.topic in non_changelog_topics]
+        if not to_pause:
+            return
+
+        logger.debug(
+            f"Pausing data partitions assigned during recovery: "
+            f"{[(tp.topic, tp.partition) for tp in to_pause]}"
+        )
+        self._pause_for_recovery(to_pause)
 
     def _generate_recovery_partitions(
         self,
@@ -701,8 +740,10 @@ class RecoveryManager:
 
         When a rebalance calls this while a recovery is already running, the newly
         added changelog partitions are also seeked+resumed so the running recovery
-        loop can consume them, and data partitions paused for recovery stay paused
-        (`do_recovery` resumes them once the loop finishes).
+        loop can consume them, every assigned data partition is (re-)paused
+        regardless of whether this call produced a `RecoveryPartition`, and data
+        partitions paused for recovery stay paused (`do_recovery` resumes them
+        once the loop finishes).
         """
         recovery_partitions = self._generate_recovery_partitions(
             topic_name=topic,
@@ -755,29 +796,34 @@ class RecoveryManager:
                 added_partitions.append(rp)
 
         # Figure out if we need to pause any topic partitions
-        if self._recovery_partitions:
-            if self._running:
-                # Some partitions are already recovering,
-                # pausing only the source topic partition
-                self._pause_for_recovery(
-                    [ConfluentPartition(topic=topic, partition=partition)]
-                )
-                # The running loop is already past `do_recovery`'s seek+resume
-                # block, so prime the changelog partitions added just now here.
-                for rp in added_partitions:
-                    self._prime_changelog_partition(rp)
-            else:
-                # Recovery hasn't started yet, so pause ALL partitions
-                # and wait for Application to start recovery
-                self._pause_for_recovery(self._consumer.assignment())
-        elif not self._running:
+        if self._running:
+            # Some partitions are already recovering: pause the source topic
+            # partition being assigned, and then every other assigned data
+            # partition, because the `Consumer.assign()` that preceded this
+            # callback reset the paused state of the whole new assignment. This
+            # runs whether or not this call produced a `RecoveryPartition`: a
+            # stateless partition assigned mid-recovery must wait for recovery
+            # like every other data partition.
+            self._pause_for_recovery(
+                [ConfluentPartition(topic=topic, partition=partition)]
+            )
+            self.pause_assigned_data_partitions(current_assignment)
+            # The running loop is already past `do_recovery`'s seek+resume
+            # block, so prime the changelog partitions added just now here.
+            for rp in added_partitions:
+                self._prime_changelog_partition(rp)
+        elif self._recovery_partitions:
+            # Recovery hasn't started yet, so pause ALL partitions
+            # and wait for Application to start recovery
+            self._pause_for_recovery(self._consumer.assignment())
+        else:
             # Nothing to recover here and no recovery in progress: release data
-            # partitions still paused by an earlier recovery generation.
-            # While `self._running` is True those pauses must stay: during an eager
-            # rebalance `_recovery_partitions` is momentarily empty between the
-            # revoke and the reassign of the same stateful partition, and resuming
-            # a data partition then would feed the still-running recovery loop
-            # source-topic messages. `do_recovery` resumes them when it finishes.
+            # partitions still paused by an earlier recovery generation. Reached
+            # only when `self._running` is False, so a recovery-paused partition
+            # can never be resumed under a running loop — during an eager rebalance
+            # `_recovery_partitions` is momentarily empty between the revoke and the
+            # reassign of the same stateful partition, and resuming a data partition
+            # then would feed the loop source-topic messages.
             self._resume_recovery_paused_data_partitions(current_assignment)
 
     def _revoke_recovery_partitions(self, recovery_partitions: List[RecoveryPartition]):
@@ -852,10 +898,12 @@ class RecoveryManager:
 
         A RecoveryPartition is unassigned immediately once fully updated.
 
-        A polled message may not belong to any tracked `RecoveryPartition`: after a
-        rebalance the consumer can still deliver the tail of a revoked changelog
-        partition, or a message from a data partition the `Application` resumed.
-        Such messages are dropped instead of raising.
+        A polled message may not belong to any tracked `RecoveryPartition`. A
+        message from a changelog partition no longer under recovery (the tail of a
+        partition revoked by a rebalance) is dropped: its state is gone. A message
+        from a data topic means a pause gap, and is rewound rather than dropped
+        (see `_rewind_data_partition`), because dropping it would lose it for the
+        whole session.
         """
         while self.recovering:
             self._log_recovery_progress()
@@ -864,18 +912,61 @@ class RecoveryManager:
             else:
                 msg = raise_for_msg_error(msg)
                 changelogs = self._recovery_partitions.get(msg.partition(), {})
-                if (rp := changelogs.get(msg.topic())) is None:
+                if (rp := changelogs.get(msg.topic())) is not None:
+                    rp.recover_from_changelog_message(changelog_message=msg)
+                elif msg.topic() in self._topic_manager.non_changelog_topics:
+                    self._rewind_data_partition(msg)
+                else:
                     logger.debug(
                         f'Skipping a message for "{msg.topic()}[{msg.partition()}]" '
                         f"at offset {msg.offset()}: not under recovery"
                     )
-                else:
-                    rp.recover_from_changelog_message(changelog_message=msg)
                 self._consumer._broker_available()  # noqa: SLF001
             if self._broker_availability_timeout:
                 self._consumer.raise_if_broker_unavailable(
                     self._broker_availability_timeout
                 )
+
+    def _rewind_data_partition(self, msg: SuccessfulConfluentKafkaMessageProto) -> None:
+        """
+        Pause a data partition the recovery loop should never have polled and rewind
+        it so the delivered message is read again after recovery.
+
+        The recovery loop only ever consumes changelog partitions, so a data-topic
+        message proves the partition escaped its recovery pause: the consumer-side
+        `assign()` of a rebalance resets the paused state of the whole new
+        assignment. Dropping the message loses it for the rest of the session: it is
+        never processed, yet the consumer position has moved past it and only the
+        pre-rebalance committed offset would bring it back. Pausing and seeking back
+        to `msg.offset()` makes it the next message read once `do_recovery` resumes
+        the partition.
+
+        Only the first message per topic-partition is acted on. Messages are
+        delivered in offset order per partition, so the first one seen is the
+        earliest; seeking again for a later message would skip the earlier rewind
+        target. Later messages are dropped, and re-read after the rewind.
+
+        :param msg: a message polled by the recovery loop from a data topic
+        """
+        topic, partition = msg.topic(), msg.partition()
+        if (topic, partition) in self._recovery_rewound_data_tps:
+            logger.debug(
+                f'Dropping a message for "{topic}[{partition}]" at offset '
+                f"{msg.offset()}: partition already rewound for recovery"
+            )
+            return
+
+        self._recovery_rewound_data_tps.add((topic, partition))
+        self._pause_for_recovery([ConfluentPartition(topic=topic, partition=partition)])
+        self._consumer.seek(
+            ConfluentPartition(topic=topic, partition=partition, offset=msg.offset())
+        )
+        logger.warning(
+            f'Data partition "{topic}[{partition}]" was consumed by the recovery '
+            f"loop; it is now paused and rewound to offset {msg.offset()} so no "
+            f"message is lost. This means the partition escaped its recovery pause, "
+            f"most likely a rebalance re-assigning it while recovery was running."
+        )
 
     def _get_position_with_cache(self, rp: RecoveryPartition) -> ConfluentPartition:
         """

--- a/quixstreams/state/recovery.py
+++ b/quixstreams/state/recovery.py
@@ -540,21 +540,12 @@ class RecoveryManager:
         """
         logger.info("Beginning recovery check...")
         self._running = True
-        # note: technically it should be rp.offset + 1, but to remain backwards
-        # compatible with <v2.7 +1 ALOS offsetting, it remains rp.offset.
-        # This means we will always re-write the "first" recovery message.
-        # More specifically, this is only covering for a very edge case:
-        # when first upgrading from <v2.7 AND a recovery was actually needed.
-        # Once on >=v2.7, this is no longer an issue...so we could eventually
-        # remove this, potentially.
 
-        # Seek the changelog partitions to the previously saved position and resume them
+        # Seek the changelog partitions to the previously saved position and resume
+        # them. Partitions added later by a rebalance are primed the same way by
+        # `assign_partition` while the loop below is running.
         for rp in dict_values(self._recovery_partitions):
-            tp = ConfluentPartition(
-                topic=rp.changelog_name, partition=rp.partition_num, offset=rp.offset
-            )
-            self._consumer.seek(tp)
-            self._consumer.resume([tp])
+            self._prime_changelog_partition(rp)
 
         self._recovery_loop()
         if self._running:
@@ -571,6 +562,34 @@ class RecoveryManager:
             self._forget_recovery_paused_data_partitions(non_changelog_tps)
         else:
             logger.debug("Recovery process interrupted; stopping.")
+
+    def _prime_changelog_partition(self, rp: RecoveryPartition) -> None:
+        """
+        Seek a `RecoveryPartition`'s changelog partition to its saved position and
+        resume consuming it, making it readable by the recovery loop.
+
+        Called by `do_recovery` for the partitions known when recovery starts, and
+        by `assign_partition` for partitions a rebalance adds while the loop is
+        already running. A changelog partition that is never seeked keeps an
+        OFFSET_INVALID (-1001) consumer position, which `_get_changelog_offset`
+        eventually turns into a "Recovery stuck" RuntimeError once
+        MAX_INVALID_OFFSET_ATTEMPTS is exceeded.
+
+        Note: technically it should be rp.offset + 1, but to remain backwards
+        compatible with <v2.7 +1 ALOS offsetting, it remains rp.offset.
+        This means we will always re-write the "first" recovery message.
+        More specifically, this is only covering for a very edge case:
+        when first upgrading from <v2.7 AND a recovery was actually needed.
+        Once on >=v2.7, this is no longer an issue...so we could eventually
+        remove this, potentially.
+
+        :param rp: the `RecoveryPartition` whose changelog partition to prime
+        """
+        tp = ConfluentPartition(
+            topic=rp.changelog_name, partition=rp.partition_num, offset=rp.offset
+        )
+        self._consumer.seek(tp)
+        self._consumer.resume([tp])
 
     def _pause_for_recovery(self, partitions: List[ConfluentPartition]) -> None:
         self._track_recovery_paused_data_partitions(partitions)
@@ -679,6 +698,11 @@ class RecoveryManager:
         Assigns `StorePartition`s (as `RecoveryPartition`s) ONLY IF recovery required.
 
         Pauses active consumer partitions as needed.
+
+        When a rebalance calls this while a recovery is already running, the newly
+        added changelog partitions are also seeked+resumed so the running recovery
+        loop can consume them, and data partitions paused for recovery stay paused
+        (`do_recovery` resumes them once the loop finishes).
         """
         recovery_partitions = self._generate_recovery_partitions(
             topic_name=topic,
@@ -690,6 +714,7 @@ class RecoveryManager:
         current_assignment = self._consumer.assignment()
         assigned_tps = set((tp.topic, tp.partition) for tp in current_assignment)
 
+        added_partitions: List[RecoveryPartition] = []
         for rp in recovery_partitions:
             changelog_name, partition = rp.changelog_name, rp.partition_num
             # Validate that the changelog topic-partition is assigned to consumer before
@@ -727,6 +752,7 @@ class RecoveryManager:
             elif rp.needs_recovery_check:
                 logger.debug(f"Adding a recovery check for {rp}")
                 self._recovery_partitions.setdefault(partition, {})[changelog_name] = rp
+                added_partitions.append(rp)
 
         # Figure out if we need to pause any topic partitions
         if self._recovery_partitions:
@@ -736,11 +762,22 @@ class RecoveryManager:
                 self._pause_for_recovery(
                     [ConfluentPartition(topic=topic, partition=partition)]
                 )
+                # The running loop is already past `do_recovery`'s seek+resume
+                # block, so prime the changelog partitions added just now here.
+                for rp in added_partitions:
+                    self._prime_changelog_partition(rp)
             else:
                 # Recovery hasn't started yet, so pause ALL partitions
                 # and wait for Application to start recovery
                 self._pause_for_recovery(self._consumer.assignment())
-        else:
+        elif not self._running:
+            # Nothing to recover here and no recovery in progress: release data
+            # partitions still paused by an earlier recovery generation.
+            # While `self._running` is True those pauses must stay: during an eager
+            # rebalance `_recovery_partitions` is momentarily empty between the
+            # revoke and the reassign of the same stateful partition, and resuming
+            # a data partition then would feed the still-running recovery loop
+            # source-topic messages. `do_recovery` resumes them when it finishes.
             self._resume_recovery_paused_data_partitions(current_assignment)
 
     def _revoke_recovery_partitions(self, recovery_partitions: List[RecoveryPartition]):
@@ -814,6 +851,11 @@ class RecoveryManager:
         messages until recovery is "complete" (i.e. no assigned `RecoveryPartition`s).
 
         A RecoveryPartition is unassigned immediately once fully updated.
+
+        A polled message may not belong to any tracked `RecoveryPartition`: after a
+        rebalance the consumer can still deliver the tail of a revoked changelog
+        partition, or a message from a data partition the `Application` resumed.
+        Such messages are dropped instead of raising.
         """
         while self.recovering:
             self._log_recovery_progress()
@@ -821,8 +863,14 @@ class RecoveryManager:
                 self._update_recovery_status()
             else:
                 msg = raise_for_msg_error(msg)
-                rp = self._recovery_partitions[msg.partition()][msg.topic()]
-                rp.recover_from_changelog_message(changelog_message=msg)
+                changelogs = self._recovery_partitions.get(msg.partition(), {})
+                if (rp := changelogs.get(msg.topic())) is None:
+                    logger.debug(
+                        f'Skipping a message for "{msg.topic()}[{msg.partition()}]" '
+                        f"at offset {msg.offset()}: not under recovery"
+                    )
+                else:
+                    rp.recover_from_changelog_message(changelog_message=msg)
                 self._consumer._broker_available()  # noqa: SLF001
             if self._broker_availability_timeout:
                 self._consumer.raise_if_broker_unavailable(

--- a/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
+++ b/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from unittest.mock import MagicMock, patch
 
@@ -342,6 +343,197 @@ class TestRecoveryRebalanceMidRecovery:
             "a stateless assign during a rebalance resumes recovery-paused "
             "data partitions while recovery is still running; the recovery "
             "loop then polls source-topic messages and crashes with KeyError"
+        )
+
+    def test_stateless_data_partition_assigned_mid_recovery_is_paused(self):
+        """
+        Round 2: ``Consumer.assign()`` (app.py ``_assign_partitions``,
+        called on every rebalance) resets the paused state of every
+        partition in the new assignment, including data partitions
+        RecoveryManager had paused for an in-progress recovery.
+        ``StateStoreManager.on_partition_assign`` (manager.py:346) only
+        calls ``RecoveryManager.assign_partition`` when the rebalance
+        brings a stateful store partition (``if ... and store_partitions``),
+        so a stateless source topic (e.g. "raw-events") reassigned
+        mid-recovery never reaches ``assign_partition`` and cannot be
+        re-paused there -- ``pause_assigned_data_partitions`` is the only
+        path that can catch it. Live evidence: build 3aa382e5, 2026-09-07
+        11:43Z -- replica 1 logged 7,469 consecutive "Skipping a message
+        ... not under recovery" lines for "raw-events[2]", offsets
+        384389-391856: those source messages were consumed by the recovery
+        loop and never processed.
+        """
+        stateless_topic_name = f"raw-events-{uuid.uuid4()}"
+        stateful_stream_id = f"repartition-{uuid.uuid4()}"
+        store_name = "default"
+        highwater = 10
+
+        topic_manager, stateful_topic, changelog_topic = _build_recovery_topics(
+            stateful_stream_id, store_name, num_partitions=1
+        )
+        stateless_topic = _add_stateless_topic(topic_manager, stateless_topic_name)
+
+        stateless_tp0 = TopicPartition(stateless_topic.name, 0)
+        stateful_tp0 = TopicPartition(stateful_topic.name, 0)
+        changelog_tp0 = TopicPartition(changelog_topic.name, 0)
+
+        consumer = MagicMock(spec_set=Consumer)
+        consumer.assignment.return_value = [stateless_tp0, stateful_tp0, changelog_tp0]
+        consumer.get_watermark_offsets.return_value = (0, highwater)
+        consumer.poll.return_value = None
+        consumer.position.return_value = [
+            TopicPartition(changelog_topic.name, 0, highwater)
+        ]
+
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+
+        # Recovery starts for the stateful partition: pauses the whole
+        # current assignment (both data tps + the changelog).
+        recovery_manager.assign_partition(
+            topic=stateful_stream_id,
+            partition=0,
+            committed_offsets={stateful_stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+        assert (stateless_topic.name, 0) in recovery_manager._recovery_paused_data_tps
+
+        # See Bug A test docstring: sets the "recovery already running"
+        # state directly instead of driving `do_recovery`'s blocking loop.
+        recovery_manager._running = True
+        assert recovery_manager.recovering
+
+        consumer.pause.reset_mock()
+
+        # This is what `Application._assign_partitions` must call,
+        # unconditionally, right after `consumer.assign()` resets every
+        # assigned partition's paused state -- including the stateless
+        # source topic, which never reaches `assign_partition` because it
+        # brings no store partitions.
+        recovery_manager.pause_assigned_data_partitions(
+            [stateless_tp0, stateful_tp0, changelog_tp0]
+        )
+
+        paused_tps = {
+            tp for call in consumer.pause.call_args_list for tp in call.args[0]
+        }
+        assert stateless_tp0 in paused_tps, (
+            "a data partition with no stateful store, assigned mid-recovery, "
+            "is never re-paused after Consumer.assign() reset it; the "
+            "recovery loop then consumes and silently drops its messages"
+        )
+        assert (stateless_topic.name, 0) in recovery_manager._recovery_paused_data_tps
+
+        # `do_recovery`'s completion resumes every non-changelog tp of the
+        # (post-rebalance) assignment -- must include the stateless tp.
+        recovery_manager.do_recovery()
+
+        resume_calls = [c.args[0] for c in consumer.resume.call_args_list]
+        assert stateless_tp0 in resume_calls[-1], (
+            "recovery completion does not resume the stateless data "
+            "partition it paused mid-recovery"
+        )
+        assert (
+            stateless_topic.name,
+            0,
+        ) not in recovery_manager._recovery_paused_data_tps
+
+    def test_recovery_loop_rewinds_data_message_instead_of_skipping(self, caplog):
+        """
+        Round 2: validates that `_recovery_loop` (recovery.py:894) must not
+        silently drop a message polled from a data (non-changelog) topic --
+        doing so loses the message for the rest of the session, since the
+        consumer position has already moved past it and only the
+        pre-rebalance committed offset would bring it back. It must instead
+        pause the partition and rewind (`seek`) it back to the message's own
+        offset, so `do_recovery`'s completion re-reads it. Live evidence:
+        build 3aa382e5, 2026-09-07 11:43Z, replica 1: 7,469 consecutive
+        "Skipping a message ... not under recovery" lines for
+        "raw-events[2]", offsets 384389-391856 -- silent data loss that
+        round 1's fix (a bare drop) introduced.
+        """
+        source_topic_name = f"raw-events-{uuid.uuid4()}"
+        stream_id = str(uuid.uuid4())
+        store_name = "default"
+        highwater = 10
+        partition_num = 2
+        rewind_offset = 384389
+
+        topic_manager, data_topic, changelog_topic = _build_recovery_topics(
+            stream_id, store_name, num_partitions=1
+        )
+        source_topic = _add_stateless_topic(topic_manager, source_topic_name)
+
+        consumer = MagicMock(spec_set=Consumer)
+        changelog_tp0 = TopicPartition(changelog_topic.name, 0)
+        consumer.assignment.return_value = [
+            TopicPartition(data_topic.name, 0),
+            changelog_tp0,
+            TopicPartition(source_topic.name, partition_num),
+        ]
+        consumer.get_watermark_offsets.return_value = (0, highwater)
+
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+        store_partition = _needs_recovery_store_partition(offset=3)
+        recovery_manager.assign_partition(
+            topic=stream_id,
+            partition=0,
+            committed_offsets={stream_id: -1001},
+            store_partitions={store_name: store_partition},
+        )
+        assert recovery_manager.partitions
+
+        rewind_message = ConfluentKafkaMessageStub(
+            topic=source_topic.name, partition=partition_num, offset=rewind_offset
+        )
+        later_message_same_tp = ConfluentKafkaMessageStub(
+            topic=source_topic.name,
+            partition=partition_num,
+            offset=rewind_offset + 1,
+        )
+        consumer.poll.side_effect = [rewind_message, later_message_same_tp, None]
+        # Once the loop reaches the empty poll, report the tracked partition
+        # as caught up so `_update_recovery_status` finishes it and the loop
+        # exits on its own.
+        consumer.position.return_value = [
+            TopicPartition(changelog_topic.name, 0, highwater)
+        ]
+
+        # See Bug A test docstring: sets the "recovery already running"
+        # state directly instead of driving `do_recovery`'s seek/resume loop.
+        recovery_manager._running = True
+
+        with caplog.at_level(logging.WARNING):
+            recovery_manager._recovery_loop()
+
+        expected_pause_tp = TopicPartition(source_topic.name, partition_num)
+        pause_calls = [c.args[0] for c in consumer.pause.call_args_list]
+        assert [expected_pause_tp] in pause_calls, (
+            "recovery loop must pause a data partition it should never have "
+            "polled, instead of leaving it fetching and dropping messages"
+        )
+
+        expected_seek_tp = TopicPartition(
+            source_topic.name, partition_num, offset=rewind_offset
+        )
+        seek_calls = [c.args[0] for c in consumer.seek.call_args_list]
+        assert seek_calls.count(expected_seek_tp) == 1, (
+            "recovery loop must rewind a leaked data-topic message back to "
+            "its own offset exactly once, so it's the next message read "
+            "once the partition is resumed; a message must never be "
+            "skipped outright (that loses it for the whole session), nor "
+            "re-seeked for every later message on the same partition"
+        )
+
+        store_partition.recover_from_changelog_message.assert_not_called()
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1, (
+            "exactly one WARNING must be logged for the rewound data "
+            "partition, not zero (silent) and not one per leaked message"
         )
 
     def test_assign_before_recovery_starts_pauses_all_and_do_recovery_resumes_changelogs(

--- a/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
+++ b/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
@@ -286,6 +286,9 @@ class TestRecoveryRebalanceMidRecovery:
             def get_watermark_offsets(self, *_args, **_kwargs):
                 return 0, 10
 
+            def seek(self, *_args, **_kwargs):
+                return None
+
         consumer = _PauseResumeTrackingConsumer(
             assignment=[stateless_tp0, stateful_tp0, changelog_tp0]
         )

--- a/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
+++ b/tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py
@@ -1,0 +1,393 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from confluent_kafka import TopicPartition
+
+from quixstreams.kafka import Consumer
+from quixstreams.models import TopicConfig, TopicManager
+from quixstreams.state.base import StorePartition
+from quixstreams.state.recovery import RecoveryManager
+from tests.utils import ConfluentKafkaMessageStub
+
+
+def _broker_topic_passthrough(topic):
+    """Stand in for TopicAdmin: never touches a real broker."""
+    topic.broker_config = topic.create_config
+    return topic
+
+
+def _build_recovery_topics(stream_id: str, store_name: str, num_partitions: int = 1):
+    """
+    Build a TopicManager with one data topic and its matching changelog topic,
+    without touching a real broker (patches ``_get_or_create_broker_topic``, the
+    same technique already used by
+    ``TestRecoveryManager.test_recovery_paused_partition_is_resumed_when_reassigned``
+    in test_recovery_manager.py).
+    """
+    topic_manager = TopicManager(
+        topic_admin=MagicMock(), consumer_group=str(uuid.uuid4())
+    )
+    with patch.object(
+        topic_manager,
+        "_get_or_create_broker_topic",
+        side_effect=_broker_topic_passthrough,
+    ):
+        data_topic = topic_manager.topic(stream_id)
+        changelog_topic = topic_manager.changelog_topic(
+            stream_id=stream_id,
+            store_name=store_name,
+            config=TopicConfig(num_partitions=num_partitions, replication_factor=1),
+        )
+    return topic_manager, data_topic, changelog_topic
+
+
+def _add_stateless_topic(topic_manager: TopicManager, name: str):
+    with patch.object(
+        topic_manager,
+        "_get_or_create_broker_topic",
+        side_effect=_broker_topic_passthrough,
+    ):
+        return topic_manager.topic(name)
+
+
+def _needs_recovery_store_partition(offset: int) -> MagicMock:
+    store_partition = MagicMock(spec_set=StorePartition)
+    store_partition.get_changelog_offset.return_value = offset
+    store_partition.has_incomplete_ttl_migration.return_value = False
+    return store_partition
+
+
+class TestRecoveryRebalanceMidRecovery:
+    """
+    Bug A and Bug B (recovery.py): a rebalance that assigns/revokes/reassigns
+    partitions WHILE a recovery is already in progress. Live evidence:
+    pathb_cold_r1_pre_restart_9.log (Bug A, "Recovery stuck" RuntimeError),
+    pathb_cold_r2_pre_restart_11.log / pathb_cold_r3_pre_restart_5.log
+    (Bug B, KeyError in ``_recovery_loop``).
+    """
+
+    def test_partition_assigned_mid_recovery_is_seeked_and_resumed(self):
+        """
+        Bug A: validates spec/architecture invariant that recovery.py:535
+        ``do_recovery`` documents as its own job -- seeking+resuming a
+        changelog partition's saved offset -- must also happen for a
+        partition assigned WHILE recovery is already running (recovery.py
+        :671 ``assign_partition``, the ``self._running`` branch at :733).
+        Currently only ``do_recovery`` seeks/resumes, once, before the loop
+        starts (:552-557); a partition assigned mid-recovery via a rebalance
+        never gets seeked/resumed, so its consumer position stays
+        OFFSET_INVALID (-1001) forever and the 60-attempt watchdog
+        (:472, :927) raises "Recovery stuck", exactly as seen live in
+        pathb_cold_r1_pre_restart_9.log at 17:56:41.
+        """
+        stream_id = str(uuid.uuid4())
+        store_name = "default"
+        topic_manager, data_topic, changelog_topic = _build_recovery_topics(
+            stream_id, store_name, num_partitions=2
+        )
+
+        data_tp0 = TopicPartition(data_topic.name, 0)
+        data_tp1 = TopicPartition(data_topic.name, 1)
+        changelog_tp0 = TopicPartition(changelog_topic.name, 0)
+        changelog_tp1 = TopicPartition(changelog_topic.name, 1)
+
+        consumer = MagicMock(spec_set=Consumer)
+        consumer.assignment.return_value = [
+            data_tp0,
+            changelog_tp0,
+            data_tp1,
+            changelog_tp1,
+        ]
+        consumer.get_watermark_offsets.return_value = (0, 10)
+
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+
+        # Assign partition 0 before recovery has started; it needs recovery.
+        recovery_manager.assign_partition(
+            topic=stream_id,
+            partition=0,
+            committed_offsets={stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+        assert recovery_manager.partitions[0][changelog_topic.name].needs_recovery_check
+
+        # Put the manager into the "recovery already running" state the way
+        # `do_recovery` does (`_running = True`), WITHOUT driving the blocking
+        # `_recovery_loop()` to completion: this isolates the `assign_partition`
+        # code path under test from the (separately tested) loop behavior.
+        recovery_manager._running = True
+        assert recovery_manager.recovering
+
+        consumer.seek.reset_mock()
+        consumer.resume.reset_mock()
+
+        # A rebalance now assigns partition 1, which also needs recovery,
+        # while recovery for partition 0 is still active.
+        recovery_manager.assign_partition(
+            topic=stream_id,
+            partition=1,
+            committed_offsets={stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+        rp1 = recovery_manager.partitions[1][changelog_topic.name]
+        assert rp1.needs_recovery_check
+
+        expected_seek_tp = TopicPartition(changelog_topic.name, 1, offset=rp1.offset)
+        expected_resume_tps = [TopicPartition(changelog_topic.name, 1)]
+
+        seek_calls = [c.args[0] for c in consumer.seek.call_args_list]
+        resume_calls = [c.args[0] for c in consumer.resume.call_args_list]
+
+        assert expected_seek_tp in seek_calls, (
+            "changelog partition assigned during an active recovery is never "
+            "seeked/resumed; only do_recovery does that, so its position "
+            "stays OFFSET_INVALID and the 60-attempt watchdog raises "
+            "'Recovery stuck'"
+        )
+        assert expected_resume_tps in resume_calls, (
+            "changelog partition assigned during an active recovery is never "
+            "seeked/resumed; only do_recovery does that, so its position "
+            "stays OFFSET_INVALID and the 60-attempt watchdog raises "
+            "'Recovery stuck'"
+        )
+
+    def test_recovery_loop_ignores_message_for_partition_not_under_recovery(self):
+        """
+        Bug B (loop): validates that `_recovery_loop` (recovery.py:811) must
+        not assume every polled message belongs to a currently-tracked
+        RecoveryPartition. On HEAD, `rp = self._recovery_partitions[msg
+        .partition()][msg.topic()]` (:824) has no membership check, so a
+        message for a topic/partition combination that isn't (or isn't yet)
+        under recovery raises an uncaught KeyError and crashes the app --
+        exactly as seen live: KeyError on the SOURCE topic name in
+        pathb_cold_r2_pre_restart_11.log, and KeyError on a not-yet-tracked
+        partition number in pathb_cold_r3_pre_restart_5.log.
+        """
+        stream_id = str(uuid.uuid4())
+        store_name = "default"
+        highwater = 10
+        topic_manager, data_topic, changelog_topic = _build_recovery_topics(
+            stream_id, store_name, num_partitions=2
+        )
+
+        consumer = MagicMock(spec_set=Consumer)
+        changelog_tp0 = TopicPartition(changelog_topic.name, 0)
+        consumer.assignment.return_value = [
+            TopicPartition(data_topic.name, 0),
+            changelog_tp0,
+        ]
+        consumer.get_watermark_offsets.return_value = (0, highwater)
+
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+        store_partition = _needs_recovery_store_partition(offset=3)
+        recovery_manager.assign_partition(
+            topic=stream_id,
+            partition=0,
+            committed_offsets={stream_id: -1001},
+            store_partitions={store_name: store_partition},
+        )
+        assert recovery_manager.partitions
+
+        # A message from the SOURCE (non-changelog) topic on a partition that
+        # DOES have a recovery check (0), followed by a changelog message for
+        # a partition that has NO recovery check at all (1). Neither should
+        # ever reach `RecoveryPartition.recover_from_changelog_message`.
+        foreign_source_message = ConfluentKafkaMessageStub(
+            topic=data_topic.name, partition=0, offset=0
+        )
+        foreign_changelog_message = ConfluentKafkaMessageStub(
+            topic=changelog_topic.name, partition=1, offset=0
+        )
+        consumer.poll.side_effect = [
+            foreign_source_message,
+            foreign_changelog_message,
+            None,
+        ]
+        # Once the loop reaches the (correctly) empty poll, report the tracked
+        # partition as caught up so `_update_recovery_status` finishes it and
+        # the loop exits on its own.
+        consumer.position.return_value = [
+            TopicPartition(changelog_topic.name, 0, highwater)
+        ]
+
+        # See Bug A test docstring: sets the "recovery already running" state
+        # directly instead of driving `do_recovery`'s seek/resume loop.
+        recovery_manager._running = True
+
+        recovery_manager._recovery_loop()
+
+        assert not recovery_manager.partitions, (
+            "recovery loop crashes with an uncaught KeyError instead of "
+            "skipping a message for a topic/partition that is not under "
+            "recovery (see pathb_cold_r2_pre_restart_11.log / "
+            "pathb_cold_r3_pre_restart_5.log)"
+        )
+        store_partition.recover_from_changelog_message.assert_not_called()
+
+    def test_rebalance_sequence_keeps_data_partitions_paused_while_recovery_continues(
+        self,
+    ):
+        """
+        Bug B (root cause): reproduces the exact ordering `app.py
+        _assign_partitions` (~:1170-1300) produces during one eager rebalance
+        inside an active recovery: `consumer.assign`, then
+        `on_partition_assign` per non-changelog tp in assignment order (a
+        stateless source topic sorts before the stateful/repartition topic).
+        `RecoveryManager.assign_partition` (recovery.py:671) only resumes
+        recovery-paused data partitions when `self._recovery_partitions` is
+        EMPTY (:743-744) with NO check on `self._running`; a stateless assign
+        that momentarily observes an empty `_recovery_partitions` (because the
+        stateful partition was just revoked and hasn't been reassigned yet)
+        wrongly resumes ALL recovery-paused data partitions, including the
+        one that belongs to the stream still under active recovery. The
+        recovery loop then polls that now-unpaused source topic and crashes
+        with KeyError (Bug B, loop test above) -- this is the mechanism
+        behind pathb_cold_r2_pre_restart_11.log /
+        pathb_cold_r3_pre_restart_5.log.
+        """
+        stateless_topic_name = f"raw-events-{uuid.uuid4()}"
+        stateful_stream_id = f"repartition-{uuid.uuid4()}"
+        store_name = "default"
+
+        topic_manager, stateful_topic, changelog_topic = _build_recovery_topics(
+            stateful_stream_id, store_name, num_partitions=1
+        )
+        stateless_topic = _add_stateless_topic(topic_manager, stateless_topic_name)
+
+        stateless_tp0 = TopicPartition(stateless_topic.name, 0)
+        stateful_tp0 = TopicPartition(stateful_topic.name, 0)
+        changelog_tp0 = TopicPartition(changelog_topic.name, 0)
+
+        class _PauseResumeTrackingConsumer:
+            """Minimal consumer stub tracking net pause/resume state, in the
+            style of TestRecoveryManager.
+            test_recovery_paused_partition_is_resumed_when_reassigned's
+            TrackingConsumer in test_recovery_manager.py."""
+
+            def __init__(self, assignment):
+                self._assignment = assignment
+                self.paused: set[tuple[str, int]] = set()
+
+            def assignment(self):
+                return list(self._assignment)
+
+            def pause(self, partitions):
+                for tp in partitions:
+                    self.paused.add((tp.topic, tp.partition))
+
+            def resume(self, partitions):
+                for tp in partitions:
+                    self.paused.discard((tp.topic, tp.partition))
+
+            def get_watermark_offsets(self, *_args, **_kwargs):
+                return 0, 10
+
+        consumer = _PauseResumeTrackingConsumer(
+            assignment=[stateless_tp0, stateful_tp0, changelog_tp0]
+        )
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+
+        # 1) Recovery starts for the stateful partition: pauses the WHOLE
+        # current assignment (both data tps + the changelog), and remembers
+        # the two data tps as recovery-paused.
+        recovery_manager.assign_partition(
+            topic=stateful_stream_id,
+            partition=0,
+            committed_offsets={stateful_stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+        assert (stateless_topic.name, 0) in recovery_manager._recovery_paused_data_tps
+        assert (stateful_topic.name, 0) in recovery_manager._recovery_paused_data_tps
+
+        # `do_recovery` would seek/resume the changelog and enter the
+        # blocking loop; see Bug A test docstring for why we set `_running`
+        # directly instead.
+        recovery_manager._running = True
+
+        # 2) An eager rebalance revokes partition 0 first (its store is
+        # about to be closed and reopened elsewhere / reassigned).
+        recovery_manager.revoke_partition(0)
+        assert not recovery_manager._recovery_partitions
+
+        # 3) `app._assign_partitions` assigns the STATELESS source topic
+        # first (it sorts before the stateful/repartition topic).
+        recovery_manager.assign_partition(
+            topic=stateless_topic_name,
+            partition=0,
+            committed_offsets={},
+            store_partitions={},
+        )
+
+        # 4) Then the STATEFUL stream is (re)assigned, needing recovery again.
+        recovery_manager.assign_partition(
+            topic=stateful_stream_id,
+            partition=0,
+            committed_offsets={stateful_stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+
+        assert recovery_manager.recovering
+
+        data_tps = {(stateless_topic.name, 0), (stateful_topic.name, 0)}
+        assert data_tps <= consumer.paused, (
+            "a stateless assign during a rebalance resumes recovery-paused "
+            "data partitions while recovery is still running; the recovery "
+            "loop then polls source-topic messages and crashes with KeyError"
+        )
+
+    def test_assign_before_recovery_starts_pauses_all_and_do_recovery_resumes_changelogs(
+        self,
+    ):
+        """
+        Control (must stay GREEN): the healthy, non-rebalance path. Before
+        recovery has started (`_running == False`), `assign_partition`
+        (recovery.py:671, :739-742) pauses the ENTIRE current assignment, and
+        `do_recovery` (:535) seeks+resumes the changelog partition before
+        entering the loop, then resumes the data partition once recovery
+        completes. Pins this already-passing behavior so a fix for Bug A/B
+        cannot regress it.
+        """
+        stream_id = str(uuid.uuid4())
+        store_name = "default"
+        highwater = 10
+        topic_manager, data_topic, changelog_topic = _build_recovery_topics(
+            stream_id, store_name, num_partitions=1
+        )
+
+        data_tp = TopicPartition(data_topic.name, 0)
+        changelog_tp = TopicPartition(changelog_topic.name, 0)
+
+        consumer = MagicMock(spec_set=Consumer)
+        consumer.assignment.return_value = [data_tp, changelog_tp]
+        consumer.get_watermark_offsets.return_value = (0, highwater)
+        consumer.poll.return_value = None
+        consumer.position.return_value = [
+            TopicPartition(changelog_topic.name, 0, highwater)
+        ]
+
+        recovery_manager = RecoveryManager(
+            consumer=consumer, topic_manager=topic_manager
+        )
+        recovery_manager.assign_partition(
+            topic=stream_id,
+            partition=0,
+            committed_offsets={stream_id: -1001},
+            store_partitions={store_name: _needs_recovery_store_partition(offset=3)},
+        )
+        assert consumer.pause.call_args_list[0].args[0] == [data_tp, changelog_tp]
+
+        recovery_manager.do_recovery()
+
+        seek_calls = [c.args[0] for c in consumer.seek.call_args_list]
+        assert seek_calls == [TopicPartition(changelog_topic.name, 0, offset=3)]
+
+        resume_calls = [c.args[0] for c in consumer.resume.call_args_list]
+        assert resume_calls[0] == [changelog_tp]
+        assert resume_calls[-1] == [data_tp]
+        assert not recovery_manager.partitions


### PR DESCRIPTION
# RecoveryManager: survive a rebalance during changelog recovery, without losing messages

Branch: `bug/sc-74868/recoverymanager-crash-loops-when-a-rebalance` → `main`
Files: `quixstreams/state/recovery.py`, `quixstreams/state/manager.py`, `quixstreams/app.py`,
one new test module. Independent of #1145 (rebased on top of it).

## Why

`RecoveryManager._recovery_loop` assumed that while it runs the set of partitions is
fixed and the shared consumer can only return changelog messages for partitions under
recovery. A consumer-group rebalance during recovery breaks both. Observed live on a
4-replica cold start (Quix Cloud, 2026-09-06), where each replica joining rebalanced
the others mid-replay and every generation crashed:

1. A partition assigned while recovery was already running was registered but never
   seeked or resumed (only `do_recovery` did that, once, before the loop). Its position
   stayed `OFFSET_INVALID` and after 60 polls the watchdog raised
   `RuntimeError: Recovery stuck ... position has been invalid for 61 consecutive attempts (offset=-1001)`.
2. The loop indexed `self._recovery_partitions[msg.partition()][msg.topic()]` with no
   membership check. `Application._assign_partitions` calls `consumer.assign(new)`,
   which resets the paused state of every assigned partition and re-pauses only
   changelog partitions; a stateless stream never reaches the RecoveryManager because
   the state manager forwards only streams with stores. Source-topic messages reached
   the loop and it died with `KeyError: '<source topic>'` (or `KeyError: <partition>`
   for a just-revoked changelog partition).

Any stateful deployment with more than one replica that needs recovery at the same
time crash-loops until the members happen to settle.

## What changes

- `_prime_changelog_partition()` (seek to the stored offset + resume) is shared by
  `do_recovery` and by `assign_partition` when recovery is already running, so a
  partition arriving mid-recovery makes progress.
- `RecoveryManager.pause_assigned_data_partitions()`: while recovery runs, every
  non-changelog partition of a new assignment is paused; `Application` calls it right
  after pausing the changelog partitions. `assign_partition`'s running branch pauses
  the assigned data partitions whether or not it registered a `RecoveryPartition`.
- `_recovery_loop` looks up with `.get()`. A message for a data topic is **rewound**
  (pause + seek to its offset, WARNING once per partition) so it is re-consumed after
  recovery instead of being dropped; a changelog-tail message for a partition no longer
  under recovery is skipped at debug level.
- `resume_reassigned_data_partitions` is inert while recovery runs.

The first version of this fix replaced the KeyError with a plain skip; live that
turned a crash into silent loss (7,469 source messages consumed and discarded by one
replica during recovery). The rewind is what makes the fix safe.

## Live verification

- 2026-09-07, 4 replicas cold-starting on a 1.4M-record changelog, four rebalance
  generations in 14 seconds: 0 `Recovery stuck`, 0 KeyError, 0 skipped or rewound
  messages, recovery complete on all replicas, processing resumed.
- Same scenario in a local Docker harness (Redpanda, 4 replicas).

## Tests

- `tests/test_quixstreams/test_state/test_recovery/test_recovery_rebalance_mid_recovery.py`:
  5 tests written red against the live crashes (partition assigned mid-recovery is
  seeked and resumed; loop ignores a changelog message not under recovery; rebalance
  sequence keeps data partitions paused; stateless partition assigned mid-recovery is
  paused; a data message is rewound, not skipped) plus 1 green control.
- Recovery suite 55 passed; `test_app.py -k recovery` 17 passed; state suite green;
  pre-commit (ruff 0.6.3, ruff-format, mypy) clean.

## Not in this PR

- `StateStoreManager._init_state_dir` check-then-mkdir race between replicas sharing
  a volume (`FileExistsError` at startup; one-line `exist_ok=True`), separate ticket.
