### PR TITLE
feat: Column stats, virtual partitions, sort column and row-group sizing for QuixTSDataLakeSink

### DIFF
--- a/docs/connectors/sinks/quix-ts-datalake-sink.md
+++ b/docs/connectors/sinks/quix-ts-datalake-sink.md
@@ -59,6 +59,23 @@ Records must be dictionaries. If your values are not dicts, convert them before 
 
 Blob credentials are read automatically from the `Quix__BlobStorage__Connection__Json` environment variable when running on Quix Cloud; for local runs, the filesystem is inferred from the `quixportal` configuration.
 
+### Parquet row groups
+
+Each file is written with row groups of about `row_group_mb` (default 32 MB) — the same
+target the lakehouse compaction uses. A reader needs roughly four storage range requests
+per row group, so many small groups make every query pay a round-trip storm on a
+high-latency storage path, while one enormous group forfeits intra-file skipping and
+inflates reader memory. Parquet sizes groups in rows, so the sink converts the target using
+the table's density: it tracks the rows and compressed bytes of the files it has already
+written and uses `rows_per_MB × row_group_mb` rows per group for the next file (clamped to
+122,880–50,000,000 rows; 1,000,000 rows before the first file, which is also pyarrow's
+default). Files smaller than one group are, as always, a single group — splitting only
+matters for large flushes.
+
+```python
+sink = QuixTSDataLakeSink(..., row_group_mb=32)
+```
+
 ## Per-Key Silence Detection
 
 The sink can detect when individual Kafka message keys go quiet and fire a callback for each one. The canonical use case is sensor drop-out detection: if `sensor-a` stops publishing while `sensor-b` continues, the callback fires only for `sensor-a`.

--- a/docs/connectors/sinks/quix-ts-datalake-sink.md
+++ b/docs/connectors/sinks/quix-ts-datalake-sink.md
@@ -61,19 +61,15 @@ Blob credentials are read automatically from the `Quix__BlobStorage__Connection_
 
 ### Parquet row groups
 
-Each file is written with row groups of about `row_group_mb` (default 32 MB) — the same
-target the lakehouse compaction uses. A reader needs roughly four storage range requests
-per row group, so many small groups make every query pay a round-trip storm on a
+Each file is written with at most `row_group_rows` rows per row group (default 1,000,000,
+the same default the lakehouse compaction uses). A reader needs roughly one storage range
+request per row group, so many small groups make every query pay a round-trip storm on a
 high-latency storage path, while one enormous group forfeits intra-file skipping and
-inflates reader memory. Parquet sizes groups in rows, so the sink converts the target using
-the table's density: it tracks the rows and compressed bytes of the files it has already
-written and uses `rows_per_MB × row_group_mb` rows per group for the next file (clamped to
-122,880–50,000,000 rows; 1,000,000 rows before the first file, which is also pyarrow's
-default). Files smaller than one group are, as always, a single group — splitting only
-matters for large flushes.
+inflates reader memory. A flush smaller than the limit is, as always, a single row group —
+only large flushes are split.
 
 ```python
-sink = QuixTSDataLakeSink(..., row_group_mb=32)
+sink = QuixTSDataLakeSink(..., row_group_rows=1_000_000)
 ```
 
 ## Per-Key Silence Detection

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -585,6 +585,57 @@ class QuixTSDataLakeSink(BatchingSink):
             out[col] = sorted({str(v) for v in values})
         return out
 
+    def _compute_partition_combinations(
+        self,
+        df: pd.DataFrame,
+        partition_columns: List[str],
+        partition_values: tuple,
+        max_distinct: int = 50000,
+    ) -> List[Dict[str, str]]:
+        """Distinct full partition tuples (physical + virtual) in this file, for
+        the catalog's ``table_partition_combinations`` dictionary.
+
+        ``_compute_virtual_values`` records each virtual column's values
+        INDEPENDENTLY, which cross-products them in the partition tree (folders
+        for value combinations that share no rows). This records which values
+        actually CO-OCCUR: the file's physical partition values (constant per
+        file) combined with each distinct virtual-value tuple
+        (``df[virtual].drop_duplicates()``). The catalog stores the DISTINCT set
+        across files, so the tree shows only real combinations and multi-column
+        queries prune. Skipped for a file with more than ``max_distinct`` distinct
+        tuples (a high-cardinality guard, matching ``_compute_virtual_values``).
+        """
+        if not self._virtual_columns:
+            return []
+        present = [c for c in self._virtual_columns if c in df.columns]
+        if not present:
+            return []
+        physical: Dict[str, str] = {}
+        for col, val in zip(partition_columns or [], partition_values or ()):
+            if val is not None:
+                physical[str(col)] = str(val)
+        try:
+            distinct = df[present].drop_duplicates()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Skipping partition combinations: %s", exc)
+            return []
+        if len(distinct) > max_distinct:
+            logger.warning(
+                "File has %d distinct virtual combinations (> %d) — skipping the "
+                "combination index for this file.",
+                len(distinct), max_distinct,
+            )
+            return []
+        combos: List[Dict[str, str]] = []
+        for row in distinct.itertuples(index=False):
+            combo = dict(physical)
+            for col, v in zip(present, row):
+                if v is None or (isinstance(v, float) and v != v):  # NULL / NaN
+                    continue
+                combo[str(col)] = str(v)
+            combos.append(combo)
+        return combos
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -606,6 +657,12 @@ class QuixTSDataLakeSink(BatchingSink):
         # (they aren't foldered, so a file can hold many). Cheap on the
         # in-memory frame; carried to the catalog's file_virtual_values index.
         virtual_values = self._compute_virtual_values(df)
+        # Distinct full partition tuples (physical + virtual) that CO-OCCUR in
+        # this file, for the catalog's combination dictionary (exact tree + query
+        # pruning). Deduplicated across the batch in _register_files_in_manifest.
+        partition_combinations = self._compute_partition_combinations(
+            df, partition_columns, partition_values
+        )
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -626,6 +683,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 "partition_values": partition_values,
                 "column_stats": column_stats,
                 "virtual_values": virtual_values,
+                "partition_combinations": partition_combinations,
             }
         )
 
@@ -952,10 +1010,27 @@ class QuixTSDataLakeSink(BatchingSink):
                 entry["virtual_values"] = virtual_values
             file_entries.append(entry)
 
+        # Aggregate the DISTINCT full partition tuples across this batch for the
+        # catalog's combination dictionary. The same tuples repeat across files,
+        # so the deduped set stays small; the catalog upserts them (additive) so
+        # the tree/pruning stay exact for newly-ingested data without a reindex.
+        combo_seen: set = set()
+        partition_combinations: List[Dict[str, str]] = []
+        for item in file_items:
+            for combo in item.get("partition_combinations") or []:
+                key = tuple(sorted(combo.items()))
+                if key not in combo_seen:
+                    combo_seen.add(key)
+                    partition_combinations.append(combo)
+
         # Send all files to catalog in a single request
+        body: Dict[str, Any] = {"files": file_entries}
+        # Omitted when empty so older catalogs simply ignore the absent field.
+        if partition_combinations:
+            body["partition_combinations"] = partition_combinations
         response = self._catalog.post(
             f"/namespaces/{self.namespace}/tables/{self.table_name}/manifest/add-files",
-            json={"files": file_entries},
+            json=body,
             timeout=10,
         )
 

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -551,40 +551,6 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         return stats
 
-    def _compute_virtual_values(
-        self, df: pd.DataFrame, max_distinct: int = 10000
-    ) -> Dict[str, List[str]]:
-        """Distinct values of each configured virtual column present in this
-        file's data, as ``{column: ["v1", "v2", ...]}``.
-
-        Virtual columns are not foldered or grouped, so a file can carry many
-        of their values; the catalog indexes these so the partition tree can
-        enumerate them and queries can prune to files that contain a value. A
-        column with more than ``max_distinct`` values in a single file is
-        skipped (a guard against accidentally marking a high-cardinality column
-        virtual, which would bloat the index and make the tree unusable).
-        """
-        if not self._virtual_columns:
-            return {}
-        out: Dict[str, List[str]] = {}
-        for col in self._virtual_columns:
-            if col not in df.columns:
-                continue
-            try:
-                values = df[col].dropna().unique()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("Skipping virtual values for column %s: %s", col, exc)
-                continue
-            if len(values) > max_distinct:
-                logger.warning(
-                    "Virtual column '%s' has %d distinct values in one file "
-                    "(> %d) — skipping its index for this file.",
-                    col, len(values), max_distinct,
-                )
-                continue
-            out[col] = sorted({str(v) for v in values})
-        return out
-
     def _compute_partition_combinations(
         self,
         df: pd.DataFrame,
@@ -595,15 +561,13 @@ class QuixTSDataLakeSink(BatchingSink):
         """Distinct full partition tuples (physical + virtual) in this file, for
         the catalog's ``table_partition_combinations`` dictionary.
 
-        ``_compute_virtual_values`` records each virtual column's values
-        INDEPENDENTLY, which cross-products them in the partition tree (folders
-        for value combinations that share no rows). This records which values
-        actually CO-OCCUR: the file's physical partition values (constant per
-        file) combined with each distinct virtual-value tuple
-        (``df[virtual].drop_duplicates()``). The catalog stores the DISTINCT set
-        across files, so the tree shows only real combinations and multi-column
-        queries prune. Skipped for a file with more than ``max_distinct`` distinct
-        tuples (a high-cardinality guard, matching ``_compute_virtual_values``).
+        Records which virtual values actually CO-OCCUR: the file's physical
+        partition values (constant per file) combined with each distinct
+        virtual-value tuple (``df[virtual].drop_duplicates()``). The catalog
+        stores the DISTINCT set across files (table_partition_combinations — the
+        sole virtual index), so the tree shows only real combinations and
+        multi-column queries prune. Skipped for a file with more than
+        ``max_distinct`` distinct tuples (a high-cardinality guard).
         """
         if not self._virtual_columns:
             return []
@@ -653,13 +617,10 @@ class QuixTSDataLakeSink(BatchingSink):
         # from storage later. Carried through _pending_futures into the catalog
         # add-files call (see _register_files_in_manifest).
         column_stats = self._compute_column_stats(table)
-        # Distinct values of any virtual partition columns present in this file
-        # (they aren't foldered, so a file can hold many). Cheap on the
-        # in-memory frame; carried to the catalog's file_virtual_values index.
-        virtual_values = self._compute_virtual_values(df)
         # Distinct full partition tuples (physical + virtual) that CO-OCCUR in
-        # this file, for the catalog's combination dictionary (exact tree + query
-        # pruning). Deduplicated across the batch in _register_files_in_manifest.
+        # this file, for the catalog's combination dictionary — the sole virtual
+        # index (exact tree + query pruning). Deduplicated across the batch in
+        # _register_files_in_manifest.
         partition_combinations = self._compute_partition_combinations(
             df, partition_columns, partition_values
         )
@@ -682,7 +643,6 @@ class QuixTSDataLakeSink(BatchingSink):
                 "partition_columns": partition_columns,
                 "partition_values": partition_values,
                 "column_stats": column_stats,
-                "virtual_values": virtual_values,
                 "partition_combinations": partition_combinations,
             }
         )
@@ -966,7 +926,6 @@ class QuixTSDataLakeSink(BatchingSink):
             partition_columns = item["partition_columns"]
             partition_values = item["partition_values"]
             column_stats = item.get("column_stats") or {}
-            virtual_values = item.get("virtual_values") or {}
 
             # Build file path as full S3 URI for catalog (API uses this with DuckDB)
             # Include workspace_id if set (for workspace-scoped storage)
@@ -1003,11 +962,6 @@ class QuixTSDataLakeSink(BatchingSink):
             # when empty so older catalogs simply ignore the absent field.
             if column_stats:
                 entry["column_stats"] = column_stats
-            # Attach virtual-partition value sets (catalog indexes them in
-            # file_virtual_values for tree navigation + pruning). Omitted when
-            # empty so older catalogs ignore the absent field.
-            if virtual_values:
-                entry["virtual_values"] = virtual_values
             file_entries.append(entry)
 
         # Aggregate the DISTINCT full partition tuples across this batch for the

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -8,6 +8,7 @@ Uses quixportal for unified blob storage access (Azure, AWS S3, GCP, MinIO, loca
 """
 
 import logging
+import math
 import time
 import uuid
 from datetime import datetime, timezone
@@ -16,6 +17,7 @@ from typing import Any, Callable, Dict, List, Optional
 try:
     import pandas as pd
     import pyarrow as pa
+    import pyarrow.compute as pc
     import pyarrow.parquet as pq
 except ImportError as exc:
     raise ImportError(
@@ -112,6 +114,14 @@ class QuixTSDataLakeSink(BatchingSink):
     :param namespace: Catalog namespace (default: "default")
     :param auto_create_bucket: If True, attempt to create bucket/path in storage if missing
     :param max_workers: Maximum number of parallel upload threads (default: 10)
+    :param stats_columns: Optional list of column names to compute per-file
+        min/max statistics ("zone maps") for. These are sent to the REST
+        Catalog with each file and let the query layer skip files whose value
+        range cannot satisfy a WHERE/ORDER BY on the column. ``None`` (default)
+        computes stats for every numeric and timestamp column in each written
+        file (cheap — the batch is already in memory). Pass an explicit list to
+        restrict the set and bound catalog storage on very wide tables. String
+        columns are not supported yet and are always skipped.
     :param stream_timeout_ms: Optional **per-key** silence threshold in
         milliseconds. Paired with ``on_stream_timeout``; both must be
         provided to enable the feature. See
@@ -150,6 +160,7 @@ class QuixTSDataLakeSink(BatchingSink):
         namespace: str = "default",
         auto_create_bucket: bool = True,
         max_workers: int = 10,
+        stats_columns: Optional[List[str]] = None,
         stream_timeout_ms: Optional[int] = None,
         on_stream_timeout: Optional[Callable[[Any], None]] = None,
         silence_azure_http_logs: bool = True,
@@ -175,6 +186,15 @@ class QuixTSDataLakeSink(BatchingSink):
         self.auto_discover = auto_discover
         self.namespace = namespace
         self.table_registered = False
+
+        # Columns to compute per-file min/max zone maps for (data-skipping at
+        # query time). ``None`` (default) -> every numeric / timestamp column
+        # in each written file, which is nearly free here because the batch is
+        # already an in-memory Arrow table. Pass an explicit list to restrict
+        # the set (e.g. just the timestamp column) and bound catalog stats-row
+        # growth on very wide tables. Stats ride along with each add-files
+        # entry as ``column_stats`` and are consumed by the catalog's pruning.
+        self._stats_columns = set(stats_columns) if stats_columns else None
 
         # Blob storage client and bucket name will be initialized in setup()
         self._blob_client: Optional[BlobStorageClient] = None
@@ -427,6 +447,83 @@ class QuixTSDataLakeSink(BatchingSink):
         self._finalize_writes()
         return rows_written
 
+    @staticmethod
+    def _safe_float_min(value: Any) -> float:
+        """Largest float <= value. Widening the low bound downward guarantees
+        the stored zone map is a *superset* of the real range, so float
+        rounding of large ints/decimals (e.g. nanosecond epochs beyond 2**53)
+        can only cost pruning, never wrongly skip a matching file."""
+        f = float(value)
+        while f > value:
+            f = math.nextafter(f, float("-inf"))
+        return f
+
+    @staticmethod
+    def _safe_float_max(value: Any) -> float:
+        """Smallest float >= value (see _safe_float_min for the safety rationale)."""
+        f = float(value)
+        while f < value:
+            f = math.nextafter(f, float("inf"))
+        return f
+
+    def _compute_column_stats(self, table: "pa.Table") -> Dict[str, Dict[str, Any]]:
+        """Compute per-column min/max/null_count for a written Arrow table.
+
+        Numeric columns (int/float/decimal) are reported as ``type="numeric"``
+        with float bounds (floored min / ceiled max for safety); timestamp and
+        date columns as ``type="timestamp"`` with ISO-8601 bounds. Everything
+        else (strings, structs, the ``__key`` column) is skipped. Respects
+        ``self._stats_columns`` when set. Runs on the in-memory batch, so it is
+        just vectorised min/max — no re-read of the parquet footer.
+        """
+        stats: Dict[str, Dict[str, Any]] = {}
+        for field in table.schema:
+            name = field.name
+            if name == "__key":
+                continue
+            if self._stats_columns is not None and name not in self._stats_columns:
+                continue
+
+            t = field.type
+            if pa.types.is_integer(t) or pa.types.is_floating(t) or pa.types.is_decimal(t):
+                vtype = "numeric"
+            elif pa.types.is_timestamp(t) or pa.types.is_date(t):
+                vtype = "timestamp"
+            else:
+                continue
+
+            column = table.column(name)
+            null_count = column.null_count
+            if len(column) - null_count == 0:
+                # All-null column: no usable bound, skip (keeps files unpruned).
+                continue
+
+            try:
+                mm = pc.min_max(column)
+                vmin = mm["min"].as_py()
+                vmax = mm["max"].as_py()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Skipping stats for column %s: %s", name, exc)
+                continue
+            if vmin is None or vmax is None:
+                continue
+
+            if vtype == "numeric":
+                vmin = self._safe_float_min(vmin)
+                vmax = self._safe_float_max(vmax)
+            else:  # timestamp / date
+                vmin = vmin.isoformat()
+                vmax = vmax.isoformat()
+
+            stats[name] = {
+                "type": vtype,
+                "min": vmin,
+                "max": vmax,
+                "null_count": int(null_count),
+                "value_count": int(len(column) - null_count),
+            }
+        return stats
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -438,6 +535,12 @@ class QuixTSDataLakeSink(BatchingSink):
         # Convert to Arrow table and prepare buffer
         self._null_empty_dicts(df)
         table = pa.Table.from_pandas(df)
+
+        # Compute per-column min/max zone maps from the in-memory table BEFORE
+        # serialising — nearly free, and avoids re-reading the parquet footer
+        # from storage later. Carried through _pending_futures into the catalog
+        # add-files call (see _register_files_in_manifest).
+        column_stats = self._compute_column_stats(table)
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -456,6 +559,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 "file_size": len(parquet_bytes),
                 "partition_columns": partition_columns,
                 "partition_values": partition_values,
+                "column_stats": column_stats,
             }
         )
 
@@ -722,6 +826,7 @@ class QuixTSDataLakeSink(BatchingSink):
             file_size = item["file_size"]
             partition_columns = item["partition_columns"]
             partition_values = item["partition_values"]
+            column_stats = item.get("column_stats") or {}
 
             # Build file path as full S3 URI for catalog (API uses this with DuckDB)
             # Include workspace_id if set (for workspace-scoped storage)
@@ -746,15 +851,19 @@ class QuixTSDataLakeSink(BatchingSink):
                     partition_dict[col] = str(val)
 
             # Create file entry
-            file_entries.append(
-                {
-                    "file_path": file_path,
-                    "file_size": file_size,
-                    "last_modified": datetime.now(tz=timezone.utc).isoformat(),
-                    "partition_values": partition_dict,
-                    "row_count": row_count,
-                }
-            )
+            entry = {
+                "file_path": file_path,
+                "file_size": file_size,
+                "last_modified": datetime.now(tz=timezone.utc).isoformat(),
+                "partition_values": partition_dict,
+                "row_count": row_count,
+            }
+            # Attach per-column zone maps when computed (catalog stores them in
+            # column_stats for query-time file pruning). Omit the key entirely
+            # when empty so older catalogs simply ignore the absent field.
+            if column_stats:
+                entry["column_stats"] = column_stats
+            file_entries.append(entry)
 
         # Send all files to catalog in a single request
         response = self._catalog.post(

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -261,6 +261,10 @@ class QuixTSDataLakeSink(BatchingSink):
 
         # Batch upload tracking
         self._pending_futures: List[Dict[str, Any]] = []
+        # Virtual-index SIDECAR uploads (one per data file, written to _vindex/).
+        # Tracked separately from data files so _finalize_writes waits on them but
+        # does NOT register them in the manifest (they are metadata, not data).
+        self._pending_sidecar_futures: List[Dict[str, Any]] = []
 
         # Stream-timeout tracking (opt-in, per-key silence detector).
         # All state, threading, and validation live inside the
@@ -725,21 +729,6 @@ class QuixTSDataLakeSink(BatchingSink):
         # from storage later. Carried through _pending_futures into the catalog
         # add-files call (see _register_files_in_manifest).
         column_stats = self._compute_column_stats(table)
-        # Distinct full partition tuples (physical + virtual) that CO-OCCUR in
-        # this file, for the catalog's combination dictionary — the sole virtual
-        # index (exact tree + query pruning). Deduplicated across the batch in
-        # _register_files_in_manifest.
-        partition_combinations = self._compute_partition_combinations(
-            df, partition_columns, partition_values
-        )
-        # Per-file distinct values of each virtual column -> the catalog's
-        # file_virtual_values index (file-grain query pruning). Empty unless all
-        # virtual columns are covered (see _compute_virtual_values).
-        virtual_values = self._compute_virtual_values(df)
-        # Auto-index lane: per-file distinct values of low-cardinality
-        # non-numeric columns (not marked virtual) so their equality filters also
-        # prune. Per-column/per-file, independent of the virtual all-or-nothing.
-        indexed_values = self._compute_auto_index_values(df)
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -759,15 +748,77 @@ class QuixTSDataLakeSink(BatchingSink):
                 "partition_columns": partition_columns,
                 "partition_values": partition_values,
                 "column_stats": column_stats,
-                "partition_combinations": partition_combinations,
-                "virtual_values": virtual_values,
-                "indexed_values": indexed_values,
             }
         )
+
+        # The VIRTUAL index for this file goes to a blob ``_vindex/`` sidecar
+        # (navigation + query pruning read it via DuckDB) — the SOLE virtual index;
+        # nothing virtual is sent to Postgres anymore. column_stats (zone maps)
+        # still go to the catalog above.
+        self._write_virtual_sidecar(df, storage_key, partition_columns, partition_values)
+
+    def _catalog_file_path(self, storage_key: str) -> str:
+        """The full ``s3://`` URI a data/sidecar file is registered under — same
+        construction as _register_files_in_manifest (workspace-scoped)."""
+        if self.workspace_id:
+            return f"s3://{self.s3_bucket}/{self.workspace_id}/{storage_key}"
+        return f"s3://{self.s3_bucket}/{storage_key}"
+
+    def _sidecar_key(self, storage_key: str) -> str:
+        """Blob key of a data file's virtual-index sidecar: in a ``.vidx/``
+        SUBFOLDER of the data file's own Hive partition folder (data
+        ``.../region=EU/data_<uuid>.parquet`` -> index
+        ``.../region=EU/.vidx/data_<uuid>.parquet``). Co-located with the data so
+        compaction rewrites a partition's data and its index together, but in a
+        dedicated dot-dir: a ``.vidx`` folder has no ``key=value`` and so is
+        naturally skipped by partition discovery, keeping sidecars out of the data
+        set. Navigation globs ``.../<physical path>/.vidx/*.parquet``."""
+        folder, _, basename = storage_key.rpartition("/")
+        return f"{folder}/.vidx/{basename}" if folder else f".vidx/{basename}"
+
+    def _write_virtual_sidecar(self, df: pd.DataFrame, storage_key: str,
+                               partition_columns: List[str], partition_values: tuple):
+        """Write this data file's virtual-index sidecar Parquet to ``_vindex/``.
+
+        Content: one row per DISTINCT tuple of the table's VIRTUAL columns present
+        in this file, with the file's PHYSICAL partition values added as constant
+        columns, plus ``__file`` = the data file's catalog URI. Carrying the
+        physical columns in the content means readers need no ``hive_partitioning``
+        — a single ``read_parquet('{root}/_vindex/**')`` yields full (physical +
+        virtual) tuples. Navigation aggregates these
+        (``SELECT DISTINCT <col> WHERE <ancestors>``) into the folder tree;
+        query-pruning selects ``__file`` for a virtual filter. Both via DuckDB over
+        blob — no Postgres. No-op when the table has no virtual columns or none are
+        present in this file. Never raises (the index is a hint, not the data).
+        """
+        present = [c for c in self._virtual_columns if c in df.columns]
+        if not present or self._blob_client is None:
+            return
+        try:
+            vdf = df[present].drop_duplicates().reset_index(drop=True)
+            if vdf.empty:
+                return
+            # Physical partition values are constant for this file (one Hive
+            # folder) -> add them as constant columns so the sidecar holds the
+            # FULL partition tuple.
+            for col, val in zip(partition_columns or [], partition_values or ()):
+                vdf[col] = str(val)
+            vdf["__file"] = self._catalog_file_path(storage_key)
+            buf = pa.BufferOutputStream()
+            pq.write_table(pa.Table.from_pandas(vdf, preserve_index=False), buf)
+            sidecar_key = self._sidecar_key(storage_key)
+            future = self._blob_client.put_object_async(
+                sidecar_key, buf.getvalue().to_pybytes())
+            self._pending_sidecar_futures.append(
+                {"future": future, "key": sidecar_key, "row_count": len(vdf)})
+        except Exception as e:
+            logger.warning("Failed to write virtual sidecar for %s: %s", storage_key, e)
 
     def _finalize_writes(self):
         """Wait for all pending uploads to complete and register files in catalog."""
         if not self._pending_futures:
+            # Still drain any sidecars (defensive; normally paired with data).
+            self._await_sidecar_uploads()
             return
 
         count = len(self._pending_futures)
@@ -792,11 +843,35 @@ class QuixTSDataLakeSink(BatchingSink):
 
             logger.info(f"Successfully uploaded {count} file(s)")
 
+            # Virtual-index sidecars ride alongside the data files. Wait for them
+            # too so the tree is queryable the moment the batch is acknowledged
+            # (a sidecar failure only degrades the index, never blocks the data).
+            self._await_sidecar_uploads()
+
             # Register all files in catalog manifest if configured
             if self._catalog and self.table_registered:
                 self._register_files_in_manifest()
         finally:
             self._pending_futures.clear()
+
+    def _await_sidecar_uploads(self):
+        """Block on the virtual-index sidecar uploads. Best-effort: a failed
+        sidecar is logged but never raised — the data is already safe and the
+        index self-heals on the next write/reindex."""
+        if not self._pending_sidecar_futures:
+            return
+        try:
+            ok = 0
+            for item in self._pending_sidecar_futures:
+                try:
+                    item["future"].result()
+                    ok += 1
+                except Exception as e:
+                    logger.warning("Virtual sidecar upload failed (%s): %s", item["key"], e)
+            logger.debug("Uploaded %d/%d virtual sidecar(s)", ok,
+                         len(self._pending_sidecar_futures))
+        finally:
+            self._pending_sidecar_futures.clear()
 
     def _null_empty_dicts(self, df: pd.DataFrame):
         """
@@ -1085,39 +1160,15 @@ class QuixTSDataLakeSink(BatchingSink):
             # when empty so older catalogs simply ignore the absent field.
             if column_stats:
                 entry["column_stats"] = column_stats
-            # Per-file virtual values -> file_virtual_values (file-grain pruning).
-            # Present only when all virtual columns are covered; the catalog marks
-            # the file virtual_indexed and prunes on it. Omitted otherwise (file
-            # stays un-indexed -> safety-kept).
-            virtual_values = item.get("virtual_values") or {}
-            if virtual_values:
-                entry["virtual_values"] = virtual_values
-            # Auto-index lane -> also file_virtual_values, but PER-COLUMN
-            # (prune-only, not tree). Independent of virtual_values, so a file
-            # can carry these even when it isn't fully virtual-indexed.
-            indexed_values = item.get("indexed_values") or {}
-            if indexed_values:
-                entry["indexed_values"] = indexed_values
+            # NOTE: the VIRTUAL index (per-file virtual values + co-occurrence
+            # tuples) is no longer sent to the catalog/Postgres — it lives entirely
+            # in the blob ``_vindex/`` sidecars written by _write_virtual_sidecar.
+            # Only column_stats (zone maps) still ride along in the manifest.
             file_entries.append(entry)
 
-        # Aggregate the DISTINCT full partition tuples across this batch for the
-        # catalog's combination dictionary. The same tuples repeat across files,
-        # so the deduped set stays small; the catalog upserts them (additive) so
-        # the tree/pruning stay exact for newly-ingested data without a reindex.
-        combo_seen: set = set()
-        partition_combinations: List[Dict[str, str]] = []
-        for item in file_items:
-            for combo in item.get("partition_combinations") or []:
-                key = tuple(sorted(combo.items()))
-                if key not in combo_seen:
-                    combo_seen.add(key)
-                    partition_combinations.append(combo)
-
-        # Send all files to catalog in a single request
+        # Send all files to catalog in a single request (files + column_stats
+        # only; the virtual index is in blob sidecars now, not Postgres).
         body: Dict[str, Any] = {"files": file_entries}
-        # Omitted when empty so older catalogs simply ignore the absent field.
-        if partition_combinations:
-            body["partition_combinations"] = partition_combinations
         response = self._catalog.post(
             f"/namespaces/{self.namespace}/tables/{self.table_name}/manifest/add-files",
             json=body,

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -818,8 +818,13 @@ class QuixTSDataLakeSink(BatchingSink):
         """Validate that the sink's partition strategy matches the existing table."""
         existing_partition_spec = table_metadata.get("partition_spec", [])
 
-        # Build expected partition spec from sink configuration
-        expected_partition_spec = self.hive_columns.copy()
+        # Build expected partition spec from sink configuration. Use the FULL tree
+        # order (physical + virtual, `~` stripped) — that's what the sink registers
+        # for a table with virtual columns (partition_spec = physical + virtual).
+        # Comparing against hive_columns (physical only) here would see the virtual
+        # columns as a spurious mismatch and wrongly reject the sink on RESTART to
+        # an existing table.
+        expected_partition_spec = self._partition_spec_order.copy()
 
         # Special case: If table has no partition spec yet (empty list),
         # it will be set when first files are added

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -106,7 +106,13 @@ class QuixTSDataLakeSink(BatchingSink):
     :param workspace_id: Workspace ID for workspace-scoped storage paths
         (auto-injected by platform)
     :param hive_columns: List of columns to use for Hive partitioning. Include
-        'year', 'month', 'day', 'hour' to extract these from timestamp_column
+        'year', 'month', 'day', 'hour' to extract these from timestamp_column.
+        Prefix an entry with ``~`` to make it a VIRTUAL partition: it appears in
+        the partition tree and is filterable, but is NOT written as a physical
+        ``key=value/`` folder and does not split files (a file keeps every value
+        of it). E.g. ``["year", "month", "~driver"]`` folders by year/month and
+        exposes ``driver`` as a virtual level. Virtual columns stay in the
+        parquet data so queries can still filter rows by them.
     :param timestamp_column: Column containing timestamp to extract time partitions from
     :param catalog_url: Optional REST Catalog URL for table registration
     :param catalog_auth_token: If using REST Catalog, the respective auth token for it
@@ -176,7 +182,19 @@ class QuixTSDataLakeSink(BatchingSink):
         self.s3_prefix = s3_prefix
         self.table_name = table_name
         self.workspace_id = workspace_id
-        self.hive_columns = hive_columns or []
+        # A ``~``-prefixed entry in hive_columns marks a VIRTUAL partition: it
+        # appears in the partition tree and is filterable, but is NOT written as
+        # a physical ``key=value/`` folder and does NOT group/split files (a
+        # single file keeps every value of it). We split the incoming list into:
+        #   * self.hive_columns          — physical columns (grouped + foldered)
+        #   * self._virtual_columns      — virtual columns (indexed, kept in data)
+        #   * self._partition_spec_order — full tree order (names, no prefix)
+        _raw_hive = hive_columns or []
+        self._virtual_columns = [c[1:] for c in _raw_hive if c.startswith("~")]
+        self.hive_columns = [c for c in _raw_hive if not c.startswith("~")]
+        self._partition_spec_order = [
+            c[1:] if c.startswith("~") else c for c in _raw_hive
+        ]
         self.timestamp_column = timestamp_column
         self._catalog = (
             QuixTSDataLakeCatalogClient(catalog_url, catalog_auth_token)
@@ -524,6 +542,40 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         return stats
 
+    def _compute_virtual_values(
+        self, df: pd.DataFrame, max_distinct: int = 10000
+    ) -> Dict[str, List[str]]:
+        """Distinct values of each configured virtual column present in this
+        file's data, as ``{column: ["v1", "v2", ...]}``.
+
+        Virtual columns are not foldered or grouped, so a file can carry many
+        of their values; the catalog indexes these so the partition tree can
+        enumerate them and queries can prune to files that contain a value. A
+        column with more than ``max_distinct`` values in a single file is
+        skipped (a guard against accidentally marking a high-cardinality column
+        virtual, which would bloat the index and make the tree unusable).
+        """
+        if not self._virtual_columns:
+            return {}
+        out: Dict[str, List[str]] = {}
+        for col in self._virtual_columns:
+            if col not in df.columns:
+                continue
+            try:
+                values = df[col].dropna().unique()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Skipping virtual values for column %s: %s", col, exc)
+                continue
+            if len(values) > max_distinct:
+                logger.warning(
+                    "Virtual column '%s' has %d distinct values in one file "
+                    "(> %d) — skipping its index for this file.",
+                    col, len(values), max_distinct,
+                )
+                continue
+            out[col] = sorted({str(v) for v in values})
+        return out
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -541,6 +593,10 @@ class QuixTSDataLakeSink(BatchingSink):
         # from storage later. Carried through _pending_futures into the catalog
         # add-files call (see _register_files_in_manifest).
         column_stats = self._compute_column_stats(table)
+        # Distinct values of any virtual partition columns present in this file
+        # (they aren't foldered, so a file can hold many). Cheap on the
+        # in-memory frame; carried to the catalog's file_virtual_values index.
+        virtual_values = self._compute_virtual_values(df)
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -560,6 +616,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 "partition_columns": partition_columns,
                 "partition_values": partition_values,
                 "column_stats": column_stats,
+                "virtual_values": virtual_values,
             }
         )
 
@@ -638,10 +695,21 @@ class QuixTSDataLakeSink(BatchingSink):
         else:
             location = f"s3://{self.s3_bucket}/{self.s3_prefix}/{self.table_name}"
 
-        # Define partition spec based on configuration
-        # For dynamic partition discovery, create table without partition spec
-        # The partition spec will be set when first files are added
-        partition_spec = []  # Empty spec for dynamic discovery
+        # Physical-only tables keep the historical dynamic-discovery behaviour
+        # (empty spec; the catalog derives it from the first files' paths). When
+        # any VIRTUAL column is configured it can't be discovered from paths, so
+        # we send the full intended tree order up front and declare which
+        # entries are virtual in properties.
+        properties = {
+            "created_by": "quixstreams-quix-lake-sink",
+            "auto_discovered": "false",
+            "expected_partitions": self._partition_spec_order.copy(),
+        }
+        if self._virtual_columns:
+            partition_spec = self._partition_spec_order.copy()
+            properties["virtual_partitions"] = self._virtual_columns.copy()
+        else:
+            partition_spec = []  # Empty spec for dynamic discovery
 
         # Create table with minimal schema (will be inferred from data)
         create_response = self._catalog.put(
@@ -649,11 +717,7 @@ class QuixTSDataLakeSink(BatchingSink):
             json={
                 "location": location,
                 "partition_spec": partition_spec,
-                "properties": {
-                    "created_by": "quixstreams-quix-lake-sink",
-                    "auto_discovered": "false",
-                    "expected_partitions": self.hive_columns.copy(),
-                },
+                "properties": properties,
             },
             timeout=30,
         )
@@ -827,6 +891,7 @@ class QuixTSDataLakeSink(BatchingSink):
             partition_columns = item["partition_columns"]
             partition_values = item["partition_values"]
             column_stats = item.get("column_stats") or {}
+            virtual_values = item.get("virtual_values") or {}
 
             # Build file path as full S3 URI for catalog (API uses this with DuckDB)
             # Include workspace_id if set (for workspace-scoped storage)
@@ -863,6 +928,11 @@ class QuixTSDataLakeSink(BatchingSink):
             # when empty so older catalogs simply ignore the absent field.
             if column_stats:
                 entry["column_stats"] = column_stats
+            # Attach virtual-partition value sets (catalog indexes them in
+            # file_virtual_values for tree navigation + pruning). Omitted when
+            # empty so older catalogs ignore the absent field.
+            if virtual_values:
+                entry["virtual_values"] = virtual_values
             file_entries.append(entry)
 
         # Send all files to catalog in a single request

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -600,6 +600,44 @@ class QuixTSDataLakeSink(BatchingSink):
             combos.append(combo)
         return combos
 
+    def _compute_virtual_values(
+        self, df: pd.DataFrame, max_distinct: int = 50000
+    ) -> Dict[str, List[str]]:
+        """Distinct values of each virtual column present in THIS file, for the
+        catalog's per-file virtual index (``file_virtual_values``) that powers
+        query PRUNING at file grain. Returns ``{col: [distinct values]}``.
+
+        Returned ONLY when EVERY virtual column is fully covered (present in the
+        file and within ``max_distinct``). The catalog marks a file
+        ``virtual_indexed`` with a single flag (not per-column), so a partially
+        covered file must stay un-indexed — otherwise a query on the missing
+        column would wrongly prune it. When we return ``{}`` the file is left
+        un-indexed (safety: never pruned; DuckDB still row-filters).
+        """
+        if not self._virtual_columns:
+            return {}
+        out: Dict[str, List[str]] = {}
+        for col in self._virtual_columns:
+            if col not in df.columns:
+                return {}   # not all virtual columns present -> don't index
+            try:
+                vals = df[col].dropna().unique()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("Skipping virtual values (col %s): %s", col, exc)
+                return {}
+            if len(vals) > max_distinct:
+                logger.warning(
+                    "Virtual column %s has %d distinct values (> %d) in a file — "
+                    "leaving the file un-indexed (safety).",
+                    col, len(vals), max_distinct,
+                )
+                return {}
+            out[str(col)] = [
+                str(v) for v in vals
+                if v is not None and not (isinstance(v, float) and v != v)
+            ]
+        return out
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -624,6 +662,10 @@ class QuixTSDataLakeSink(BatchingSink):
         partition_combinations = self._compute_partition_combinations(
             df, partition_columns, partition_values
         )
+        # Per-file distinct values of each virtual column -> the catalog's
+        # file_virtual_values index (file-grain query pruning). Empty unless all
+        # virtual columns are covered (see _compute_virtual_values).
+        virtual_values = self._compute_virtual_values(df)
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -644,6 +686,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 "partition_values": partition_values,
                 "column_stats": column_stats,
                 "partition_combinations": partition_combinations,
+                "virtual_values": virtual_values,
             }
         )
 
@@ -967,6 +1010,13 @@ class QuixTSDataLakeSink(BatchingSink):
             # when empty so older catalogs simply ignore the absent field.
             if column_stats:
                 entry["column_stats"] = column_stats
+            # Per-file virtual values -> file_virtual_values (file-grain pruning).
+            # Present only when all virtual columns are covered; the catalog marks
+            # the file virtual_indexed and prunes on it. Omitted otherwise (file
+            # stays un-indexed -> safety-kept).
+            virtual_values = item.get("virtual_values") or {}
+            if virtual_values:
+                entry["virtual_values"] = virtual_values
             file_entries.append(entry)
 
         # Aggregate the DISTINCT full partition tuples across this batch for the

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -129,19 +129,7 @@ class QuixTSDataLakeSink(BatchingSink):
         range cannot satisfy a WHERE/ORDER BY on the column. ``None`` (default)
         computes stats for every numeric and timestamp column in each written
         file (cheap — the batch is already in memory). Pass an explicit list to
-        restrict the set and bound catalog storage on very wide tables. String
-        columns are not supported here — use ``auto_index_max_cardinality`` for
-        those.
-    :param auto_index_max_cardinality: Auto-index low-cardinality non-numeric
-        columns (strings/bools/categoricals — the ones ``stats_columns`` can't
-        cover) so ``WHERE col = 'x'`` prunes files without marking the column
-        virtual (``~``). For each written file, any such column whose distinct
-        count in that file is <= this value has its distinct values recorded in
-        the catalog's file_virtual_values index; a column over the cap is skipped
-        for that file only (safe — the file is kept and rows are filtered at read
-        time). Default 100; set 0 to disable. Only worthwhile for CLUSTERED
-        columns (each file holds a small, distinct subset) — an un-clustered
-        column costs storage for no pruning, so keep the cap modest on wide tables.
+        restrict the set and bound catalog storage on very wide tables.
     :param stream_timeout_ms: Optional **per-key** silence threshold in
         milliseconds. Paired with ``on_stream_timeout``; both must be
         provided to enable the feature. See
@@ -182,7 +170,6 @@ class QuixTSDataLakeSink(BatchingSink):
         auto_create_bucket: bool = True,
         max_workers: int = 10,
         stats_columns: Optional[List[str]] = None,
-        auto_index_max_cardinality: int = 100,
         stream_timeout_ms: Optional[int] = None,
         on_stream_timeout: Optional[Callable[[Any], None]] = None,
         silence_azure_http_logs: bool = True,
@@ -235,20 +222,6 @@ class QuixTSDataLakeSink(BatchingSink):
         # entry as ``column_stats`` and are consumed by the catalog's pruning.
         self._stats_columns = set(stats_columns) if stats_columns else None
 
-        # Auto-indexing of low-cardinality NON-numeric columns (strings, bools,
-        # categoricals) that column_stats can't prune. For each written file we
-        # record the distinct values of every such column whose per-file distinct
-        # count is <= this cap into the catalog's file_virtual_values index, so
-        # ``WHERE col = 'x'`` prunes files even without marking the column
-        # virtual (``~``). PER-COLUMN + PER-FILE: a column over the cap in a
-        # given file is simply skipped for that file (never taints other columns
-        # or other files). 0 disables. Numeric/timestamp columns are excluded —
-        # they already prune via column_stats. NOTE: only pays off for CLUSTERED
-        # columns (each file holds a small, distinct subset); an un-clustered
-        # column costs storage for no pruning, so keep the cap modest and prefer
-        # an explicit set on very wide tables.
-        self._auto_index_max_cardinality = max(0, int(auto_index_max_cardinality))
-
         # Blob storage client and bucket name will be initialized in setup()
         self._blob_client: Optional[BlobStorageClient] = None
         self._s3_bucket: Optional[str] = None
@@ -261,7 +234,7 @@ class QuixTSDataLakeSink(BatchingSink):
 
         # Batch upload tracking
         self._pending_futures: List[Dict[str, Any]] = []
-        # Virtual-index SIDECAR uploads (one per data file, written to _vindex/).
+        # Virtual-index SIDECAR uploads (one per data file, written to .vidx/).
         # Tracked separately from data files so _finalize_writes waits on them but
         # does NOT register them in the manifest (they are metadata, not data).
         self._pending_sidecar_futures: List[Dict[str, Any]] = []
@@ -581,137 +554,6 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         return stats
 
-    def _compute_partition_combinations(
-        self,
-        df: pd.DataFrame,
-        partition_columns: List[str],
-        partition_values: tuple,
-        max_distinct: int = 50000,
-    ) -> List[Dict[str, str]]:
-        """Distinct full partition tuples (physical + virtual) in this file, for
-        the catalog's ``table_partition_combinations`` dictionary.
-
-        Records which virtual values actually CO-OCCUR: the file's physical
-        partition values (constant per file) combined with each distinct
-        virtual-value tuple (``df[virtual].drop_duplicates()``). The catalog
-        stores the DISTINCT set across files (table_partition_combinations — the
-        sole virtual index), so the tree shows only real combinations and
-        multi-column queries prune. Skipped for a file with more than
-        ``max_distinct`` distinct tuples (a high-cardinality guard).
-        """
-        if not self._virtual_columns:
-            return []
-        present = [c for c in self._virtual_columns if c in df.columns]
-        if not present:
-            return []
-        physical: Dict[str, str] = {}
-        for col, val in zip(partition_columns or [], partition_values or ()):
-            if val is not None:
-                physical[str(col)] = str(val)
-        try:
-            distinct = df[present].drop_duplicates()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.debug("Skipping partition combinations: %s", exc)
-            return []
-        if len(distinct) > max_distinct:
-            logger.warning(
-                "File has %d distinct virtual combinations (> %d) — skipping the "
-                "combination index for this file.",
-                len(distinct), max_distinct,
-            )
-            return []
-        combos: List[Dict[str, str]] = []
-        for row in distinct.itertuples(index=False):
-            combo = dict(physical)
-            for col, v in zip(present, row):
-                if v is None or (isinstance(v, float) and v != v):  # NULL / NaN
-                    continue
-                combo[str(col)] = str(v)
-            combos.append(combo)
-        return combos
-
-    def _compute_virtual_values(
-        self, df: pd.DataFrame, max_distinct: int = 50000
-    ) -> Dict[str, List[str]]:
-        """Distinct values of each virtual column present in THIS file, for the
-        catalog's per-file virtual index (``file_virtual_values``) that powers
-        query PRUNING at file grain. Returns ``{col: [distinct values]}``.
-
-        Returned ONLY when EVERY virtual column is fully covered (present in the
-        file and within ``max_distinct``). The catalog marks a file
-        ``virtual_indexed`` with a single flag (not per-column), so a partially
-        covered file must stay un-indexed — otherwise a query on the missing
-        column would wrongly prune it. When we return ``{}`` the file is left
-        un-indexed (safety: never pruned; DuckDB still row-filters).
-        """
-        if not self._virtual_columns:
-            return {}
-        out: Dict[str, List[str]] = {}
-        for col in self._virtual_columns:
-            if col not in df.columns:
-                return {}   # not all virtual columns present -> don't index
-            try:
-                vals = df[col].dropna().unique()
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("Skipping virtual values (col %s): %s", col, exc)
-                return {}
-            if len(vals) > max_distinct:
-                logger.warning(
-                    "Virtual column %s has %d distinct values (> %d) in a file — "
-                    "leaving the file un-indexed (safety).",
-                    col, len(vals), max_distinct,
-                )
-                return {}
-            out[str(col)] = [
-                str(v) for v in vals
-                if v is not None and not (isinstance(v, float) and v != v)
-            ]
-        return out
-
-    def _compute_auto_index_values(self, df: pd.DataFrame) -> Dict[str, List[str]]:
-        """Per-file distinct values of low-cardinality NON-numeric columns for
-        the catalog's file_virtual_values PRUNING index — the "auto-index" lane.
-
-        Covers exactly the columns column_stats can't (strings, bools,
-        categoricals); numeric/timestamp are skipped (they prune via min/max).
-        PER-COLUMN, PER-FILE: each eligible column is included independently iff
-        its distinct count in THIS file is within
-        ``self._auto_index_max_cardinality``; an over-cap column is skipped for
-        this file only (safe — the catalog keeps such files and DuckDB
-        row-filters). Virtual (``~``) and physical partition columns are excluded
-        (handled elsewhere / not in the data). Returns ``{col: [values]}`` or {}.
-        """
-        cap = self._auto_index_max_cardinality
-        if cap <= 0:
-            return {}
-        skip = set(self._virtual_columns) | set(self.hive_columns) | {"__key", self.timestamp_column}
-        out: Dict[str, List[str]] = {}
-        for col in df.columns:
-            if col in skip:
-                continue
-            s = df[col]
-            # Only column kinds column_stats does NOT already cover.
-            is_indexable = (
-                pd.api.types.is_string_dtype(s)
-                or pd.api.types.is_object_dtype(s)
-                or pd.api.types.is_bool_dtype(s)
-                or isinstance(s.dtype, pd.CategoricalDtype)
-            )
-            if not is_indexable:
-                continue
-            try:
-                vals = s.dropna().unique()
-            except Exception as exc:  # pragma: no cover - defensive (unhashable)
-                logger.debug("Skipping auto-index (col %s): %s", col, exc)
-                continue
-            if len(vals) == 0 or len(vals) > cap:
-                continue  # nothing to index / over cap -> skip THIS column for THIS file
-            # Skip complex/object values (dicts, lists) — only scalar categoricals.
-            if any(isinstance(v, (dict, list, set, tuple)) for v in vals):
-                continue
-            out[str(col)] = sorted({str(v) for v in vals})
-        return out
-
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -751,18 +593,11 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         )
 
-        # The VIRTUAL index for this file goes to a blob ``_vindex/`` sidecar
-        # (navigation + query pruning read it via DuckDB) — the SOLE virtual index;
-        # nothing virtual is sent to Postgres anymore. column_stats (zone maps)
-        # still go to the catalog above.
+        # The VIRTUAL index for this file goes to a blob ``.vidx/`` sidecar
+        # (navigation reads it via DuckDB) — the SOLE virtual index; nothing
+        # virtual is sent to Postgres anymore. column_stats (zone maps) still go
+        # to the catalog above.
         self._write_virtual_sidecar(df, storage_key, partition_columns, partition_values)
-
-    def _catalog_file_path(self, storage_key: str) -> str:
-        """The full ``s3://`` URI a data/sidecar file is registered under — same
-        construction as _register_files_in_manifest (workspace-scoped)."""
-        if self.workspace_id:
-            return f"s3://{self.s3_bucket}/{self.workspace_id}/{storage_key}"
-        return f"s3://{self.s3_bucket}/{storage_key}"
 
     def _sidecar_key(self, storage_key: str) -> str:
         """Blob key of a data file's virtual-index sidecar: in a ``.vidx/``
@@ -778,7 +613,7 @@ class QuixTSDataLakeSink(BatchingSink):
 
     def _write_virtual_sidecar(self, df: pd.DataFrame, storage_key: str,
                                partition_columns: List[str], partition_values: tuple):
-        """Write this data file's virtual-index sidecar Parquet to ``_vindex/``.
+        """Write this data file's virtual-index sidecar Parquet to ``.vidx/``.
 
         Content: one row per DISTINCT tuple of the table's VIRTUAL columns present
         in this file, with the file's PHYSICAL partition values added as constant
@@ -1160,7 +995,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 entry["column_stats"] = column_stats
             # NOTE: the VIRTUAL index (per-file virtual values + co-occurrence
             # tuples) is no longer sent to the catalog/Postgres — it lives entirely
-            # in the blob ``_vindex/`` sidecars written by _write_virtual_sidecar.
+            # in the blob ``.vidx/`` sidecars written by _write_virtual_sidecar.
             # Only column_stats (zone maps) still ride along in the manifest.
             file_entries.append(entry)
 

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -130,7 +130,18 @@ class QuixTSDataLakeSink(BatchingSink):
         computes stats for every numeric and timestamp column in each written
         file (cheap — the batch is already in memory). Pass an explicit list to
         restrict the set and bound catalog storage on very wide tables. String
-        columns are not supported yet and are always skipped.
+        columns are not supported here — use ``auto_index_max_cardinality`` for
+        those.
+    :param auto_index_max_cardinality: Auto-index low-cardinality non-numeric
+        columns (strings/bools/categoricals — the ones ``stats_columns`` can't
+        cover) so ``WHERE col = 'x'`` prunes files without marking the column
+        virtual (``~``). For each written file, any such column whose distinct
+        count in that file is <= this value has its distinct values recorded in
+        the catalog's file_virtual_values index; a column over the cap is skipped
+        for that file only (safe — the file is kept and rows are filtered at read
+        time). Default 100; set 0 to disable. Only worthwhile for CLUSTERED
+        columns (each file holds a small, distinct subset) — an un-clustered
+        column costs storage for no pruning, so keep the cap modest on wide tables.
     :param stream_timeout_ms: Optional **per-key** silence threshold in
         milliseconds. Paired with ``on_stream_timeout``; both must be
         provided to enable the feature. See
@@ -171,6 +182,7 @@ class QuixTSDataLakeSink(BatchingSink):
         auto_create_bucket: bool = True,
         max_workers: int = 10,
         stats_columns: Optional[List[str]] = None,
+        auto_index_max_cardinality: int = 100,
         stream_timeout_ms: Optional[int] = None,
         on_stream_timeout: Optional[Callable[[Any], None]] = None,
         silence_azure_http_logs: bool = True,
@@ -222,6 +234,20 @@ class QuixTSDataLakeSink(BatchingSink):
         # growth on very wide tables. Stats ride along with each add-files
         # entry as ``column_stats`` and are consumed by the catalog's pruning.
         self._stats_columns = set(stats_columns) if stats_columns else None
+
+        # Auto-indexing of low-cardinality NON-numeric columns (strings, bools,
+        # categoricals) that column_stats can't prune. For each written file we
+        # record the distinct values of every such column whose per-file distinct
+        # count is <= this cap into the catalog's file_virtual_values index, so
+        # ``WHERE col = 'x'`` prunes files even without marking the column
+        # virtual (``~``). PER-COLUMN + PER-FILE: a column over the cap in a
+        # given file is simply skipped for that file (never taints other columns
+        # or other files). 0 disables. Numeric/timestamp columns are excluded —
+        # they already prune via column_stats. NOTE: only pays off for CLUSTERED
+        # columns (each file holds a small, distinct subset); an un-clustered
+        # column costs storage for no pruning, so keep the cap modest and prefer
+        # an explicit set on very wide tables.
+        self._auto_index_max_cardinality = max(0, int(auto_index_max_cardinality))
 
         # Blob storage client and bucket name will be initialized in setup()
         self._blob_client: Optional[BlobStorageClient] = None
@@ -638,6 +664,50 @@ class QuixTSDataLakeSink(BatchingSink):
             ]
         return out
 
+    def _compute_auto_index_values(self, df: pd.DataFrame) -> Dict[str, List[str]]:
+        """Per-file distinct values of low-cardinality NON-numeric columns for
+        the catalog's file_virtual_values PRUNING index — the "auto-index" lane.
+
+        Covers exactly the columns column_stats can't (strings, bools,
+        categoricals); numeric/timestamp are skipped (they prune via min/max).
+        PER-COLUMN, PER-FILE: each eligible column is included independently iff
+        its distinct count in THIS file is within
+        ``self._auto_index_max_cardinality``; an over-cap column is skipped for
+        this file only (safe — the catalog keeps such files and DuckDB
+        row-filters). Virtual (``~``) and physical partition columns are excluded
+        (handled elsewhere / not in the data). Returns ``{col: [values]}`` or {}.
+        """
+        cap = self._auto_index_max_cardinality
+        if cap <= 0:
+            return {}
+        skip = set(self._virtual_columns) | set(self.hive_columns) | {"__key", self.timestamp_column}
+        out: Dict[str, List[str]] = {}
+        for col in df.columns:
+            if col in skip:
+                continue
+            s = df[col]
+            # Only column kinds column_stats does NOT already cover.
+            is_indexable = (
+                pd.api.types.is_string_dtype(s)
+                or pd.api.types.is_object_dtype(s)
+                or pd.api.types.is_bool_dtype(s)
+                or isinstance(s.dtype, pd.CategoricalDtype)
+            )
+            if not is_indexable:
+                continue
+            try:
+                vals = s.dropna().unique()
+            except Exception as exc:  # pragma: no cover - defensive (unhashable)
+                logger.debug("Skipping auto-index (col %s): %s", col, exc)
+                continue
+            if len(vals) == 0 or len(vals) > cap:
+                continue  # nothing to index / over cap -> skip THIS column for THIS file
+            # Skip complex/object values (dicts, lists) — only scalar categoricals.
+            if any(isinstance(v, (dict, list, set, tuple)) for v in vals):
+                continue
+            out[str(col)] = sorted({str(v) for v in vals})
+        return out
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -666,6 +736,10 @@ class QuixTSDataLakeSink(BatchingSink):
         # file_virtual_values index (file-grain query pruning). Empty unless all
         # virtual columns are covered (see _compute_virtual_values).
         virtual_values = self._compute_virtual_values(df)
+        # Auto-index lane: per-file distinct values of low-cardinality
+        # non-numeric columns (not marked virtual) so their equality filters also
+        # prune. Per-column/per-file, independent of the virtual all-or-nothing.
+        indexed_values = self._compute_auto_index_values(df)
 
         buf = pa.BufferOutputStream()
         pq.write_table(table, buf)
@@ -687,6 +761,7 @@ class QuixTSDataLakeSink(BatchingSink):
                 "column_stats": column_stats,
                 "partition_combinations": partition_combinations,
                 "virtual_values": virtual_values,
+                "indexed_values": indexed_values,
             }
         )
 
@@ -1017,6 +1092,12 @@ class QuixTSDataLakeSink(BatchingSink):
             virtual_values = item.get("virtual_values") or {}
             if virtual_values:
                 entry["virtual_values"] = virtual_values
+            # Auto-index lane -> also file_virtual_values, but PER-COLUMN
+            # (prune-only, not tree). Independent of virtual_values, so a file
+            # can carry these even when it isn't fully virtual-indexed.
+            indexed_values = item.get("indexed_values") or {}
+            if indexed_values:
+                entry["indexed_values"] = indexed_values
             file_entries.append(entry)
 
         # Aggregate the DISTINCT full partition tuples across this batch for the

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -114,6 +114,9 @@ class QuixTSDataLakeSink(BatchingSink):
         exposes ``driver`` as a virtual level. Virtual columns stay in the
         parquet data so queries can still filter rows by them.
     :param timestamp_column: Column containing timestamp to extract time partitions from
+    :param sort_column: Optional column recorded on the table (properties.sort_column)
+        that compaction orders files by, so ORDER BY / time-range queries can skip
+        files and stream. When None, the lakehouse falls back to timestamp_column.
     :param catalog_url: Optional REST Catalog URL for table registration
     :param catalog_auth_token: If using REST Catalog, the respective auth token for it
     :param auto_discover: Whether to auto-register table on first write
@@ -160,6 +163,7 @@ class QuixTSDataLakeSink(BatchingSink):
         workspace_id: str = "",
         hive_columns: Optional[List[str]] = None,
         timestamp_column: str = "ts_ms",
+        sort_column: Optional[str] = None,
         catalog_url: Optional[str] = None,
         catalog_auth_token: Optional[str] = None,
         auto_discover: bool = True,
@@ -196,6 +200,11 @@ class QuixTSDataLakeSink(BatchingSink):
             c[1:] if c.startswith("~") else c for c in _raw_hive
         ]
         self.timestamp_column = timestamp_column
+        # Preferred ordering column recorded on the table (properties.sort_column).
+        # Compaction writes files ordered by it so ORDER BY / range queries can
+        # skip files and stream. When None, the lakehouse falls back to the
+        # timestamp column automatically.
+        self.sort_column = sort_column or None
         self._catalog = (
             QuixTSDataLakeCatalogClient(catalog_url, catalog_auth_token)
             if catalog_url
@@ -710,6 +719,14 @@ class QuixTSDataLakeSink(BatchingSink):
             properties["virtual_partitions"] = self._virtual_columns.copy()
         else:
             partition_spec = []  # Empty spec for dynamic discovery
+
+        # Record the ordering columns so lakehouse compaction can write
+        # time-ordered, skippable files. sort_column (when set) takes precedence;
+        # timestamp_column is the automatic fallback, so persist it too.
+        if self.timestamp_column:
+            properties["timestamp_column"] = self.timestamp_column
+        if self.sort_column:
+            properties["sort_column"] = self.sort_column
 
         # Create table with minimal schema (will be inferred from data)
         create_response = self._catalog.put(

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -782,14 +782,13 @@ class QuixTSDataLakeSink(BatchingSink):
 
         Content: one row per DISTINCT tuple of the table's VIRTUAL columns present
         in this file, with the file's PHYSICAL partition values added as constant
-        columns, plus ``__file`` = the data file's catalog URI. Carrying the
-        physical columns in the content means readers need no ``hive_partitioning``
-        — a single ``read_parquet('{root}/_vindex/**')`` yields full (physical +
-        virtual) tuples. Navigation aggregates these
-        (``SELECT DISTINCT <col> WHERE <ancestors>``) into the folder tree;
-        query-pruning selects ``__file`` for a virtual filter. Both via DuckDB over
-        blob — no Postgres. No-op when the table has no virtual columns or none are
-        present in this file. Never raises (the index is a hint, not the data).
+        columns. Carrying the physical columns in the content means readers need no
+        ``hive_partitioning`` — a single ``read_parquet('{root}/.../.vidx/*')``
+        yields full (physical + virtual) tuples that navigation aggregates
+        (``SELECT DISTINCT <col> WHERE <ancestors>``) into the folder tree. The
+        index is navigation-only (no query pruning), so no per-file back-reference
+        is stored. No-op when the table has no virtual columns or none are present
+        in this file. Never raises (the index is a hint, not the data).
         """
         present = [c for c in self._virtual_columns if c in df.columns]
         if not present or self._blob_client is None:
@@ -803,7 +802,6 @@ class QuixTSDataLakeSink(BatchingSink):
             # FULL partition tuple.
             for col, val in zip(partition_columns or [], partition_values or ()):
                 vdf[col] = str(val)
-            vdf["__file"] = self._catalog_file_path(storage_key)
             buf = pa.BufferOutputStream()
             pq.write_table(pa.Table.from_pandas(vdf, preserve_index=False), buf)
             sidecar_key = self._sidecar_key(storage_key)

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -123,16 +123,13 @@ class QuixTSDataLakeSink(BatchingSink):
     :param namespace: Catalog namespace (default: "default")
     :param auto_create_bucket: If True, attempt to create bucket/path in storage if missing
     :param max_workers: Maximum number of parallel upload threads (default: 10)
-    :param row_group_mb: Target size in MB of each Parquet ROW GROUP in the
-        files this sink writes (default 32, the lakehouse compaction target).
-        A reader pays ~4 storage range requests per row group, so many small
-        groups make every query slow on a high-latency storage path, while
-        one huge group forfeits intra-file skipping and inflates reader memory.
-        Row groups are sized in rows: the sink learns the table's rows-per-MB
-        from the compressed bytes of the files it has already written and
-        uses ``rows_per_mb x row_group_mb`` rows per group for the next file
-        (clamped to [122,880; 50,000,000]; 1,000,000 rows before the first
-        file). Files smaller than the target are, as always, a single group.
+    :param row_group_rows: Maximum rows per Parquet ROW GROUP in the files this
+        sink writes (default 1,000,000, the same as the lakehouse compaction's
+        ``COMPACTION_ROW_GROUP_ROWS``). A reader pays about one storage range
+        request per row group, so many small groups make every query slow on a
+        high-latency storage path, while one huge group forfeits intra-file
+        skipping and inflates reader memory. A flush smaller than this is, as
+        always, a single row group.
     :param stats_columns: Optional list of column names to compute per-file
         min/max statistics ("zone maps") for. These are sent to the REST
         Catalog with each file and let the query layer skip files whose value
@@ -180,7 +177,7 @@ class QuixTSDataLakeSink(BatchingSink):
         auto_create_bucket: bool = True,
         max_workers: int = 10,
         stats_columns: Optional[List[str]] = None,
-        row_group_mb: Optional[float] = None,
+        row_group_rows: Optional[int] = None,
         stream_timeout_ms: Optional[int] = None,
         on_stream_timeout: Optional[Callable[[Any], None]] = None,
         silence_azure_http_logs: bool = True,
@@ -233,17 +230,14 @@ class QuixTSDataLakeSink(BatchingSink):
         # entry as ``column_stats`` and are consumed by the catalog's pruning.
         self._stats_columns = set(stats_columns) if stats_columns else None
 
-        # Parquet row-group sizing (see ROW_GROUP_* below): target MB per row
-        # group, and the running rows/bytes totals of everything this sink has
-        # serialised, from which the table's density (rows per MB) is derived.
-        if row_group_mb is not None and float(row_group_mb) <= 0:
-            raise ValueError("row_group_mb must be > 0")
-        self._row_group_mb = (
-            float(row_group_mb) if row_group_mb is not None
-            else float(self.ROW_GROUP_TARGET_MB_DEFAULT)
+        # Parquet row-group size: a fixed, configurable row count (no
+        # statistics-derived sizing — owner decision, keep it simple).
+        if row_group_rows is not None and int(row_group_rows) < 1:
+            raise ValueError("row_group_rows must be >= 1")
+        self._row_group_rows = (
+            int(row_group_rows) if row_group_rows is not None
+            else self.ROW_GROUP_ROWS_DEFAULT
         )
-        self._written_rows = 0
-        self._written_bytes = 0
 
         # Blob storage client and bucket name will be initialized in setup()
         self._blob_client: Optional[BlobStorageClient] = None
@@ -577,40 +571,16 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         return stats
 
-    # ---- Parquet row-group sizing -------------------------------------------
+    # ---- Parquet row-group size ----------------------------------------------
     # Same rule as the lakehouse compaction/repartition rewrites: a reader needs
-    # ~4 storage range requests PER ROW GROUP (column chunks are coalesced within
-    # a group, never across), so a file cut into many small groups costs a
-    # round-trip storm on a high-latency storage path, while one enormous group
-    # forfeits intra-file skipping and inflates reader memory. Parquet writers
-    # size groups in ROWS, so we convert the MB target with the table's density:
-    # rows_per_mb (from the compressed bytes of files already written by this
-    # sink — same columns, same encodings) x row_group_mb rows per group.
-    # Before the first file the density is unknown -> ROW_GROUP_ROWS_FALLBACK,
-    # which is also pyarrow's own default (~1Mi rows), so behaviour is unchanged
-    # until there is something to learn from. Files smaller than one group are,
-    # as always, a single group; splitting only kicks in for large flushes.
-    ROW_GROUP_TARGET_MB_DEFAULT = 32
-    ROW_GROUP_ROWS_FALLBACK = 1_000_000  # density unknown (nothing written yet)
-    ROW_GROUP_ROWS_MIN = 122_880  # never smaller than DuckDB's default group
-    ROW_GROUP_ROWS_MAX = 50_000_000  # bounds the writer's in-memory buffer
-
-    @classmethod
-    def _row_group_rows(cls, total_rows: Any, total_bytes: Any, target_mb: Any) -> int:
-        """Rows per row group that come to about ``target_mb`` at the density
-        ``total_rows / total_bytes``; the fallback when either is unknown."""
-        try:
-            rows, size, target = float(total_rows or 0), float(total_bytes or 0), float(target_mb or 0)
-        except (TypeError, ValueError):
-            return cls.ROW_GROUP_ROWS_FALLBACK
-        if rows <= 0 or size <= 0 or target <= 0:
-            return cls.ROW_GROUP_ROWS_FALLBACK
-        rows_per_mb = rows / (size / (1024 * 1024))
-        return int(max(cls.ROW_GROUP_ROWS_MIN, min(cls.ROW_GROUP_ROWS_MAX, round(rows_per_mb * target))))
-
-    def _row_group_size(self) -> int:
-        """Row-group size (rows) for the next file, from what was written so far."""
-        return self._row_group_rows(self._written_rows, self._written_bytes, self._row_group_mb)
+    # about one storage range request PER ROW GROUP (column chunks are coalesced
+    # within a group, never across), so a file cut into many small groups costs
+    # a round-trip storm on a high-latency storage path, while one enormous
+    # group forfeits intra-file skipping and inflates reader memory. The size is
+    # a fixed row count (default 1,000,000 = the lakehouse's
+    # COMPACTION_ROW_GROUP_ROWS default and ~pyarrow's own default), so small
+    # flushes are a single group and only large flushes are split.
+    ROW_GROUP_ROWS_DEFAULT = 1_000_000
 
     def _write_parquet_to_storage(
         self,
@@ -630,20 +600,13 @@ class QuixTSDataLakeSink(BatchingSink):
         # add-files call (see _register_files_in_manifest).
         column_stats = self._compute_column_stats(table)
 
-        row_group_size = self._row_group_size()
         buf = pa.BufferOutputStream()
-        pq.write_table(table, buf, row_group_size=row_group_size)
+        pq.write_table(table, buf, row_group_size=self._row_group_rows)
         parquet_bytes = buf.getvalue().to_pybytes()
-        # Feed the density estimate for the next file (weighted by bytes, so
-        # large files dominate and the per-file footer overhead of tiny files
-        # does not skew it).
-        self._written_rows += table.num_rows
-        self._written_bytes += len(parquet_bytes)
-        if table.num_rows > row_group_size:
+        if table.num_rows > self._row_group_rows:
             logger.debug(
-                "Wrote %s with %d row groups of <= %d rows (target %.1f MB, %.0f rows/MB observed)",
-                storage_key, -(-table.num_rows // row_group_size), row_group_size, self._row_group_mb,
-                self._written_rows / max(self._written_bytes / (1024 * 1024), 1e-9),
+                "Wrote %s with %d row groups of <= %d rows",
+                storage_key, -(-table.num_rows // self._row_group_rows), self._row_group_rows,
             )
 
         # Submit async upload

--- a/quixstreams/sinks/core/quix_ts_datalake_sink.py
+++ b/quixstreams/sinks/core/quix_ts_datalake_sink.py
@@ -123,6 +123,16 @@ class QuixTSDataLakeSink(BatchingSink):
     :param namespace: Catalog namespace (default: "default")
     :param auto_create_bucket: If True, attempt to create bucket/path in storage if missing
     :param max_workers: Maximum number of parallel upload threads (default: 10)
+    :param row_group_mb: Target size in MB of each Parquet ROW GROUP in the
+        files this sink writes (default 32, the lakehouse compaction target).
+        A reader pays ~4 storage range requests per row group, so many small
+        groups make every query slow on a high-latency storage path, while
+        one huge group forfeits intra-file skipping and inflates reader memory.
+        Row groups are sized in rows: the sink learns the table's rows-per-MB
+        from the compressed bytes of the files it has already written and
+        uses ``rows_per_mb x row_group_mb`` rows per group for the next file
+        (clamped to [122,880; 50,000,000]; 1,000,000 rows before the first
+        file). Files smaller than the target are, as always, a single group.
     :param stats_columns: Optional list of column names to compute per-file
         min/max statistics ("zone maps") for. These are sent to the REST
         Catalog with each file and let the query layer skip files whose value
@@ -170,6 +180,7 @@ class QuixTSDataLakeSink(BatchingSink):
         auto_create_bucket: bool = True,
         max_workers: int = 10,
         stats_columns: Optional[List[str]] = None,
+        row_group_mb: Optional[float] = None,
         stream_timeout_ms: Optional[int] = None,
         on_stream_timeout: Optional[Callable[[Any], None]] = None,
         silence_azure_http_logs: bool = True,
@@ -221,6 +232,18 @@ class QuixTSDataLakeSink(BatchingSink):
         # growth on very wide tables. Stats ride along with each add-files
         # entry as ``column_stats`` and are consumed by the catalog's pruning.
         self._stats_columns = set(stats_columns) if stats_columns else None
+
+        # Parquet row-group sizing (see ROW_GROUP_* below): target MB per row
+        # group, and the running rows/bytes totals of everything this sink has
+        # serialised, from which the table's density (rows per MB) is derived.
+        if row_group_mb is not None and float(row_group_mb) <= 0:
+            raise ValueError("row_group_mb must be > 0")
+        self._row_group_mb = (
+            float(row_group_mb) if row_group_mb is not None
+            else float(self.ROW_GROUP_TARGET_MB_DEFAULT)
+        )
+        self._written_rows = 0
+        self._written_bytes = 0
 
         # Blob storage client and bucket name will be initialized in setup()
         self._blob_client: Optional[BlobStorageClient] = None
@@ -554,6 +577,41 @@ class QuixTSDataLakeSink(BatchingSink):
             }
         return stats
 
+    # ---- Parquet row-group sizing -------------------------------------------
+    # Same rule as the lakehouse compaction/repartition rewrites: a reader needs
+    # ~4 storage range requests PER ROW GROUP (column chunks are coalesced within
+    # a group, never across), so a file cut into many small groups costs a
+    # round-trip storm on a high-latency storage path, while one enormous group
+    # forfeits intra-file skipping and inflates reader memory. Parquet writers
+    # size groups in ROWS, so we convert the MB target with the table's density:
+    # rows_per_mb (from the compressed bytes of files already written by this
+    # sink — same columns, same encodings) x row_group_mb rows per group.
+    # Before the first file the density is unknown -> ROW_GROUP_ROWS_FALLBACK,
+    # which is also pyarrow's own default (~1Mi rows), so behaviour is unchanged
+    # until there is something to learn from. Files smaller than one group are,
+    # as always, a single group; splitting only kicks in for large flushes.
+    ROW_GROUP_TARGET_MB_DEFAULT = 32
+    ROW_GROUP_ROWS_FALLBACK = 1_000_000  # density unknown (nothing written yet)
+    ROW_GROUP_ROWS_MIN = 122_880  # never smaller than DuckDB's default group
+    ROW_GROUP_ROWS_MAX = 50_000_000  # bounds the writer's in-memory buffer
+
+    @classmethod
+    def _row_group_rows(cls, total_rows: Any, total_bytes: Any, target_mb: Any) -> int:
+        """Rows per row group that come to about ``target_mb`` at the density
+        ``total_rows / total_bytes``; the fallback when either is unknown."""
+        try:
+            rows, size, target = float(total_rows or 0), float(total_bytes or 0), float(target_mb or 0)
+        except (TypeError, ValueError):
+            return cls.ROW_GROUP_ROWS_FALLBACK
+        if rows <= 0 or size <= 0 or target <= 0:
+            return cls.ROW_GROUP_ROWS_FALLBACK
+        rows_per_mb = rows / (size / (1024 * 1024))
+        return int(max(cls.ROW_GROUP_ROWS_MIN, min(cls.ROW_GROUP_ROWS_MAX, round(rows_per_mb * target))))
+
+    def _row_group_size(self) -> int:
+        """Row-group size (rows) for the next file, from what was written so far."""
+        return self._row_group_rows(self._written_rows, self._written_bytes, self._row_group_mb)
+
     def _write_parquet_to_storage(
         self,
         df: pd.DataFrame,
@@ -572,9 +630,21 @@ class QuixTSDataLakeSink(BatchingSink):
         # add-files call (see _register_files_in_manifest).
         column_stats = self._compute_column_stats(table)
 
+        row_group_size = self._row_group_size()
         buf = pa.BufferOutputStream()
-        pq.write_table(table, buf)
+        pq.write_table(table, buf, row_group_size=row_group_size)
         parquet_bytes = buf.getvalue().to_pybytes()
+        # Feed the density estimate for the next file (weighted by bytes, so
+        # large files dominate and the per-file footer overhead of tiny files
+        # does not skew it).
+        self._written_rows += table.num_rows
+        self._written_bytes += len(parquet_bytes)
+        if table.num_rows > row_group_size:
+            logger.debug(
+                "Wrote %s with %d row groups of <= %d rows (target %.1f MB, %.0f rows/MB observed)",
+                storage_key, -(-table.num_rows // row_group_size), row_group_size, self._row_group_mb,
+                self._written_rows / max(self._written_bytes / (1024 * 1024), 1e-9),
+            )
 
         # Submit async upload
         if self._blob_client is None:

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -1608,6 +1608,49 @@ class TestQuixTSDataLakeSinkVirtualPartitions:
         assert len(files) == 1  # not split by driver
         assert set(files[0]["virtual_values"]["driver"]) == {"HAM", "VER"}
 
+    def test_compute_partition_combinations(self, sink_factory):
+        sink = sink_factory(hive_columns=["year", "~driver", "~channel"])
+        # HAM only ever on radio, VER only on tv — they never share a row.
+        df = pd.DataFrame({
+            "driver": ["HAM", "HAM", "VER"],
+            "channel": ["radio", "radio", "tv"],
+            "x": [1, 2, 3],
+        })
+        combos = sink._compute_partition_combinations(df, ["year"], ("2024",))
+        # Only the tuples that CO-OCCUR — NOT the cross-product (no HAM/tv, VER/radio).
+        assert {tuple(sorted(c.items())) for c in combos} == {
+            (("channel", "radio"), ("driver", "HAM"), ("year", "2024")),
+            (("channel", "tv"), ("driver", "VER"), ("year", "2024")),
+        }
+
+    def test_compute_partition_combinations_no_virtual_columns(self, sink_factory):
+        sink = sink_factory(hive_columns=["year"])  # physical only
+        df = pd.DataFrame({"x": [1, 2]})
+        assert sink._compute_partition_combinations(df, ["year"], ("2024",)) == []
+
+    def test_high_cardinality_combinations_skipped(self, sink_factory):
+        sink = sink_factory(hive_columns=["~id"])
+        df = pd.DataFrame({"id": [str(i) for i in range(50)]})
+        assert sink._compute_partition_combinations(df, [], (), max_distinct=10) == []
+
+    def test_add_files_payload_has_partition_combinations(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(hive_columns=["year", "~driver"], catalog_url="http://catalog:8080")
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+        sink.write(self._drivers_batch())
+
+        manifest_calls = [
+            c for c in mock_catalog_client.post.call_args_list if "manifest" in str(c)
+        ]
+        body = manifest_calls[0].kwargs["json"]
+        combos = body["partition_combinations"]
+        # year (from ts_ms) x {HAM, VER}; deduped across the batch.
+        assert len(combos) == 2
+        assert {c["driver"] for c in combos} == {"HAM", "VER"}
+        assert all("year" in c for c in combos)
+
     def test_register_table_declares_virtual_partitions(
         self, sink_factory, mock_blob_client, mock_catalog_client
     ):

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -200,6 +200,7 @@ class TestQuixTSDataLakeSinkInit:
             workspace_id="ws-123",
             hive_columns=["year", "month", "day"],
             timestamp_column="event_time",
+            sort_column="seq",
             catalog_url="http://catalog:8080",
             catalog_auth_token="token123",
             auto_discover=False,
@@ -212,6 +213,7 @@ class TestQuixTSDataLakeSinkInit:
         assert sink.workspace_id == "ws-123"
         assert sink.hive_columns == ["year", "month", "day"]
         assert sink.timestamp_column == "event_time"
+        assert sink.sort_column == "seq"
         assert sink._catalog is not None
         assert sink.auto_discover is False
         assert sink.namespace == "production"
@@ -1620,3 +1622,33 @@ class TestQuixTSDataLakeSinkVirtualPartitions:
         # Full tree order sent up front (virtual can't be discovered from paths).
         assert body["partition_spec"] == ["year", "month", "driver"]
         assert body["properties"]["virtual_partitions"] == ["driver"]
+
+    def test_register_table_records_sort_and_timestamp_columns(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(
+            timestamp_column="ts_ms", sort_column="seq",
+            catalog_url="http://catalog:8080", auto_discover=True,
+        )
+        sink._catalog = mock_catalog_client
+        sink._register_table()
+
+        props = mock_catalog_client.put.call_args.kwargs["json"]["properties"]
+        assert props["sort_column"] == "seq"
+        assert props["timestamp_column"] == "ts_ms"
+
+    def test_register_table_omits_sort_column_when_unset(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(
+            timestamp_column="ts_ms",
+            catalog_url="http://catalog:8080", auto_discover=True,
+        )
+        sink._catalog = mock_catalog_client
+        sink._register_table()
+
+        props = mock_catalog_client.put.call_args.kwargs["json"]["properties"]
+        # No explicit sort_column -> omitted so the lakehouse falls back to the
+        # timestamp column (which is still recorded).
+        assert "sort_column" not in props
+        assert props["timestamp_column"] == "ts_ms"

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -1744,3 +1744,77 @@ class TestQuixTSDataLakeSinkVirtualPartitions:
         # timestamp column (which is still recorded).
         assert "sort_column" not in props
         assert props["timestamp_column"] == "ts_ms"
+
+
+# =============================================================================
+# Auto-indexing of low-cardinality non-numeric columns (prune without ~)
+# =============================================================================
+
+
+class TestQuixTSDataLakeSinkAutoIndex:
+    """Tests for _compute_auto_index_values (the auto-index lane)."""
+
+    def _df(self):
+        return pd.DataFrame({
+            "machine": ["A", "B", "A"],       # low-card string -> indexed
+            "region": ["EU", "EU", "US"],      # low-card string -> indexed
+            "speed": [1, 2, 3],                # numeric -> column_stats, not here
+            "ts_ms": [1, 2, 3],                # timestamp col -> excluded
+            "__key": ["k1", "k2", "k3"],       # internal -> excluded
+        })
+
+    def test_indexes_low_cardinality_strings_only(self, sink_factory):
+        sink = sink_factory()  # default cap 100
+        out = sink._compute_auto_index_values(self._df())
+        assert set(out.keys()) == {"machine", "region"}
+        assert out["machine"] == ["A", "B"]      # sorted distinct
+        assert out["region"] == ["EU", "US"]
+        assert "speed" not in out and "ts_ms" not in out and "__key" not in out
+
+    def test_over_cap_column_skipped_per_column(self, sink_factory):
+        # cap=2: 'region' (2 distinct) kept, 'machine' would need <=2 too — make
+        # machine exceed the cap and confirm only it is dropped, region stays.
+        sink = sink_factory(auto_index_max_cardinality=2)
+        df = pd.DataFrame({
+            "machine": ["A", "B", "C"],   # 3 distinct > cap -> skipped
+            "region": ["EU", "US", "EU"], # 2 distinct <= cap -> kept
+        })
+        out = sink._compute_auto_index_values(df)
+        assert "machine" not in out
+        assert out["region"] == ["EU", "US"]
+
+    def test_disabled_when_cap_zero(self, sink_factory):
+        sink = sink_factory(auto_index_max_cardinality=0)
+        assert sink._compute_auto_index_values(self._df()) == {}
+
+    def test_excludes_virtual_and_partition_columns(self, sink_factory):
+        # 'region' is a ~virtual column and 'machine' physical -> neither should
+        # be auto-indexed (handled by their own lanes / dropped from data).
+        sink = sink_factory(hive_columns=["machine", "~region"])
+        out = sink._compute_auto_index_values(self._df())
+        assert "region" not in out   # virtual lane
+        assert "machine" not in out  # physical partition
+
+    def test_write_attaches_indexed_values_to_manifest(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(catalog_url="http://catalog:8080")
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+        records = [
+            {"value": {"machine": "A", "speed": 1, "ts_ms": 1704067200000},
+             "key": "k1", "timestamp": 1704067200000, "offset": 0},
+            {"value": {"machine": "B", "speed": 2, "ts_ms": 1704067260000},
+             "key": "k2", "timestamp": 1704067260000, "offset": 1},
+        ]
+        batch = SinkBatch(topic="t", partition=0)
+        for r in records:
+            batch.append(value=r["value"], key=r["key"], timestamp=r["timestamp"],
+                         headers=[], offset=r["offset"])
+        sink.write(batch)
+
+        files = [c for c in mock_catalog_client.post.call_args_list
+                 if "manifest" in str(c)][0].kwargs["json"]["files"]
+        assert set(files[0]["indexed_values"]["machine"]) == {"A", "B"}
+        # numeric columns are NOT in the auto-index lane (they use column_stats)
+        assert "speed" not in files[0].get("indexed_values", {})

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -1531,3 +1531,92 @@ class TestQuixTSDataLakeSinkColumnStats:
         assert "ts_ms" in cs and cs["ts_ms"]["type"] == "numeric"
         assert "field1" not in cs
         assert "__key" not in cs
+
+
+# =============================================================================
+# Virtual partition columns (~ prefix): navigate/filter without foldering/splitting
+# =============================================================================
+
+
+class TestQuixTSDataLakeSinkVirtualPartitions:
+    """Tests for ~-prefixed virtual partition columns."""
+
+    def _batch(self, records):
+        batch = SinkBatch(topic="test", partition=0)
+        for r in records:
+            batch.append(
+                value=r["value"], key=r["key"], timestamp=r["timestamp"],
+                headers=[], offset=r["offset"],
+            )
+        return batch
+
+    def _drivers_batch(self):
+        # Two drivers, same day -> would be one physical partition group.
+        return self._batch([
+            {"value": {"driver": "HAM", "speed": 100, "ts_ms": 1704067200000},
+             "key": "k1", "timestamp": 1704067200000, "offset": 0},
+            {"value": {"driver": "VER", "speed": 200, "ts_ms": 1704067200000},
+             "key": "k2", "timestamp": 1704067200000, "offset": 1},
+        ])
+
+    def test_tilde_prefix_parsing(self, sink_factory):
+        sink = sink_factory(hive_columns=["year", "month", "~driver"])
+        assert sink.hive_columns == ["year", "month"]          # physical only
+        assert sink._virtual_columns == ["driver"]
+        assert sink._partition_spec_order == ["year", "month", "driver"]
+
+    def test_virtual_column_does_not_split_files(self, sink_factory, mock_blob_client):
+        # physical=year, virtual=driver: two drivers in one year -> ONE file.
+        sink = sink_factory(hive_columns=["year", "~driver"])
+        sink.write(self._drivers_batch())
+        assert mock_blob_client.put_object_async.call_count == 1
+
+    def test_virtual_column_kept_in_data_physical_dropped(self, sink_factory, mock_blob_client):
+        sink = sink_factory(hive_columns=["year", "~driver"])
+        sink.write(self._drivers_batch())
+        parquet_bytes = mock_blob_client.put_object_async.call_args[0][1]
+        df = pq.read_table(io.BytesIO(parquet_bytes)).to_pandas()
+        assert "driver" in df.columns   # virtual column stays in the data
+        assert "year" not in df.columns  # physical partition column is foldered away
+        assert set(df["driver"]) == {"HAM", "VER"}
+
+    def test_compute_virtual_values(self, sink_factory):
+        sink = sink_factory(hive_columns=["~driver"])
+        df = pd.DataFrame({"driver": ["HAM", "VER", "HAM", None], "x": [1, 2, 3, 4]})
+        assert sink._compute_virtual_values(df) == {"driver": ["HAM", "VER"]}
+
+    def test_high_cardinality_virtual_column_skipped(self, sink_factory):
+        sink = sink_factory(hive_columns=["~id"])
+        df = pd.DataFrame({"id": [str(i) for i in range(50)]})
+        assert sink._compute_virtual_values(df, max_distinct=10) == {}
+
+    def test_add_files_payload_has_virtual_values(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(hive_columns=["year", "~driver"], catalog_url="http://catalog:8080")
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+        sink.write(self._drivers_batch())
+
+        manifest_calls = [
+            c for c in mock_catalog_client.post.call_args_list if "manifest" in str(c)
+        ]
+        assert len(manifest_calls) == 1
+        files = manifest_calls[0].kwargs["json"]["files"]
+        assert len(files) == 1  # not split by driver
+        assert set(files[0]["virtual_values"]["driver"]) == {"HAM", "VER"}
+
+    def test_register_table_declares_virtual_partitions(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(
+            hive_columns=["year", "month", "~driver"],
+            catalog_url="http://catalog:8080", auto_discover=True,
+        )
+        sink._catalog = mock_catalog_client
+        sink._register_table()
+
+        body = mock_catalog_client.put.call_args.kwargs["json"]
+        # Full tree order sent up front (virtual can't be discovered from paths).
+        assert body["partition_spec"] == ["year", "month", "driver"]
+        assert body["properties"]["virtual_partitions"] == ["driver"]

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -1425,3 +1426,108 @@ class TestStreamTimeoutWiring:
         sink._timeout.check_now()
         sink._timeout.start()
         sink._timeout.stop()
+
+
+# =============================================================================
+# Column statistics (per-file min/max zone maps for query-time pruning)
+# =============================================================================
+
+
+class TestQuixTSDataLakeSinkColumnStats:
+    """Tests for per-file min/max stats computed in the sink."""
+
+    def test_compute_column_stats_numeric_and_timestamp(self, sink_factory):
+        sink = sink_factory()
+        table = pa.table(
+            {
+                "speed": pa.array([100, 50, 300], type=pa.int64()),
+                "temp": pa.array([1.5, 2.5, None], type=pa.float64()),
+                "ts": pa.array(
+                    [
+                        datetime(2026, 1, 1, tzinfo=timezone.utc),
+                        datetime(2026, 1, 3, tzinfo=timezone.utc),
+                        datetime(2026, 1, 2, tzinfo=timezone.utc),
+                    ]
+                ),
+                "name": pa.array(["a", "b", "c"]),  # string -> skipped
+                "__key": pa.array(["k1", "k2", "k3"]),  # internal -> skipped
+            }
+        )
+
+        stats = sink._compute_column_stats(table)
+
+        # String and internal columns are not tracked.
+        assert set(stats.keys()) == {"speed", "temp", "ts"}
+
+        assert stats["speed"] == {
+            "type": "numeric",
+            "min": 50.0,
+            "max": 300.0,
+            "null_count": 0,
+            "value_count": 3,
+        }
+        # One null in temp: min/max ignore it, counts reflect it.
+        assert stats["temp"]["type"] == "numeric"
+        assert stats["temp"]["min"] == 1.5
+        assert stats["temp"]["max"] == 2.5
+        assert stats["temp"]["null_count"] == 1
+        assert stats["temp"]["value_count"] == 2
+
+        assert stats["ts"]["type"] == "timestamp"
+        # ISO-8601 bounds, min/max by time (not input order).
+        assert stats["ts"]["min"].startswith("2026-01-01")
+        assert stats["ts"]["max"].startswith("2026-01-03")
+
+    def test_all_null_numeric_column_is_skipped(self, sink_factory):
+        sink = sink_factory()
+        table = pa.table({"x": pa.array([None, None], type=pa.float64())})
+        assert sink._compute_column_stats(table) == {}
+
+    def test_stats_columns_restricts_the_tracked_set(self, sink_factory):
+        sink = sink_factory(stats_columns=["speed"])
+        table = pa.table(
+            {
+                "speed": pa.array([1, 2], type=pa.int64()),
+                "temp": pa.array([1.0, 2.0], type=pa.float64()),
+            }
+        )
+        stats = sink._compute_column_stats(table)
+        assert set(stats.keys()) == {"speed"}
+
+    def test_safe_float_bounds_widen_for_large_ints(self, sink_factory):
+        sink = sink_factory()
+        # 2**53 + 1 is not exactly representable as float64 (rounds down).
+        v = 2**53 + 1
+        lo = sink._safe_float_min(v)
+        hi = sink._safe_float_max(v)
+        # Stored bounds must ENCLOSE the true value so pruning never wrongly
+        # skips a file: lo <= v <= hi.
+        assert lo <= v <= hi
+
+    def test_write_attaches_column_stats_to_manifest_payload(
+        self, sink_factory, sample_batch, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(catalog_url="http://catalog:8080", auto_discover=True)
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+
+        sink.write(sample_batch())
+
+        manifest_calls = [
+            call
+            for call in mock_catalog_client.post.call_args_list
+            if "manifest" in str(call)
+        ]
+        assert len(manifest_calls) == 1
+        files = manifest_calls[0].kwargs["json"]["files"]
+        assert len(files) == 1
+        cs = files[0]["column_stats"]
+
+        # Numeric data columns get zone maps; the string column and the
+        # internal __key column do not.
+        assert "field2" in cs and cs["field2"]["type"] == "numeric"
+        assert cs["field2"]["min"] == 100.0
+        assert cs["field2"]["max"] == 200.0
+        assert "ts_ms" in cs and cs["ts_ms"]["type"] == "numeric"
+        assert "field1" not in cs
+        assert "__key" not in cs

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -1582,31 +1582,12 @@ class TestQuixTSDataLakeSinkVirtualPartitions:
         assert "year" not in df.columns  # physical partition column is foldered away
         assert set(df["driver"]) == {"HAM", "VER"}
 
-    def test_compute_virtual_values(self, sink_factory):
-        sink = sink_factory(hive_columns=["~driver"])
-        df = pd.DataFrame({"driver": ["HAM", "VER", "HAM", None], "x": [1, 2, 3, 4]})
-        assert sink._compute_virtual_values(df) == {"driver": ["HAM", "VER"]}
-
-    def test_high_cardinality_virtual_column_skipped(self, sink_factory):
-        sink = sink_factory(hive_columns=["~id"])
-        df = pd.DataFrame({"id": [str(i) for i in range(50)]})
-        assert sink._compute_virtual_values(df, max_distinct=10) == {}
-
-    def test_add_files_payload_has_virtual_values(
-        self, sink_factory, mock_blob_client, mock_catalog_client
-    ):
-        sink = sink_factory(hive_columns=["year", "~driver"], catalog_url="http://catalog:8080")
-        sink._catalog = mock_catalog_client
-        sink.table_registered = True
+    def test_virtual_column_not_split_stays_single_file(self, sink_factory, mock_blob_client):
+        # A virtual column is kept in the data, not foldered -> one file per
+        # physical group regardless of how many virtual values it holds.
+        sink = sink_factory(hive_columns=["year", "~driver"])
         sink.write(self._drivers_batch())
-
-        manifest_calls = [
-            c for c in mock_catalog_client.post.call_args_list if "manifest" in str(c)
-        ]
-        assert len(manifest_calls) == 1
-        files = manifest_calls[0].kwargs["json"]["files"]
-        assert len(files) == 1  # not split by driver
-        assert set(files[0]["virtual_values"]["driver"]) == {"HAM", "VER"}
+        assert mock_blob_client.put_object_async.call_count == 1
 
     def test_compute_partition_combinations(self, sink_factory):
         sink = sink_factory(hive_columns=["year", "~driver", "~channel"])

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -1651,6 +1651,55 @@ class TestQuixTSDataLakeSinkVirtualPartitions:
         assert {c["driver"] for c in combos} == {"HAM", "VER"}
         assert all("year" in c for c in combos)
 
+    def test_compute_virtual_values(self, sink_factory):
+        sink = sink_factory(hive_columns=["year", "~driver", "~channel"])
+        df = pd.DataFrame({
+            "driver": ["HAM", "HAM", "VER"],
+            "channel": ["radio", "radio", "tv"],
+            "x": [1, 2, 3],
+        })
+        vv = sink._compute_virtual_values(df)
+        assert set(vv.keys()) == {"driver", "channel"}
+        assert sorted(vv["driver"]) == ["HAM", "VER"]
+        assert sorted(vv["channel"]) == ["radio", "tv"]
+
+    def test_compute_virtual_values_no_virtual_columns(self, sink_factory):
+        sink = sink_factory(hive_columns=["year"])  # physical only
+        assert sink._compute_virtual_values(pd.DataFrame({"x": [1, 2]})) == {}
+
+    def test_compute_virtual_values_partial_coverage_returns_empty(self, sink_factory):
+        # A file missing one virtual column must NOT be marked indexed (the
+        # catalog's virtual_indexed flag is per-file, not per-column) — otherwise
+        # a query on the missing column would wrongly prune it.
+        sink = sink_factory(hive_columns=["year", "~driver", "~channel"])
+        df = pd.DataFrame({"driver": ["HAM"], "x": [1]})  # channel absent
+        assert sink._compute_virtual_values(df) == {}
+
+    def test_compute_virtual_values_high_cardinality_returns_empty(self, sink_factory):
+        sink = sink_factory(hive_columns=["~id"])
+        df = pd.DataFrame({"id": [str(i) for i in range(50)]})
+        assert sink._compute_virtual_values(df, max_distinct=10) == {}
+
+    def test_add_files_payload_has_virtual_values(
+        self, sink_factory, mock_blob_client, mock_catalog_client
+    ):
+        sink = sink_factory(hive_columns=["year", "~driver"], catalog_url="http://catalog:8080")
+        sink._catalog = mock_catalog_client
+        sink.table_registered = True
+        sink.write(self._drivers_batch())
+
+        manifest_calls = [
+            c for c in mock_catalog_client.post.call_args_list if "manifest" in str(c)
+        ]
+        entries = manifest_calls[0].kwargs["json"]["files"]
+        # driver is virtual (not split), so each file carries its per-file distinct
+        # driver values; the union across files is {HAM, VER}.
+        assert all("virtual_values" in e for e in entries)
+        seen = set()
+        for e in entries:
+            seen |= set(e["virtual_values"]["driver"])
+        assert seen == {"HAM", "VER"}
+
     def test_register_table_declares_virtual_partitions(
         self, sink_factory, mock_blob_client, mock_catalog_client
     ):

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -885,6 +885,25 @@ class TestPartitionValidation:
         with pytest.raises(ValueError, match="Partition strategy mismatch"):
             sink._validate_partition_strategy(table_metadata)
 
+    def test_validate_catalog_partition_matches_with_virtual_on_restart(
+        self, sink_factory, mock_catalog_client
+    ):
+        """RESTART to an existing virtual-partitioned table must NOT raise.
+
+        The catalog stores the full spec (physical + virtual) as the sink
+        registers it; validation must compare against the full tree order, not
+        the physical-only hive_columns (which previously caused a spurious
+        'Partition strategy mismatch' on every restart of a ~-virtual sink)."""
+        sink = sink_factory(
+            hive_columns=["year", "month", "~driver"],
+            catalog_url="http://catalog:8080",
+        )
+        sink._catalog = mock_catalog_client
+
+        table_metadata = {"partition_spec": ["year", "month", "driver"]}  # phys + virtual
+        # Should NOT raise.
+        sink._validate_partition_strategy(table_metadata)
+
 
 # =============================================================================
 # 6. Catalog Integration Tests

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -383,9 +383,9 @@ class TestSilenceChattyLoggers:
         silence_chatty_loggers()
 
         for name in self._SILENCED:
-            assert _logging.getLogger(name).level == _logging.WARNING, (
-                f"{name} not raised to WARNING"
-            )
+            assert (
+                _logging.getLogger(name).level == _logging.WARNING
+            ), f"{name} not raised to WARNING"
 
     def test_setup_silences_when_flag_is_true(self, sink_factory, mock_blob_client):
         import logging as _logging

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -175,49 +175,19 @@ def sample_batch():
 
 
 class TestRowGroupSizing:
-    """Row groups are sized in rows from the table's observed density so each
-    comes to about ``row_group_mb`` (default 32 MB) — the lakehouse compaction
-    rule. A reader pays ~4 range requests per row group, so this bounds the
-    request count of every query over sink-written files."""
+    """Row groups are capped at a fixed, configurable row count (default
+    1,000,000 — the lakehouse compaction's default). A reader pays about one
+    range request per row group, so this bounds the request count of every
+    query over sink-written files; small flushes stay a single group."""
 
-    R = QuixTSDataLakeSink
+    def test_default_matches_lakehouse_compaction(self, sink_factory):
+        assert sink_factory()._row_group_rows == 1_000_000
+        assert QuixTSDataLakeSink.ROW_GROUP_ROWS_DEFAULT == 1_000_000
+        assert sink_factory(row_group_rows=250_000)._row_group_rows == 250_000
 
-    def test_default_target_matches_lakehouse_compaction(self, sink_factory):
-        assert sink_factory()._row_group_mb == 32.0
-        assert sink_factory(row_group_mb=8)._row_group_mb == 8.0
-
-    def test_rejects_non_positive_target(self, sink_factory):
+    def test_rejects_non_positive(self, sink_factory):
         with pytest.raises(ValueError):
-            sink_factory(row_group_mb=0)
-
-    def test_rows_per_group_from_density(self):
-        mb = 1024 * 1024
-        # 50k rows/MB (CAN-shaped data) x 32 MB -> 1.6M rows per group
-        assert self.R._row_group_rows(1_000_000, 20 * mb, 32) == 1_600_000
-        # wide rows: 1k rows/MB -> 32k rows, clamped up to the minimum group
-        assert self.R._row_group_rows(1_000, 1 * mb, 32) == self.R.ROW_GROUP_ROWS_MIN
-        # extremely dense rows: clamped to the maximum
-        assert self.R._row_group_rows(10_000_000, 1 * mb, 32) == self.R.ROW_GROUP_ROWS_MAX
-        # target scales linearly
-        assert self.R._row_group_rows(1_000_000, 20 * mb, 8) == 400_000
-
-    def test_fallback_when_density_unknown(self):
-        assert self.R._row_group_rows(0, 0, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
-        assert self.R._row_group_rows(None, None, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
-        assert self.R._row_group_rows(100, 100, 0) == self.R.ROW_GROUP_ROWS_FALLBACK
-        assert self.R._row_group_rows("x", 5, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
-
-    def test_first_file_uses_fallback_then_learns_density(self, sink_factory, mock_blob_client):
-        sink = sink_factory(row_group_mb=32)
-        assert sink._row_group_size() == self.R.ROW_GROUP_ROWS_FALLBACK
-        df = pd.DataFrame({"ts_ms": range(1_000), "v": [1.5] * 1_000, "__key": ["k"] * 1_000})
-        sink._write_parquet_to_storage(df, "p/data_1.parquet", [], ())
-        parquet_bytes = mock_blob_client.put_object_async.call_args.args[1]
-        assert sink._written_rows == 1_000
-        assert sink._written_bytes == len(parquet_bytes) > 0
-        # density now known -> a sizing derived from it (not the fallback)
-        expected = self.R._row_group_rows(1_000, len(parquet_bytes), 32)
-        assert sink._row_group_size() == expected != self.R.ROW_GROUP_ROWS_FALLBACK
+            sink_factory(row_group_rows=0)
 
     def test_small_files_are_one_row_group(self, sink_factory, sample_batch, mock_blob_client):
         sink = sink_factory()
@@ -225,49 +195,23 @@ class TestRowGroupSizing:
         parquet_bytes = mock_blob_client.put_object_async.call_args.args[1]
         assert pq.ParquetFile(io.BytesIO(parquet_bytes)).num_row_groups == 1
 
-    def test_large_file_is_split_into_target_sized_groups(self, sink_factory, mock_blob_client):
-        """Learn density from one file, then a big flush is cut into groups of
-        the derived row count — verified on the serialised parquet bytes."""
-        import numpy as np
+    def test_large_flush_is_split_at_the_configured_rows(self, sink_factory, mock_blob_client):
+        sink = sink_factory(row_group_rows=100_000)
+        n = 250_000
+        df = pd.DataFrame({"ts_ms": range(n), "v": [1.5] * n, "__key": ["k"] * n})
+        sink._write_parquet_to_storage(df, "p/data.parquet", [], ())
+        meta = pq.ParquetFile(io.BytesIO(mock_blob_client.put_object_async.call_args.args[1])).metadata
+        assert meta.num_row_groups == 3
+        assert [meta.row_group(i).num_rows for i in range(3)] == [100_000, 100_000, 50_000]
+        pending = sink._pending_futures[-1]
+        assert pending["row_count"] == n  # the catalog entry is per FILE, unaffected by splitting
 
-        rng = np.random.default_rng(0)
-        sink = sink_factory(row_group_mb=1)  # 1 MB groups keep the test data small
-
-        def frame(n):
-            return pd.DataFrame({
-                "ts_ms": np.arange(n, dtype=np.int64),
-                "v": rng.random(n),  # incompressible -> stable density
-                "__key": ["k"] * n,
-            })
-
-        sink._write_parquet_to_storage(frame(50_000), "p/data_1.parquet", [], ())
-        first_bytes = mock_blob_client.put_object_async.call_args.args[1]
-        assert pq.ParquetFile(io.BytesIO(first_bytes)).num_row_groups == 1  # fallback 1M rows
-
-        rows_per_group = sink._row_group_size()
-        assert rows_per_group == self.R._row_group_rows(50_000, len(first_bytes), 1)
-        n = 3 * rows_per_group + 10  # -> exactly 4 groups
-        sink._write_parquet_to_storage(frame(n), "p/data_2.parquet", [], ())
-        second_bytes = mock_blob_client.put_object_async.call_args.args[1]
-        meta = pq.ParquetFile(io.BytesIO(second_bytes)).metadata
-        assert meta.num_row_groups == 4
-        assert [meta.row_group(i).num_rows for i in range(4)] == [rows_per_group] * 3 + [10]
-        # and each full group is about the 1 MB target (random doubles ~ 8 B/row
-        # + int64 ts -> the byte target is what the row count was derived from)
-        rg0 = meta.row_group(0)
-        full_group_bytes = sum(rg0.column(c).total_compressed_size for c in range(rg0.num_columns))
-        assert 0.5 * 1024 * 1024 < full_group_bytes < 2 * 1024 * 1024, full_group_bytes
-
-    def test_row_count_reported_to_catalog_unchanged_by_splitting(self, sink_factory, mock_blob_client):
-        sink = sink_factory(row_group_mb=1)
-        sink._written_rows, sink._written_bytes = 1_000_000, 8 * 1024 * 1024  # pretend: 125k rows/MB
-        n = 300_000
+    def test_default_keeps_a_million_row_flush_in_one_group(self, sink_factory, mock_blob_client):
+        sink = sink_factory()
+        n = 1_000_000
         df = pd.DataFrame({"ts_ms": range(n), "__key": ["k"] * n})
         sink._write_parquet_to_storage(df, "p/data.parquet", [], ())
-        pending = sink._pending_futures[-1]
-        assert pending["row_count"] == n
-        assert pending["file_size"] == len(mock_blob_client.put_object_async.call_args.args[1])
-        assert pq.ParquetFile(io.BytesIO(mock_blob_client.put_object_async.call_args.args[1])).num_row_groups > 1
+        assert pq.ParquetFile(io.BytesIO(mock_blob_client.put_object_async.call_args.args[1])).num_row_groups == 1
 
 
 # =============================================================================

--- a/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
+++ b/tests/test_quixstreams/test_sinks/test_core/test_quix_ts_datalake_sink.py
@@ -170,6 +170,107 @@ def sample_batch():
 
 
 # =============================================================================
+# Parquet row-group sizing
+# =============================================================================
+
+
+class TestRowGroupSizing:
+    """Row groups are sized in rows from the table's observed density so each
+    comes to about ``row_group_mb`` (default 32 MB) — the lakehouse compaction
+    rule. A reader pays ~4 range requests per row group, so this bounds the
+    request count of every query over sink-written files."""
+
+    R = QuixTSDataLakeSink
+
+    def test_default_target_matches_lakehouse_compaction(self, sink_factory):
+        assert sink_factory()._row_group_mb == 32.0
+        assert sink_factory(row_group_mb=8)._row_group_mb == 8.0
+
+    def test_rejects_non_positive_target(self, sink_factory):
+        with pytest.raises(ValueError):
+            sink_factory(row_group_mb=0)
+
+    def test_rows_per_group_from_density(self):
+        mb = 1024 * 1024
+        # 50k rows/MB (CAN-shaped data) x 32 MB -> 1.6M rows per group
+        assert self.R._row_group_rows(1_000_000, 20 * mb, 32) == 1_600_000
+        # wide rows: 1k rows/MB -> 32k rows, clamped up to the minimum group
+        assert self.R._row_group_rows(1_000, 1 * mb, 32) == self.R.ROW_GROUP_ROWS_MIN
+        # extremely dense rows: clamped to the maximum
+        assert self.R._row_group_rows(10_000_000, 1 * mb, 32) == self.R.ROW_GROUP_ROWS_MAX
+        # target scales linearly
+        assert self.R._row_group_rows(1_000_000, 20 * mb, 8) == 400_000
+
+    def test_fallback_when_density_unknown(self):
+        assert self.R._row_group_rows(0, 0, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
+        assert self.R._row_group_rows(None, None, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
+        assert self.R._row_group_rows(100, 100, 0) == self.R.ROW_GROUP_ROWS_FALLBACK
+        assert self.R._row_group_rows("x", 5, 32) == self.R.ROW_GROUP_ROWS_FALLBACK
+
+    def test_first_file_uses_fallback_then_learns_density(self, sink_factory, mock_blob_client):
+        sink = sink_factory(row_group_mb=32)
+        assert sink._row_group_size() == self.R.ROW_GROUP_ROWS_FALLBACK
+        df = pd.DataFrame({"ts_ms": range(1_000), "v": [1.5] * 1_000, "__key": ["k"] * 1_000})
+        sink._write_parquet_to_storage(df, "p/data_1.parquet", [], ())
+        parquet_bytes = mock_blob_client.put_object_async.call_args.args[1]
+        assert sink._written_rows == 1_000
+        assert sink._written_bytes == len(parquet_bytes) > 0
+        # density now known -> a sizing derived from it (not the fallback)
+        expected = self.R._row_group_rows(1_000, len(parquet_bytes), 32)
+        assert sink._row_group_size() == expected != self.R.ROW_GROUP_ROWS_FALLBACK
+
+    def test_small_files_are_one_row_group(self, sink_factory, sample_batch, mock_blob_client):
+        sink = sink_factory()
+        sink.write(sample_batch())
+        parquet_bytes = mock_blob_client.put_object_async.call_args.args[1]
+        assert pq.ParquetFile(io.BytesIO(parquet_bytes)).num_row_groups == 1
+
+    def test_large_file_is_split_into_target_sized_groups(self, sink_factory, mock_blob_client):
+        """Learn density from one file, then a big flush is cut into groups of
+        the derived row count — verified on the serialised parquet bytes."""
+        import numpy as np
+
+        rng = np.random.default_rng(0)
+        sink = sink_factory(row_group_mb=1)  # 1 MB groups keep the test data small
+
+        def frame(n):
+            return pd.DataFrame({
+                "ts_ms": np.arange(n, dtype=np.int64),
+                "v": rng.random(n),  # incompressible -> stable density
+                "__key": ["k"] * n,
+            })
+
+        sink._write_parquet_to_storage(frame(50_000), "p/data_1.parquet", [], ())
+        first_bytes = mock_blob_client.put_object_async.call_args.args[1]
+        assert pq.ParquetFile(io.BytesIO(first_bytes)).num_row_groups == 1  # fallback 1M rows
+
+        rows_per_group = sink._row_group_size()
+        assert rows_per_group == self.R._row_group_rows(50_000, len(first_bytes), 1)
+        n = 3 * rows_per_group + 10  # -> exactly 4 groups
+        sink._write_parquet_to_storage(frame(n), "p/data_2.parquet", [], ())
+        second_bytes = mock_blob_client.put_object_async.call_args.args[1]
+        meta = pq.ParquetFile(io.BytesIO(second_bytes)).metadata
+        assert meta.num_row_groups == 4
+        assert [meta.row_group(i).num_rows for i in range(4)] == [rows_per_group] * 3 + [10]
+        # and each full group is about the 1 MB target (random doubles ~ 8 B/row
+        # + int64 ts -> the byte target is what the row count was derived from)
+        rg0 = meta.row_group(0)
+        full_group_bytes = sum(rg0.column(c).total_compressed_size for c in range(rg0.num_columns))
+        assert 0.5 * 1024 * 1024 < full_group_bytes < 2 * 1024 * 1024, full_group_bytes
+
+    def test_row_count_reported_to_catalog_unchanged_by_splitting(self, sink_factory, mock_blob_client):
+        sink = sink_factory(row_group_mb=1)
+        sink._written_rows, sink._written_bytes = 1_000_000, 8 * 1024 * 1024  # pretend: 125k rows/MB
+        n = 300_000
+        df = pd.DataFrame({"ts_ms": range(n), "__key": ["k"] * n})
+        sink._write_parquet_to_storage(df, "p/data.parquet", [], ())
+        pending = sink._pending_futures[-1]
+        assert pending["row_count"] == n
+        assert pending["file_size"] == len(mock_blob_client.put_object_async.call_args.args[1])
+        assert pq.ParquetFile(io.BytesIO(mock_blob_client.put_object_async.call_args.args[1])).num_row_groups > 1
+
+
+# =============================================================================
 # 1. Initialization Tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Adds four query-performance features to `QuixTSDataLakeSink` so the lakehouse can prune files and navigate partitions without reading Parquet footers.

- **Per-file column statistics.** Min/max/null_count zone maps are computed from the in-memory Arrow batch for every numeric and timestamp column and sent to the REST Catalog as `column_stats` on each add-files entry. Numeric bounds are widened to the nearest representable float so pruning can only lose precision, never skip a matching file. `stats_columns` restricts the tracked set on wide tables.
- **Virtual partition columns.** A `~` prefix in `hive_columns` (e.g. `["year", "month", "~driver"]`) marks a column that appears in the partition tree and is filterable, but is not written as a `key=value/` folder and does not split files. The column stays in the Parquet data. Each data file gets a `.vidx/` sidecar Parquet next to it holding the distinct virtual tuples plus the file's physical partition values, so navigation can glob the sidecars with DuckDB. Sidecar writes are best-effort and never block data.
- **`sort_column`.** Recorded on the table as `properties.sort_column` (with `timestamp_column` as the fallback) so compaction can write ordered, skippable files.
- **Fixed Parquet row-group size.** New `row_group_rows` parameter (default 1,000,000, matching the lakehouse compaction) caps rows per row group so large flushes are split and small flushes remain one group.

Also fixes a spurious "Partition strategy mismatch" on restart against an existing virtual-partitioned table: catalog validation now compares against the full tree order rather than physical columns only.

## Catalog contract changes

- `PUT table`: `partition_spec` is sent up front when virtual columns are configured, plus `properties.virtual_partitions`, `properties.sort_column`, `properties.timestamp_column`.
- `add-files`: entries may carry `column_stats`. The key is omitted when empty so older catalogs ignore it. Nothing virtual is sent to the catalog any more; the virtual index lives only in blob sidecars.